### PR TITLE
Add small program to print out ordered notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,26 @@ All of the settings listed in ```settings.py``` can be overridden in a
   file will be used instead of retrieving the file, allowing for local
   edits, etc. to help the parser.
 
+## Other Utilities
+
+### Notice Order
+
+When debugging, it can be helpful to know how notices will be grouped and
+sequenced when compiling the regulation. The `notice_order.py` utility tells
+you exactly that information, once it is given a CFR title and part.
+
+```
+$ python notice_order.py 12 1026
+```
+
+By default, this only includes notices which explicitly change the text of the
+regulation. To include all final notices, add this flag:
+
+```
+$ python notice_order.py 12 1005 --include-notices-without-changes
+```
+
+
 ## Building the documentation
 
 For most tweaks, you will simply need to run the Sphinx documentation

--- a/notice_order.py
+++ b/notice_order.py
@@ -16,8 +16,10 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Notice Orderer")
     parser.add_argument('cfr_title', help='CFR_TITLE')
     parser.add_argument('cfr_part', help='CFR_PART')
-    parser.add_argument('--include-notices-without-changes', type=bool,
-                        default=False)
+    parser.add_argument('--include-notices-without-changes', const=True,
+                        default=False, action='store_const',
+                        help=('Include notices which do not change the '
+                              'regulation (default: false)'))
     args = parser.parse_args()
 
     notices_by_date = notices_for_cfr_part(args.cfr_title, args.cfr_part)

--- a/notice_order.py
+++ b/notice_order.py
@@ -1,0 +1,28 @@
+# @todo - this should be combined with build_from.py
+import argparse
+
+from regparser.builder import notices_for_cfr_part
+
+try:
+    import requests_cache
+    requests_cache.install_cache('fr_cache')
+except ImportError:
+    # If the cache library isn't present, do nothing -- we'll just make full
+    # HTTP requests rather than looking it up from the cache
+    pass
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Notice Orderer")
+    parser.add_argument('cfr_title', help='CFR_TITLE')
+    parser.add_argument('cfr_part', help='CFR_PART')
+    parser.add_argument('--include-notices-without-changes', type=bool,
+                        default=False)
+    args = parser.parse_args()
+
+    notices_by_date = notices_for_cfr_part(args.cfr_title, args.cfr_part)
+    for date in sorted(notices_by_date.keys()):
+        print(date)
+        for notice in notices_by_date[date]:
+            if 'changes' in notice or args.include_notices_without_changes:
+                print("\t" + notice['document_number'])

--- a/regparser/builder.py
+++ b/regparser/builder.py
@@ -171,6 +171,8 @@ class LayerCacheAggregator(object):
 
 
 def notices_for_cfr_part(title, part):
+    """Retrieves all final notices for a title-part pair, orders them, and
+    returns them as a dict[effective_date_str] -> list(notices)"""
     notices = fetch_notices(title, part, only_final=True)
     modify_effective_dates(notices)
     return group_by_eff_date(notices)

--- a/regparser/builder.py
+++ b/regparser/builder.py
@@ -27,12 +27,10 @@ class Builder(object):
         self.doc_number = doc_number
         self.writer = api_writer.Client()
 
-        self.notices = fetch_notices(self.cfr_title, self.cfr_part,
-                                     only_final=True)
-        modify_effective_dates(self.notices)
-        #   Only care about final
-        self.notices = [n for n in self.notices if 'effective_on' in n]
-        self.eff_notices = group_by_eff_date(self.notices)
+        self.eff_notices = notices_for_cfr_part(self.cfr_title, self.cfr_part)
+        self.notices = []
+        for notice_group in self.eff_notices.values():
+            self.notices.extend(notice_group)
 
     def write_notices(self):
         for notice in self.notices:
@@ -165,11 +163,17 @@ class LayerCacheAggregator(object):
         if layer_name in ('external-citations', 'internal-citations',
                           'interpretations', 'paragraph-markers', 'keyterms',
                           'formatting', 'graphics'):
-            if not layer_name in self._caches:
+            if layer_name not in self._caches:
                 self._caches[layer_name] = LayerCache(self)
             return self._caches[layer_name]
         else:
             return EmptyCache()
+
+
+def notices_for_cfr_part(title, part):
+    notices = fetch_notices(title, part, only_final=True)
+    modify_effective_dates(notices)
+    return group_by_eff_date(notices)
 
 
 def _fr_doc_to_doc_number(xml):


### PR DESCRIPTION
Nothing amazing, but this adds a little script that pulls makes it easy to see the order notices will be applied in. Future work includes using checkpoints and writing a common cli framework so that this could be ran with something like `regulations notice_order 12 1026`.

Output examples (skipping warnings):
```bash
(parser)vagrant@debian8:~/regulations-parser$ python notice_order.py 12 1026
2011-12-30
2012-11-23
	2012-28341
2013-01-01
	2012-27993
	2012-27997
2013-03-28
	2013-07066
2013-05-03
	2013-10429
2013-06-01
	2013-00734
	2013-01503_20130601
	2013-12125
2013-11-21
2014-01-01
	2013-01503_20140101
	2013-22752_20140101
	2013-28195
	2013-29844
	2013-31225
2014-01-10
	2013-00736
	2013-00740
	2013-01241
	2013-01503_20140110
	2013-13173
	2013-16962
	2013-22752_20140110
	2013-24521
2014-01-18
	2013-01809
	2013-30108_20140118
2014-07-17
2014-11-03
	2014-25503_20141103
2015-01-01
	2014-18838
	2014-21849
	2014-30405
	2014-30419
2015-04-17
	2015-09000
2015-07-18
	2013-30108_20150718
2015-08-01
	2013-28210
	2014-25503_20150801
	2015-01321
```

```bash
(parser)vagrant@debian8:~/regulations-parser$ python notice_order.py 12 1005 --include-notices-without-changes
2011-12-30
	2011-31725
2012-02-07
	2013-01595
2013-03-26
	2013-06861
2013-10-28
	2012-1728
	2012-16245
	2012-19702
	2013-10604
	2013-19503
	2013-25754
2013-11-21
	2013-27337
2014-11-17
	2014-20681
```