### PR TITLE
Allow regs which have no history

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,12 @@ reissuance of the whole regulation (e.g. CFPB
 regulation E).
 
 
-### Run the parser
+### Run the parser (`build_from`)
 
 The syntax is 
 
 ```bash
-$ python build_from.py regulation.ext title act_title act_section
+$ python build_from.py regulation.xml title act_title act_section
 ```
 
 For example, to match regulation H in the quick start above:
@@ -146,11 +146,10 @@ For example, to match regulation H in the quick start above:
 $ python build_from.py CFR-2012-title12-vol8-part1004.xml 12 15 1693
 ```
 
-Here ```12``` is the CFR title number (in our case, for "Banks and
-Banking"), ```15``` is the
-title of "the Act" and ```1693``` is the relevant section. Wherever the
-phrase "the Act" is used in the regulation, the external link parser will
-treat it as "15 U.S.C. 1693".
+Here ```12``` is the CFR title number (in our case, for "Banks and Banking"),
+```15``` is the title of "the Act" and ```1693``` is the relevant section.
+Wherever the phrase "the Act" is used in the regulation, the external link
+parser will treat it as "15 U.S.C. 1693".
 
 Running the command will generate four folders, ```regulation```,
 ```notice```, ``layer`` and possibly ``diff`` in the ```OUTPUT_DIR```
@@ -158,6 +157,19 @@ Running the command will generate four folders, ```regulation```,
 
 If you'd like to write the data to an api instead (most likely, one running
 regulations-core), you can set the ```API_BASE``` setting (described below).
+
+There are also some advanced flags which can be set when running the parser
+
+* `--no-generate-diffs` Avoids the default behavior of generating additional
+  versions of the regulation based on federal register rules. If this flag is
+  set, the parser will produce a single tree and set of layers
+* `--checkpoint CHECKPOINT_DIR` Defines a directory to store checkpoint
+  information. It's always safe to not provide this, though you may improve
+  performance when you do. See [Runtime](#runtime), below.
+* `--version-identifier DOC_NUMBER` If you are trying to parse a version of
+  the regulation issued before federalregister.gov has records (~2000), you
+  may need to explicitly provide a version number. This will just be an
+  identifier for the version; you may use "1997-annual", for example.
 
 ### Settings
 

--- a/build_from.py
+++ b/build_from.py
@@ -97,7 +97,8 @@ if __name__ == "__main__":
     parser.add_argument(
         '--version-identifier', dest='doc_number', required=False,
         help=('Do not try to derive the version information. (Only use if '
-              "your regulation is older than federalregister.gov's records)"))
+              'the regulation has no electronic final rules on '
+              'federalregister.gov, i.e. has not changed since before ~2000)'))
 
     args = parser.parse_args()
 

--- a/build_from.py
+++ b/build_from.py
@@ -28,7 +28,7 @@ def parse_regulation(args):
     act_title_and_section = [args.act_title, args.act_section]
     #   First, the regulation tree
     reg_tree, builder = tree_and_builder(args.filename, args.title,
-                                         args.checkpoint)
+                                         args.checkpoint_dir, args.doc_number)
     builder.write_notices()
 
     #   Always do at least the first reg
@@ -92,8 +92,12 @@ if __name__ == "__main__":
     diffs.add_argument('--no-generate-diffs', dest='generate_diffs',
                        action='store_false', help="Don't generate diffs")
     diffs.set_defaults(generate_diffs=True)
-    parser.add_argument('--checkpoint', required=False,
+    parser.add_argument('--checkpoint', dest='checkpoint_dir', required=False,
                         help='Directory to save checkpoint data')
+    parser.add_argument(
+        '--version-identifier', dest='doc_number', required=False,
+        help=('Do not try to derive the version information. (Only use if '
+              "your regulation is older than federalregister.gov's records)"))
 
     args = parser.parse_args()
 

--- a/regparser/builder.py
+++ b/regparser/builder.py
@@ -327,9 +327,10 @@ class NullCheckpointer(object):
         return fn()
 
 
-def tree_and_builder(filename, title, checkpoint_path=None):
+def tree_and_builder(filename, title, checkpoint_path=None, doc_number=None):
     """Reads the regulation file and parses it. Returns the resulting tree as
-    well as a Builder object for further manipulation"""
+    well as a Builder object for further manipulation. Looks up the doc_number
+    if it's not provided"""
     if checkpoint_path is None:
         checkpointer = NullCheckpointer()
     else:
@@ -343,9 +344,10 @@ def tree_and_builder(filename, title, checkpoint_path=None):
     reg_tree = checkpointer.checkpoint("init-tree-" + file_digest,
                                        lambda: Builder.reg_tree(reg_text))
     title_part = reg_tree.label_id()
-    doc_number = checkpointer.checkpoint(
-        "doc-number-" + file_digest,
-        lambda: Builder.determine_doc_number(reg_text, title, title_part))
+    if doc_number is None:
+        doc_number = checkpointer.checkpoint(
+            "doc-number-" + file_digest,
+            lambda: Builder.determine_doc_number(reg_text, title, title_part))
     if not doc_number:
         raise ValueError("Could not determine document number")
 


### PR DESCRIPTION
Certain regulations haven't changed since before federalregister.gov was keeping electronic copies of notices. In these situations, we'd like to manually specify what version number should be associated with the provided version of the regulation.

I thought the code assumed that the regulation would have a notice associated with it, but I didn't run into any problems with this change. I manually traced through the version generating code as well, and didn't see a problem.

No tests as the changes are occurring in the runner script, which doesn't have a good test harness. The changes are also minor.