### PR TITLE
Significantly tighten memory usage in build_from

### DIFF
--- a/build_from.py
+++ b/build_from.py
@@ -22,20 +22,11 @@ logger = logging.getLogger('build_from')
 logger.setLevel(logging.INFO)
 logger.addHandler(logging.StreamHandler())
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Regulation parser')
-    parser.add_argument('filename',
-                        help='XML file containing the regulation')
-    parser.add_argument('title', type=int, help='Title number')
-    parser.add_argument('act_title', type=int, help='Act title',
-                        action='store')
-    parser.add_argument('act_section', type=int, help='Act section')
-    parser.add_argument('--generate-diffs', type=bool, help='Generate diffs?',
-                        required=False, default=True)
-    parser.add_argument('--checkpoint', required=False,
-                        help='Directory to save checkpoint data')
-
-    args = parser.parse_args()
+# @profile
+def parse_regulation(args):
+    """ Run the parser on the specified command-line arguments. Broken out
+        into separate function to assist in profiling.
+    """
     with codecs.open(args.filename, 'r', 'utf-8') as f:
         reg = f.read()
         file_digest = hashlib.sha256(reg.encode('utf-8')).hexdigest()
@@ -56,7 +47,6 @@ if __name__ == "__main__":
         lambda: Builder.determine_doc_number(reg, args.title, title_part))
     if not doc_number:
         raise ValueError("Could not determine document number")
-    del reg     # never used again
     checkpointer.suffix = ":".join(
         ["", title_part, str(args.title), doc_number])
 
@@ -75,35 +65,59 @@ if __name__ == "__main__":
     builder.gen_and_write_layers(reg_tree, act_title_and_section, layer_cache)
     layer_cache.replace_using(reg_tree)
 
-    # this used to assume implicitly that if gen-diffs was not specified it was
-    # True; changed it to explicit check
     if args.generate_diffs:
-        all_versions = {doc_number: FrozenNode.from_node(reg_tree)}
+        generate_diffs(doc_number, reg_tree, act_title_and_section, builder,
+                       layer_cache, checkpointer)
 
-        for last_notice, old, new_tree, notices in builder.revision_generator(
-                reg_tree):
-            version = last_notice['document_number']
-            logger.info("Version %s", version)
-            all_versions[version] = FrozenNode.from_node(new_tree)
-            builder.doc_number = version
-            builder.write_regulation(new_tree)
-            layer_cache.invalidate_by_notice(last_notice)
-            builder.gen_and_write_layers(new_tree, act_title_and_section,
-                                         layer_cache, notices)
-            layer_cache.replace_using(new_tree)
-            del last_notice, old, new_tree, notices     # free some memory
 
-        # convert to frozen trees
-        label_id = reg_tree.label_id()
-        writer = builder.writer
-        del reg_tree, layer_cache, builder  # free some memory
+def generate_diffs(doc_number, reg_tree, act_title_and_section, builder,
+                   layer_cache, checkpointer):
+    """ Generate all the diffs for the given regulation. Broken out into
+        separate function to assist with profiling so it's easier to determine
+        which parts of the parser take the most time """
+    all_versions = {doc_number: FrozenNode.from_node(reg_tree)}
 
-        # now build diffs - include "empty" diffs comparing a version to itself
-        for lhs_version, lhs_tree in all_versions.iteritems():
-            for rhs_version, rhs_tree in all_versions.iteritems():
-                changes = checkpointer.checkpoint(
-                    "-".join(["diff", lhs_version, rhs_version]),
-                    lambda: dict(changes_between(lhs_tree, rhs_tree)))
-                writer.diff(
-                    label_id, lhs_version, rhs_version
-                ).write(changes)
+    for last_notice, old, new_tree, notices in builder.revision_generator(
+            reg_tree):
+        version = last_notice['document_number']
+        logger.info("Version %s", version)
+        all_versions[version] = FrozenNode.from_node(new_tree)
+        builder.doc_number = version
+        builder.write_regulation(new_tree)
+        layer_cache.invalidate_by_notice(last_notice)
+        builder.gen_and_write_layers(new_tree, act_title_and_section,
+                                     layer_cache, notices)
+        layer_cache.replace_using(new_tree)
+        del last_notice, old, new_tree, notices     # free some memory
+
+    label_id = reg_tree.label_id()
+    writer = builder.writer
+    del reg_tree, layer_cache, builder  # free some memory
+
+    # now build diffs - include "empty" diffs comparing a version to itself
+    for lhs_version, lhs_tree in all_versions.iteritems():
+        for rhs_version, rhs_tree in all_versions.iteritems():
+            changes = checkpointer.checkpoint(
+                "-".join(["diff", lhs_version, rhs_version]),
+                lambda: dict(changes_between(lhs_tree, rhs_tree)))
+            writer.diff(
+                label_id, lhs_version, rhs_version
+            ).write(changes)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Regulation parser')
+    parser.add_argument('filename',
+                        help='XML file containing the regulation')
+    parser.add_argument('title', type=int, help='Title number')
+    parser.add_argument('act_title', type=int, help='Act title',
+                        action='store')
+    parser.add_argument('act_section', type=int, help='Act section')
+    parser.add_argument('--generate-diffs', type=bool, help='Generate diffs?',
+                        required=False, default=True)
+    parser.add_argument('--checkpoint', required=False,
+                        help='Directory to save checkpoint data')
+
+    args = parser.parse_args()
+
+    parse_regulation(args)

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -1,4 +1,6 @@
+from collections import defaultdict
 from json import JSONEncoder
