### PR TITLE
Bug fix around notices containing multiple regs

### DIFF
--- a/regparser/notice/compiler.py
+++ b/regparser/notice/compiler.py
@@ -524,7 +524,7 @@ def compile_regulation(previous_tree, notice_changes):
     labels = sort_labels(notice_changes.keys())
 
     reg_part = previous_tree.label[0]
-    labels = filter(lambda l: l.startswith(reg_part), labels)
+    labels = filter(lambda l: l.split('-')[0] == reg_part, labels)
 
     next_pass = [(label, change)
                  for label in labels

--- a/tests/notice_compiler_tests.py
+++ b/tests/notice_compiler_tests.py
@@ -639,11 +639,15 @@ class CompilerTests(TestCase):
         self.assertEqual(added_node.text, '2a1 text')
 
     def test_compile_reg_move_wrong_reg(self):
+        """Changes applied to other regulations shouldn't affect the
+        regulation we care about, even if that has the same textual prefix"""
         root = self.tree_with_paragraphs()
-        notice_changes = {'202-2-a': [{'action': 'MOVE',
-                                       'destination': ['202', '2', 'b']}]}
+        notice_changes = {'2055-2-a': [{'action': 'MOVE',
+                                       'destination': ['2055', '2', 'b']}]}
         reg = compiler.compile_regulation(root, notice_changes)
         self.assertEqual(find(reg, '205-2-a').text, 'n2a')
+        self.assertEqual(find(reg, '205-2-b').text, 'n2b')
+        self.assertEqual(find(reg, '2055-2-b'), None)
 
     def test_compile_add_to_subpart(self):
         root = self.tree_with_subparts()


### PR DESCRIPTION
The problem we ran into was that a notice would contain changes to both reg 2 and reg 200. The filter was not properly filtering out the 200 when looking at changes for 2.