### PR TITLE
Update README with FEC example and full UI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,8 @@ Here's an example, using CFPB's regulation H.
 1. `git clone https://github.com/cfpb/regulations-parser.git`
 1. `cd regulations-parser`
 1. `pip install -r requirements.txt`
-1. `wget
-   http://www.gpo.gov/fdsys/pkg/CFR-2012-title12-vol8/xml/CFR-2012-title12-vol8-part1004.xml`
-1. `python build_from.py CFR-2012-title12-vol8-part1004.xml 12 2011-18676 15
-   1693`
+1. `wget http://www.gpo.gov/fdsys/pkg/CFR-2012-title12-vol8/xml/CFR-2012-title12-vol8-part1004.xml`
+1. `python build_from.py CFR-2012-title12-vol8-part1004.xml 12 2011-18676 15 1693`
 
 At the end, you will have new directories for `regulation`, `layer`,
 `diff`, and `notice` which would mirror the JSON files sent to the API.
@@ -38,8 +36,7 @@ tweaked to pass the parser.
 1. `git clone https://github.com/micahsaul/fec_docs`
 1. `pip install -r requirements.txt`
 1. `echo "LOCAL_XML_PATHS = ['fec_docs']" >> local_settings.py`
-1. `python build_from.py fec_docs/1997CFR/CFR-1997-title11-vol1-part110.xml 11
-   96-20102 5 552`
+1. `python build_from.py fec_docs/1997CFR/CFR-1997-title11-vol1-part110.xml 11 96-20102 5 552`
 
 If you review the history of the `fec_docs` repo, you'll see some of the types
 of changes that need to be made.
@@ -144,13 +141,13 @@ The syntax is
 $ python build_from.py regulation.ext title notice_doc_# act_title act_section
 ```
 
-For example, to match the reissuance above:
+For example, to match regulation H in the quick start above:
 ```bash
-$ python build_from.py 725.xml 12 2013-1725 15 1693
+$ python build_from.py CFR-2012-title12-vol8-part1004.xml 12 2011-18676 15 1693
 ```
 
 Here ```12``` is the CFR title number (in our case, for "Banks and
-Banking"), ```2013-1725``` is the last notice used to create this version
+Banking"), ```2011-18676``` is the last notice used to create this version
 (i.e. the last "final rule" which is currently in effect), ```15``` is the
 title of "the Act" and ```1693``` is the relevant section. Wherever the
 phrase "the Act" is used in the regulation, the external link parser will

--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ Here's an example, using CFPB's regulation H.
 At the end, you will have new directories for `regulation`, `layer`,
 `diff`, and `notice` which would mirror the JSON files sent to the API.
 
+## Quick Start with Modified Documents
+
+Here's an example using FEC's regulation 110, showing how documents can be
+tweaked to pass the parser.
+
+1. `git clone https://github.com/cfpb/regulations-parser.git`
+1. `cd regulations-parser`
+1. `git clone https://github.com/micahsaul/fec_docs`
+1. `pip install -r requirements.txt`
+1. `echo "LOCAL_XML_PATHS = ['fec_docs']" >> local_settings.py`
+1. `python build_from.py fec_docs/1997CFR/CFR-1997-title11-vol1-part110.xml 11
+   96-20102 5 552`
+
+If you review the history of the `fec_docs` repo, you'll see some of the types
+of changes that need to be made.
+
 ## Features
 
 * Split regulation into paragraph-level chunks
@@ -474,3 +490,41 @@ structure. AMDPARs, which contain the list of changes may also need to be
 simplified. If the same type of change needs to be made for multiple
 documents, consider adding a corresponding rule to the parser -- just test
 existing docs first.
+
+### Integration with regulations-core and regulations-site
+
+With the above examples, you should have been able to run the parser and
+generate some output. "But where's the website?" you ask. The parser was
+written to be as generic as possible, but integrating with `regulations-core`
+and `regulations-site` is likely where you'll want to end up. Here, we'll show
+one way to connect these applications up; see the individual repos for more
+configuration detail.
+
+Let's set up `regulations-core` first. This is an API which will be used to
+both store and query the regulation data.
+
+ 1. `git clone https://github.com/cfpb/regulations-core.git`
+ 1. `cd regulations-core`
+ 1. `pip install zc.buildout`
+ 1. `buildout   # pulls in python dependencies`
+ 1. `./bin/django syncdb --migrate`
+ 1. `./bin/django runserver 127.0.0.0:8888 &   # Starts the API`
+
+Then, we can configure the parser to write to this API and run it, here using
+the FEC example above
+
+ 1. `cd /path/to/regulations-parser`
+ 1. `echo "API_BASE = 'http://localhost:8000/'" >> local_settings.py`
+ 1. `python build_from.py fec_docs/1997CFR/CFR-1997-title11-vol1-part110.xml 11
+    96-20102 5 552`
+
+Next up, we set up `regulations-site` to provide a webapp.
+
+ 1. `git clone https://github.com/18f/regulations-site.git`
+ 1. `cd regulations-site`
+ 1. `buildout`
+ 1. `echo "API_BASE = 'http://127.0.0.1:8888/'" >>
+    regulations/settings/local_settings.py`
+ 1. `./run_server.sh`
+
+Then, navigate to `http://localhost:8000/` in your browser to see the FEC reg.


### PR DESCRIPTION
This should provide a soup-to-nuts working example.

It switches between cfpb repos and 18f repos due to https://github.com/cfpb/regulations-site/issues/698 and https://github.com/cfpb/regulations-parser/pull/265