+import hashlib
 
 
 class Node(object):
@@ -142,6 +144,8 @@ def treeify(nodes):
 
 class FrozenNode(object):
     """Immutable interface for nodes. No guarantees about internal state."""
+    _pool = defaultdict(set)    # collection of all FrozenNodes, keyed by hash
+
     def __init__(self, text='', children=(), label=(), title='',
                  node_type=Node.REGTEXT, tagged_text=''):
         self._text = text or ''
@@ -150,6 +154,8 @@ class FrozenNode(object):
         self._title = title or ''
         self._node_type = node_type
         self._tagged_text = tagged_text or ''
+        self._hash = self._generate_hash()
+        FrozenNode._pool[self.hash].add(self)
 
     @property
     def text(self):
@@ -175,27 +181,44 @@ class FrozenNode(object):
     def tagged_text(self):
         return self._tagged_text
 
-    def __repr__(self):
-        if not hasattr(self, '_repr_value'):
-            self._repr_value = (
-                "FrozenNode(text=%s, children=%s, label=%s, title=%s)"
-                % (repr(self.text), repr(self.children), repr(self.label),
-                   repr(self.title)))
-        return self._repr_value
+    @property
+    def hash(self):
+        return self._hash
 
-    def __cmp__(self, other):
-        return (other.__class__ == self.__class__
-                and cmp(repr(self), repr(other)))
+    def _generate_hash(self):
+        hasher = hashlib.sha256()
+        hasher.update(self.text.encode('utf-8'))
+        hasher.update(self.tagged_text.encode('utf-8'))
+        hasher.update(self.title.encode('utf-8'))
+        hasher.update(self.label_id.encode('utf-8'))
+        hasher.update(self.node_type)
+        for child in self.children:
+            hasher.update(child.hash)
+        return hasher.hexdigest()
 
     def __hash__(self):
-        return hash(repr(self))
+        return hash(self.hash)
+
+    def __eq__(self, other):
+        return (other.__class__ == self.__class__
+                and self.hash == other.hash
+                and self.text == other.text
+                and self.title == other.title
+                and self.node_type == other.node_type
+                and self.tagged_text == other.tagged_text
+                and self.label_id == other.label_id
+                and [c.hash for c in self.children] ==
+                    [c.hash for c in other.children])
 
     @staticmethod
     def from_node(node):
         children = map(FrozenNode.from_node, node.children)
