### PR TITLE
Account for more FDSYS locations of the CFR part

### DIFF
--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -36,6 +36,7 @@ def get_reg_part(reg_doc):
     potential_parts.extend(
         # e-CFR XML, under FDSYS/GRANULENUM
         node.text.strip() for node in reg_doc.xpath('//FDSYS/GRANULENUM'))
+    potential_parts = [p for p in potential_parts if p.strip()]
 
     if potential_parts:
         return potential_parts[0]

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -1,10 +1,10 @@
-#vim: set encoding=utf-8
+# vim: set encoding=utf-8
 from unittest import TestCase
 
 from lxml import etree
 from mock import patch
 
-from regparser.tree.xml_parser.reg_text import *
+from regparser.tree.xml_parser import reg_text
 
 
 class RegTextTest(TestCase):
@@ -17,7 +17,7 @@ class RegTextTest(TestCase):
                 <P>(a) something something</P>
             </SECTION>
         """
-        node = build_from_section('8675', etree.fromstring(xml))[0]
+        node = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
         self.assertEqual('Some content about this section.', node.text.strip())
         self.assertEqual(1, len(node.children))
         self.assertEqual(['8675', '309'], node.label)
@@ -37,7 +37,7 @@ class RegTextTest(TestCase):
             <P>(b) <E T="03">Contents</E> (1) Here</P>
         </SECTION>
         """
-        node = build_from_section('8675', etree.fromstring(xml))[0]
+        node = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
         self.assertEqual(node.label, ['8675', '309'])
         self.assertEqual(2, len(node.children))
         self.assertEqual(node.children[0].label, ['8675', '309', 'a'])
@@ -59,7 +59,7 @@ class RegTextTest(TestCase):
                 <P>(A) AAA—(<E T="03">1</E>) eeee</P>
             </SECTION>
         """
-        node = build_from_section('8675', etree.fromstring(xml))[0]
+        node = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
         a1iA = node.children[0].children[0].children[0].children[0]
         self.assertEqual(u"(A) AAA—", a1iA.text)
         self.assertEqual(1, len(a1iA.children))
@@ -74,7 +74,7 @@ class RegTextTest(TestCase):
                 <P>(ii) Content2</P>
             </SECTION>
         """
-        node = build_from_section('8675', etree.fromstring(xml))[0]
+        node = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
         self.assertEqual(['8675', '309'], node.label)
         self.assertEqual(1, len(node.children))
 
@@ -96,7 +96,7 @@ class RegTextTest(TestCase):
                 <SECTNO>§ 8675.309</SECTNO>
                 <RESERVED>[Reserved]</RESERVED>
             </SECTION>"""
-        node = build_from_section('8675', etree.fromstring(xml))[0]
+        node = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
         self.assertEqual(node.label, ['8675', '309'])
         self.assertEqual(u'§ 8675.309 [Reserved]', node.title)
         self.assertEqual([], node.children)
@@ -107,7 +107,8 @@ class RegTextTest(TestCase):
                 <SECTNO>§§ 8675.309-8675.311</SECTNO>
                 <RESERVED>[Reserved]</RESERVED>
             </SECTION>"""
-        n309, n310, n311 = build_from_section('8675', etree.fromstring(xml))
+        n309, n310, n311 = reg_text.build_from_section(
+            '8675', etree.fromstring(xml))
         self.assertEqual(n309.label, ['8675', '309'])
         self.assertEqual(n310.label, ['8675', '310'])
         self.assertEqual(n311.label, ['8675', '311'])
