### PR TITLE
A "Watch Node" script

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,21 @@ regulation. To include all final notices, add this flag:
 $ python notice_order.py 12 1005 --include-notices-without-changes
 ```
 
+### Watch Node
+
+Tracing how a specific node changes over the life of a regulation can help
+track down why the parser is failing (or exploding). The `watch_node.py`
+utility does exactly that, stepping through the initial tree and all
+subsequent notices. Whenever a node is changed (created, modified, deleted,
+etc.) this utility will log some output.
+
+```
+$ python watch_node.py 1005-16-c path/to/regulation.xml 12
+```
+
+The first parameter is the label of the node you want to watch, the second is
+the initial regulation XML file and the final parameter is the CFR title.
+
 
 ## Building the documentation
 

--- a/regparser/builder.py
+++ b/regparser/builder.py
@@ -74,6 +74,9 @@ class Builder(object):
                 layer)
 
     def revision_generator(self, reg_tree):
+        """Given an initial regulation tree, this will emit (and checkpoint)
+        new versions of the tree, along with the notice that caused the
+        change. This is a generator, so processing only occurs as needed"""
         for version, merged_changes in self.changes_in_sequence():
             old_tree = reg_tree
             reg_tree = self.checkpointer.checkpoint(

--- a/regparser/grammar/tokens.py
+++ b/regparser/grammar/tokens.py
@@ -51,6 +51,7 @@ class Verb(Token):
     DELETE = 'DELETE'
     DESIGNATE = 'DESIGNATE'
     RESERVE = 'RESERVE'
+    KEEP = 'KEEP'
 
     def __init__(self, verb, active, and_prefix=False):
         self.verb = verb

--- a/regparser/notice/changes.py
+++ b/regparser/notice/changes.py
@@ -246,7 +246,7 @@ def pretty_change(change):
     node = change.get('node')
     field = change.get('field')
     if change['action'] == Verb.PUT and field:
-        return '%s changed to: %s' % (field.strip('[]'),
+        return '%s changed to: %s' % (field.strip('[]').title(),
                                       node.get('title', node['text']))
     elif change['action'] in (Verb.PUT, Verb.POST):
         verb = 'Modified' if change['action'] == Verb.PUT else 'Added'
@@ -257,7 +257,7 @@ def pretty_change(change):
     elif change['action'] == Verb.DELETE:
         return 'Deleted'
     elif change['action'] == Verb.DESIGNATE:
-        return 'Moved to ' + change['destination']
+        return 'Moved to ' + '-'.join(change['destination'])
     elif change['action'] == Verb.RESERVE:
         return 'Reserved'
     elif change['action'] == 'KEEP':

--- a/regparser/notice/changes.py
+++ b/regparser/notice/changes.py
@@ -192,7 +192,7 @@ def create_add_amendment(amendment):
         # Text is stars, but this is not the root. Explicitly try to keep
         # this node
         if text == '* * *':
-            change[label]['action'] = 'KEEP'
+            change[label]['action'] = Verb.KEEP
 
         # If text ends with a colon and is followed by stars, assume we are
         # only modifying the intro text
@@ -260,7 +260,7 @@ def pretty_change(change):
         return 'Moved to ' + '-'.join(change['destination'])
     elif change['action'] == Verb.RESERVE:
         return 'Reserved'
-    elif change['action'] == 'KEEP':
+    elif change['action'] == Verb.KEEP:
         return 'Mentioned but not modified'
     else:
         return change['action']

--- a/regparser/notice/changes.py
+++ b/regparser/notice/changes.py
@@ -6,6 +6,7 @@ import logging
 import copy
 from collections import defaultdict
 
+from regparser.grammar.tokens import Verb
 from regparser.layer.paragraph_markers import marker_of
 from regparser.tree import struct
 from regparser.tree.paragraph import p_levels
@@ -238,6 +239,31 @@ def remove_intro(l):
     """ Remove the marker that indicates this is a change to introductory
     text. """
     return l.replace('[text]', '')
+
+
+def pretty_change(change):
+    """Pretty print output for a change"""
+    node = change.get('node')
+    field = change.get('field')
+    if change['action'] == Verb.PUT and field:
+        return '%s changed to: %s' % (field.strip('[]'),
+                                      node.get('title', node['text']))
+    elif change['action'] in (Verb.PUT, Verb.POST):
+        verb = 'Modified' if change['action'] == Verb.PUT else 'Added'
+        if node.get('title'):
+            return verb + ' (title: %s): %s' % (node['title'], node['text'])
+        else:
+            return verb + ": " + node['text']
+    elif change['action'] == Verb.DELETE:
+        return 'Deleted'
+    elif change['action'] == Verb.DESIGNATE:
+        return 'Moved to ' + change['destination']
+    elif change['action'] == Verb.RESERVE:
+        return 'Reserved'
+    elif change['action'] == 'KEEP':
+        return 'Mentioned but not modified'
+    else:
+        return change['action']
 
 
 class NoticeChanges(object):

--- a/regparser/notice/compiler.py
+++ b/regparser/notice/compiler.py
@@ -7,6 +7,7 @@ import copy
 import itertools
 import logging
 
+from regparser.grammar.tokens import Verb
 from regparser.tree.struct import Node, find
 from regparser.tree.xml_parser import interpretations
 from regparser.tree.xml_parser import tree_utils
@@ -393,7 +394,7 @@ class RegulationTree(object):
     def create_new_subpart(self, subpart_label):
         """ Create a whole new subpart. """
 
-        #XXX Subparts need titles. We'll need to pull this up from parsing.
+        # XXX Subparts need titles. We'll need to pull this up from parsing.
         subpart_node = Node('', [], subpart_label, None, Node.SUBPART)
         self.add_to_root(subpart_node)
         return subpart_node
@@ -453,7 +454,7 @@ def sort_labels(labels):
     """ Deal with higher up elements first. """
     sorted_labels = sorted(labels, key=lambda x: len(x))
 
-    #The length of a Subpart label doesn't indicate it's level in the tree
+    # The length of a Subpart label doesn't indicate it's level in the tree
     subparts = [l for l in sorted_labels if 'Subpart' in l]
     non_subparts = [l for l in sorted_labels if 'Subpart' not in l]
 
@@ -530,8 +531,8 @@ def compile_regulation(previous_tree, notice_changes):
                  for change in notice_changes[label]]
     pass_len = len(next_pass) + 1
 
-    reg.keep(l for l, change in next_pass if change['action'] == 'KEEP')
-    next_pass = [pair for pair in next_pass if pair[1]['action'] != 'KEEP']
+    reg.keep(l for l, change in next_pass if change['action'] == Verb.KEEP)
+    next_pass = [pair for pair in next_pass if pair[1]['action'] != Verb.KEEP]
 
     #   Monotonically decreasing length - guarantees we'll end
     while pass_len > len(next_pass):

--- a/tests/notice_changes_tests.py
+++ b/tests/notice_changes_tests.py
@@ -1,4 +1,4 @@
-#vim: set encoding=utf-8
+# vim: set encoding=utf-8
 from unittest import TestCase
 from regparser.notice import changes
 from regparser.tree.struct import Node, find
@@ -226,6 +226,47 @@ class ChangesTests(TestCase):
 
         node = Node('', label=['205', '35', 'c', '1', 'i'])
         self.assertFalse(changes.impossible_label(node, amended_labels))
+
+    def test_pretty_changes(self):
+        """Verify the output for a variety of "changes" """
+        self.assertEqual(
+            changes.pretty_change({'action': 'DELETE'}), 'Deleted')
+        self.assertEqual(
+            changes.pretty_change({'action': 'RESERVE'}), 'Reserved')
+        self.assertEqual(
+            changes.pretty_change({'action': 'KEEP'}),
+            'Mentioned but not modified')
+        self.assertEqual(
+            changes.pretty_change({'action': 'DESIGNATE',
+                                   'destination': ['123', '43', 'a', '2']}),
+            'Moved to 123-43-a-2')
+
+        node = {'text': 'Some Text'}
+        change = {'action': 'PUT', 'node': node}
+        self.assertEqual(
+            changes.pretty_change(change), 'Modified: Some Text')
+
+        change['action'] = 'POST'
+        self.assertEqual(
+            changes.pretty_change(change), 'Added: Some Text')
+
+        node['title'] = 'A Title'
+        self.assertEqual(
+            changes.pretty_change(change), 'Added (title: A Title): Some Text')
+
+        change['action'] = 'PUT'
+        self.assertEqual(
+            changes.pretty_change(change),
+            'Modified (title: A Title): Some Text')
+
+        change['field'] = '[title]'
+        self.assertEqual(
+            changes.pretty_change(change), 'Title changed to: A Title')
+
+        del node['title']
+        change['field'] = '[a field]'
+        self.assertEqual(
+            changes.pretty_change(change), 'A Field changed to: Some Text')
 
 
 class NoticeChangesTests(TestCase):

--- a/watch_node.py
+++ b/watch_node.py
@@ -1,6 +1,6 @@
 # @todo - this should be combined with build_from.py
 import argparse
-import codecs
+
 
 try:
     import requests_cache
@@ -10,27 +10,9 @@ except ImportError:
     # HTTP requests rather than looking it up from the cache
     pass
 
-from regparser.builder import Builder
+from regparser.builder import tree_and_builder
 from regparser.notice.changes import node_to_dict, pretty_change
 from regparser.tree.struct import find
-
-
-def init_reg_and_builder(args):
-    """This function repeats a lot of what's done in build_from.py -- parse
-    the provided regulation file into a tree and create a Builder object"""
-    reg_text = ''
-    with codecs.open(args.filename, 'r', 'utf-8') as f:
-        reg_text = f.read()
-    initial_tree = Builder.reg_tree(reg_text)
-    title_part = initial_tree.label_id()
-    doc_number = Builder.determine_doc_number(
-        reg_text, args.title, title_part)
-    if not doc_number:
-        raise ValueError("Could not determine document number")
-    builder = Builder(cfr_title=args.title,
-                      cfr_part=title_part,
-                      doc_number=doc_number)
-    return initial_tree, builder
 
 
 if __name__ == "__main__":
@@ -43,7 +25,7 @@ if __name__ == "__main__":
     parser.add_argument('title', type=int, help='Title number')
     args = parser.parse_args()
 
-    initial_tree, builder = init_reg_and_builder(args)
+    initial_tree, builder = tree_and_builder(args.filename, args.title)
     initial_node = find(initial_tree, args.node_label)
     if initial_node:
         print("> " + builder.doc_number)

--- a/watch_node.py
+++ b/watch_node.py
@@ -1,0 +1,58 @@
+# @todo - this should be combined with build_from.py
+import argparse
+import codecs
+
+try:
+    import requests_cache
+    requests_cache.install_cache('fr_cache')
+except ImportError:
+    # If the cache library isn't present, do nothing -- we'll just make full
+    # HTTP requests rather than looking it up from the cache
+    pass
+
+from regparser.builder import Builder
+from regparser.notice.changes import node_to_dict, pretty_change
+from regparser.tree.struct import find
+
+
+def init_reg_and_builder(args):
+    """This function repeats a lot of what's done in build_from.py -- parse
+    the provided regulation file into a tree and create a Builder object"""
+    reg_text = ''
+    with codecs.open(args.filename, 'r', 'utf-8') as f:
+        reg_text = f.read()
+    initial_tree = Builder.reg_tree(reg_text)
+    title_part = initial_tree.label_id()
+    doc_number = Builder.determine_doc_number(
+        reg_text, args.title, title_part)
+    if not doc_number:
+        raise ValueError("Could not determine document number")
+    builder = Builder(cfr_title=args.title,
+                      cfr_part=title_part,
+                      doc_number=doc_number)
+    return initial_tree, builder
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Node Watcher")
+    parser.add_argument(
+        'node_label',
+        help='Label for the node you wish to watch. e.g. 1026-5-a')
+    parser.add_argument('filename',
+                        help='XML file containing the regulation')
+    parser.add_argument('title', type=int, help='Title number')
+    args = parser.parse_args()
+
+    initial_tree, builder = init_reg_and_builder(args)
+    initial_node = find(initial_tree, args.node_label)
+    if initial_node:
+        print("> " + builder.doc_number)
+        print("\t" + pretty_change(
+            {'action': 'POST', 'node': node_to_dict(initial_node)}))
+
+    # search for label
+    for version, changes in builder.changes_in_sequence():
+        if args.node_label in changes:
+            print("> " + version)
+            for change in changes[args.node_label]:
+                print("\t" + pretty_change(change))


### PR DESCRIPTION
README describes what this does, but the hope is that it'd make debugging a little bit easier. Right now, it's possible to manually grep through trees and notices, but it's awfully cumbersome.

This has a lot of duplication with `build_from.py` and doesn't make use of checkpoints, but I think it's still useful in its current form.

Looks like:

```
$ python watch_node.py 1005-16-c fr-notices/articles/xml/201/131/725.xml 12
WARNING:root:Bad format for whole appendix
> 2011-31725
    Added: (c) Notice requirement. To meet the requirements of paragraph (b) of this section, an automated teller machine operator must comply with the following:
> 2013-06861
    Modified: (c) Notice requirement. An automated teller machine operator must provide the notice required by paragraph (b) of this section either by showing it on the screen of the automated teller machine or by providing it on paper, before the consumer is committed to paying a fee.
```