-        return FrozenNode(text=node.text, children=children, label=node.label,
-                          title=node.title or '', node_type=node.node_type,
-                          tagged_text=getattr(node, 'tagged_text', '') or '')
+        fresh = FrozenNode(text=node.text, children=children, label=node.label,
+                           title=node.title or '', node_type=node.node_type,
+                           tagged_text=getattr(node, 'tagged_text', '') or '')
+        for el in FrozenNode._pool[fresh.hash]:
+            if el == fresh:
+                return el   # note we are _not_ returning fresh
 
     @property
     def label_id(self):

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -207,6 +207,7 @@ class FrozenNode(object):
         (this is a Merkle tree)"""
         return (other.__class__ == self.__class__
                 and self.hash == other.hash
+                # Compare the fields to limit the effect of hash collisions
                 and self.text == other.text
                 and self.title == other.title
                 and self.node_type == other.node_type

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -186,6 +186,7 @@ class FrozenNode(object):
         return self._hash
 
     def _generate_hash(self):
+        """Called during instantiation. Digests all fields"""
         hasher = hashlib.sha256()
         hasher.update(self.text.encode('utf-8'))
         hasher.update(self.tagged_text.encode('utf-8'))
@@ -197,9 +198,13 @@ class FrozenNode(object):
         return hasher.hexdigest()
 
     def __hash__(self):
+        """As the hash property is already distinctive, re-use it"""
         return hash(self.hash)
 
     def __eq__(self, other):
+        """We define equality as having the same fields except for children.
+        Instead of recursively inspecting them, we compare only their hash
+        (this is a Merkle tree)"""
         return (other.__class__ == self.__class__
                 and self.hash == other.hash
                 and self.text == other.text
@@ -212,6 +217,10 @@ class FrozenNode(object):
 
     @staticmethod
     def from_node(node):
+        """Convert a struct.Node (or similar) into a struct.FrozenNode. This
+        also checks if this node has already been instantiated. If so, it
+        returns the instantiated version (i.e. only one of each identical node
+        exists in memory)"""
         children = map(FrozenNode.from_node, node.children)
         fresh = FrozenNode(text=node.text, children=children, label=node.label,
                            title=node.title or '', node_type=node.node_type,

--- a/tests/tree_struct_tests.py
+++ b/tests/tree_struct_tests.py
@@ -199,3 +199,18 @@ class FrozenNodeTests(TestCase):
         frozen2 = struct.FrozenNode.from_node(node2)
         self.assertNotEqual(id(node1), id(node2))
         self.assertEqual(id(frozen1), id(frozen2))
+
+    def test_hash(self):
+        """Different fields lead to different hashes. The same fields lead to
+        the same hash"""
+        args = {'text': 'text', 'children': [struct.FrozenNode(text='child')],
+                'label': ['b', 'c'], 'title': 'title',
+                'tagged_text': 'tagged_text'}
+        same1 = struct.FrozenNode(**args)
+        same2 = struct.FrozenNode(**args)
+        args['text'] = 'new text'
+        diff = struct.FrozenNode(**args)
+        self.assertNotEqual(id(same1), id(same2))
+        self.assertNotEqual(id(same2), id(diff))
+        self.assertEqual(same1.hash, same2.hash)
+        self.assertNotEqual(same1.hash, diff.hash)

--- a/tests/tree_struct_tests.py
+++ b/tests/tree_struct_tests.py
@@ -141,11 +141,28 @@ class DepthTreeTest(TestCase):
 class FrozenNodeTests(TestCase):
     def test_comparison(self):
         """Frozen nodes with the same values are considered equal"""
-        args = {'text': 'text', 'children': ['a', 'b'], 'label': ['b', 'c'],
-                'title': 'title', 'tagged_text': 'tagged_text'}
+        args = {'text': 'text', 'children': [struct.FrozenNode(text='child')],
+                'label': ['b', 'c'], 'title': 'title',
+                'tagged_text': 'tagged_text'}
         left = struct.FrozenNode(**args)
         right = struct.FrozenNode(**args)
+        self.assertNotEqual(id(left), id(right))
         self.assertEqual(left, right)
+
+    def test_in_set(self):
+        """Frozen nodes with the same values are not replaced in a set"""
+        args = {'text': 'text', 'children': [struct.FrozenNode(text='child')],
+                'label': ['b', 'c'], 'title': 'title',
+                'tagged_text': 'tagged_text'}
+        left = struct.FrozenNode(**args)
+        right = struct.FrozenNode(**args)
+        self.assertNotEqual(id(left), id(right))
+        dict_to_set = {left: set([left])}
+        self.assertTrue(right in dict_to_set)
+        self.assertTrue(right in dict_to_set[right])
+        set_node = dict_to_set[right].pop()
+        self.assertEqual(id(set_node), id(left))
+        self.assertNotEqual(id(set_node), id(right))
 
     def test_from_node(self):
         """Conversion from a normal struct Node should be accurate and
@@ -170,3 +187,15 @@ class FrozenNodeTests(TestCase):
         self.assertEqual(child.node_type, struct.Node.REGTEXT)
         self.assertEqual(child.tagged_text, '')
         self.assertEqual(child.children, ())
+
+    def test_from_node_reuse(self):
+        """If the same node is converted twice, from_node will only allocate
+        memory for it once"""
+        args = {'text': 'text', 'children': [], 'label': ['b', 'c'],
+                'title': 'title'}
+        node1 = struct.Node(**args)
+        node2 = struct.Node(**args)
+        frozen1 = struct.FrozenNode.from_node(node1)
+        frozen2 = struct.FrozenNode.from_node(node2)
+        self.assertNotEqual(id(node1), id(node2))
+        self.assertEqual(id(frozen1), id(frozen2))


### PR DESCRIPTION
This improves memory usage (allowing reg Z to compile on machines with < 1G memory) through a few optimizations.

1. FrozenNodes now have a proper digest hash, which is calculated at their creation time. Equality checks look only at the fields and the hashes, reducing the need to generate a gigantic `repr` string.
1. FrozenNode creation should only occur once. Because they are immutable, we don't need duplicate versions of the same FrozenNode. This means that the majority of the tree is shared between versions which cuts memory usage by about half (for Z)
1. The build_from script includes a few more `del` statements, to indicate memory can be reclaimed.

I also synchronized the build_from script with CFPB's re-order. That'll make merging upstream much easier.