@@ -128,16 +129,16 @@ class RegTextTest(TestCase):
                 <P>%s</P>
             </SECTION>
         """
-        n8675_309 = build_from_section('8675',
-                                       etree.fromstring(xml % '(ii) A'))[0]
+        n8675_309 = reg_text.build_from_section(
+            '8675', etree.fromstring(xml % '(ii) A'))[0]
         n8675_309_h = n8675_309.children[1]
         n8675_309_h_2 = n8675_309_h.children[1]
         self.assertEqual(2, len(n8675_309.children))
         self.assertEqual(2, len(n8675_309_h.children))
         self.assertEqual(2, len(n8675_309_h_2.children))
 
-        n8675_309 = build_from_section('8675',
-                                       etree.fromstring(xml % '(A) B'))[0]
+        n8675_309 = reg_text.build_from_section(
+            '8675', etree.fromstring(xml % '(A) B'))[0]
         n8675_309_h = n8675_309.children[1]
         n8675_309_h_2 = n8675_309_h.children[1]
         n8675_309_h_2_i = n8675_309_h_2.children[0]
@@ -146,12 +147,12 @@ class RegTextTest(TestCase):
         self.assertEqual(1, len(n8675_309_h_2.children))
         self.assertEqual(1, len(n8675_309_h_2_i.children))
 
-        n8675_309 = build_from_section('8675',
-                                       etree.fromstring(xml % '(1) C'))[0]
+        n8675_309 = reg_text.build_from_section(
+            '8675', etree.fromstring(xml % '(1) C'))[0]
         self.assertEqual(3, len(n8675_309.children))
 
-        n8675_309 = build_from_section('8675',
-                                       etree.fromstring(xml % '(3) D'))[0]
+        n8675_309 = reg_text.build_from_section(
+            '8675', etree.fromstring(xml % '(3) D'))[0]
         n8675_309_h = n8675_309.children[1]
         n8675_309_h_2 = n8675_309_h.children[1]
         self.assertEqual(2, len(n8675_309.children))
@@ -169,7 +170,7 @@ class RegTextTest(TestCase):
                 <P>(B) BBB</P>
             </SECTION>
         """
-        n309 = build_from_section('8675', etree.fromstring(xml))[0]
+        n309 = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
         self.assertEqual(1, len(n309.children))
         n309_a = n309.children[0]
         self.assertEqual(2, len(n309_a.children))
@@ -191,7 +192,7 @@ class RegTextTest(TestCase):
                 <P>\n(<E T="03">2</E>) i2i2i2</P>
             </SECTION>
         """
-        node = build_from_section('8675', etree.fromstring(xml))[0]
+        node = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
         self.assertEqual(1, len(node.children))
         self.assertEqual(node.label, ['8675', '309'])
 
@@ -224,7 +225,7 @@ class RegTextTest(TestCase):
                 <P>(b)<E T="03">General.</E>Content Content.</P>
             </SECTION>
         """
-        node = build_from_section('8675', etree.fromstring(xml))[0]
+        node = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
         self.assertEqual(1, len(node.children))
         nb = node.children[0]
         self.assertEqual(nb.text.strip(), "(b) General. Content Content.")
@@ -234,17 +235,19 @@ class RegTextTest(TestCase):
             <PART>
                 <HD>regulation title</HD>
             </PART>"""
-        title = get_title(etree.fromstring(xml))
+        title = reg_text.get_title(etree.fromstring(xml))
         self.assertEqual(u'regulation title', title)
 
     def test_get_reg_part(self):
-        xml = u"""
-            <PART>
-                <EAR> Pt. 204 </EAR>
-            </PART>
-        """
-        part = get_reg_part(etree.fromstring(xml))
-        self.assertEqual(part, '204')
+        """Test various formats for the Regulation part to be present in a
+        CFR-XML document"""
+        xmls = []
+        xmls.append(u"<PART><EAR>Pt. 204</EAR></PART>")
+        xmls.append(u"<FDSYS><HEADING>PART 204</HEADING></FDSYS>")
+        xmls.append(u"<FDSYS><GRANULENUM>204</GRANULENUM></FDSYS>")
+        for xml_str in xmls:
+            part = reg_text.get_reg_part(etree.fromstring(xml_str))
+            self.assertEqual(part, '204')
 
     def test_get_reg_part_fr_notice_style(self):
         xml = u"""
@@ -253,7 +256,7 @@ class RegTextTest(TestCase):
             </SECTION>
             </REGTEXT>
         """
-        part = get_reg_part(etree.fromstring(xml))
+        part = reg_text.get_reg_part(etree.fromstring(xml))
         self.assertEqual(part, '204')
 
     def test_get_subpart_title(self):
@@ -261,7 +264,7 @@ class RegTextTest(TestCase):
             <SUBPART>
                 <HD>Subpart A—First subpart</HD>
             </SUBPART>"""
-        subpart_title = get_subpart_title(etree.fromstring(xml))
+        subpart_title = reg_text.get_subpart_title(etree.fromstring(xml))
         self.assertEqual(subpart_title, u'Subpart A—First subpart')
 
     def test_build_subpart(self):
@@ -282,7 +285,7 @@ class RegTextTest(TestCase):
             </SECTION>
             </SUBPART>
         """
-        subpart = build_subpart('8675', etree.fromstring(xml))
+        subpart = reg_text.build_subpart('8675', etree.fromstring(xml))
         self.assertEqual(subpart.node_type, 'subpart')
         self.assertEqual(len(subpart.children), 2)
         self.assertEqual(subpart.label, ['8675', 'Subpart', 'A'])
@@ -291,7 +294,7 @@ class RegTextTest(TestCase):
 
     def test_get_markers(self):
         text = u'(a) <E T="03">Transfer </E>—(1) <E T="03">Notice.</E> follow'
-        markers = get_markers(text)
+        markers = reg_text.get_markers(text)
         self.assertEqual(markers, [u'a', u'1'])
 
     def test_get_markers_and_text(self):
@@ -299,8 +302,8 @@ class RegTextTest(TestCase):
         wrap = '<P>%s</P>' % text
 
         doc = etree.fromstring(wrap)
-        markers = get_markers(text)
-        result = get_markers_and_text(doc, markers)
+        markers = reg_text.get_markers(text)
+        result = reg_text.get_markers_and_text(doc, markers)
 
         markers = [r[0] for r in result]
         self.assertEqual(markers, [u'a', u'1'])
@@ -317,8 +320,8 @@ class RegTextTest(TestCase):
     def test_get_markers_and_text_emph(self):
         text = '(A) aaaa. (<E T="03">1</E>) 1111'
         xml = etree.fromstring('<P>%s</P>' % text)
-        markers = get_markers(text)
-        result = get_markers_and_text(xml, markers)
+        markers = reg_text.get_markers(text)
+        result = reg_text.get_markers_and_text(xml, markers)
 
         a, a1 = result
         self.assertEqual(('A', ('(A) aaaa. ', '(A) aaaa. ')), a)
@@ -330,7 +333,7 @@ class RegTextTest(TestCase):
         text += 'paragraphs (a)(2), (a)(4)(iii), (a)(5), (b) through (d), '
         text += '(f), and (g) with respect to something, (i), (j), (l) '
         text += 'through (p), (q)(1), and (r) with respect to something.'
-        self.assertEqual(['vi'], get_markers(text))
+        self.assertEqual(['vi'], reg_text.get_markers(text))
 
     @patch('regparser.tree.xml_parser.reg_text.content')
     def test_preprocess_xml(self, content):
@@ -351,7 +354,7 @@ class RegTextTest(TestCase):
               <GPH DEEP="453" SPAN="2">
                 <GID>EFGH.0123</GID>
               </GPH>""")]
-        preprocess_xml(xml)
+        reg_text.preprocess_xml(xml)
         should_be = etree.fromstring("""
         <CFRGRANULE>
           <PART>
@@ -375,4 +378,4 @@ class RegTextTest(TestCase):
                 <STARS />
                 <P>(xi) More</P>
             </ROOT>""")
-        self.assertEqual('xi', next_marker(xml.getchildren()[0], []))
+        self.assertEqual('xi', reg_text.next_marker(xml.getchildren()[0], []))


### PR DESCRIPTION
The FDSYS XML might include the CFR part in a few different places. For the FEC regs, it was in a different place than the CFPB regs.

Also some cleanup due to flake8 warnings.