### PR TITLE
Pull in some code from CFPB

### DIFF
--- a/regparser/grammar/terms.py
+++ b/regparser/grammar/terms.py
@@ -1,7 +1,7 @@
 #vim: set encoding=utf-8
 from pyparsing import (
     LineStart, Literal, OneOrMore, Optional, Regex, SkipTo, srange, Suppress,
-    Word, ZeroOrMore)
+    Word, ZeroOrMore, NotAny)
 
 from regparser.grammar import atomic, unified
 from regparser.grammar.utils import DocLiteral, keep_pos, Marker
@@ -16,6 +16,7 @@ smart_quotes = (
 
 e_tag = (
     Suppress(Regex(r"<E[^>]*>"))
+    + NotAny(Marker("this") + Marker("term")) 
     + OneOrMore(
         Word(srange("[a-zA-Z-]"))
     ).setParseAction(keep_pos).setResultsName("term")

--- a/regparser/grammar/terms.py
+++ b/regparser/grammar/terms.py
@@ -24,7 +24,7 @@ e_tag = (
 
 xml_term_parser = (
     LineStart()
-    + Suppress(unified.any_depth_p)
+    + Optional(Suppress(unified.any_depth_p))
     + e_tag.setResultsName("head")
     + ZeroOrMore(
         (atomic.conj_phrases + e_tag).setResultsName(

--- a/regparser/grammar/terms.py
+++ b/regparser/grammar/terms.py
@@ -16,7 +16,6 @@ smart_quotes = (
 
 e_tag = (
     Suppress(Regex(r"<E[^>]*>"))
-    + NotAny(Marker("this") + Marker("term")) 
     + OneOrMore(
         Word(srange("[a-zA-Z-]"))
     ).setParseAction(keep_pos).setResultsName("term")

--- a/regparser/layer/formatting.py
+++ b/regparser/layer/formatting.py
@@ -103,7 +103,7 @@ class Formatting(Layer):
                            + r"(?P<lines>([^\n]*\n)+)"
                            + r"```")
     subscript_re = re.compile(r"([a-zA-Z0-9]+)_\{(\w+)\}")
-    dashes_re = re.compile(r"_{5}$")
+    dashes_re = re.compile(r"_{5,}$")
 
     def process(self, node):
         layer_el = []

--- a/regparser/layer/formatting.py
+++ b/regparser/layer/formatting.py
@@ -103,6 +103,7 @@ class Formatting(Layer):
                            + r"(?P<lines>([^\n]*\n)+)"
                            + r"```")
     subscript_re = re.compile(r"([a-zA-Z0-9]+)_\{(\w+)\}")
+    dashes_re = re.compile(r"_{5}$")
 
     def process(self, node):
         layer_el = []
@@ -116,6 +117,7 @@ class Formatting(Layer):
                 layer_el.append({'text': table_xml_to_plaintext(table),
                                  'locations': [0],
                                  'table_data': table_xml_to_data(table)})
+
         for match in Formatting.fenced_re.finditer(node.text):
             layer_el.append({
                 'text': node.text[match.start():match.end()],
@@ -123,6 +125,7 @@ class Formatting(Layer):
                 'fence_data': {
                     'type': match.group('type'),
                     'lines': filter(bool, match.group('lines').split("\n"))}})
+
         subscripts = {}
         for match in Formatting.subscript_re.finditer(node.text):
             key = (match.group(1), match.group(2))
@@ -134,5 +137,15 @@ class Formatting(Layer):
                 'locations': list(range(count)),
                 'subscript_data': {'variable': variable,
                                    'subscript': subscript}})
+
+        for match in Formatting.dashes_re.finditer(node.text):
+            layer_el.append({
+                'text': node.text,
+                'locations': [0],
+                'dash_data': {
+                    'text': node.text[:match.start()],
+                },
+            })
+        
         if layer_el:
             return layer_el

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -20,7 +20,7 @@ from regparser.tree.xml_parser import tree_utils
 from regparser.tree.xml_parser.interpretations import build_supplement_tree
 from regparser.tree.xml_parser.interpretations import get_app_title
 
-from local_settings import APPENDIX_IGNORE_SUBHEADER_LABEL
+from settings import APPENDIX_IGNORE_SUBHEADER_LABEL
 
 def remove_toc(appendix, letter):
     """The TOC at the top of certain appendices gives us trouble since it

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -138,6 +138,14 @@ class AppendixProcessor(object):
 
         self.m_stack.add(self.depth, n)
 
+    def insert_dashes(self, xml_node, text):
+        """ If paragraph has a SOURCE attribute with a value of FP-DASH 
+            it fills out with dashes, like Foo_____. """
+        mtext = text
+        if xml_node.get('SOURCE') == 'FP-DASH':
+            mtext = mtext + '_____'
+        return mtext
+
     def paragraph_with_marker(self, text, tagged_text):
         """The paragraph has a marker, like (a) or a. etc."""
         # To aid in determining collapsed paragraphs, replace any
@@ -157,14 +165,6 @@ class AppendixProcessor(object):
             node = Node(mtext, node_type=Node.APPENDIX,
                         label=[initial_marker(mtext)[0]])
             self.nodes.append(node)
-
-    def paragraph_with_dash(self, text):
-        """ The paragraph fills out with dashes, like Foo_____. """
-        self.paragraph_counter += 1
-        mtext = text + '_____'
-        n = Node(mtext, node_type=Node.APPENDIX,
-                 label=['p' + str(self.paragraph_counter)])
-        self.nodes.append(n)
 
     def paragraph_no_marker(self, text):
         """The paragraph has no (a) or a. etc."""
@@ -276,11 +276,12 @@ class AppendixProcessor(object):
                 self.end_group()
                 self.subheader(child, text)
             elif initial_marker(text) and child.tag in ('P', 'FP', 'HD'):
+                text = self.insert_dashes(child, text)
                 self.paragraph_with_marker(
-                    text, tree_utils.get_node_text_tags_preserved(child))
-            elif child.tag in ('P', 'FP') and child.get('SOURCE') == 'FP-DASH':
-                self.paragraph_with_dash(text)
+                    text,
+                    tree_utils.get_node_text_tags_preserved(child))
             elif child.tag in ('P', 'FP'):
+                text = self.insert_dashes(child, text)
                 self.paragraph_no_marker(text)
             elif child.tag == 'GPH':
                 self.graphic(child)

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -158,6 +158,14 @@ class AppendixProcessor(object):
                         label=[initial_marker(mtext)[0]])
             self.nodes.append(node)
 
+    def paragraph_with_dash(self, text):
+        """ The paragraph fills out with dashes, like Foo_____. """
+        self.paragraph_counter += 1
+        mtext = text + '_____'
+        n = Node(mtext, node_type=Node.APPENDIX,
+                 label=['p' + str(self.paragraph_counter)])
+        self.nodes.append(n)
+
     def paragraph_no_marker(self, text):
         """The paragraph has no (a) or a. etc."""
         self.paragraph_counter += 1
@@ -270,6 +278,8 @@ class AppendixProcessor(object):
             elif initial_marker(text) and child.tag in ('P', 'FP', 'HD'):
                 self.paragraph_with_marker(
                     text, tree_utils.get_node_text_tags_preserved(child))
+            elif child.tag in ('P', 'FP') and child.get('SOURCE') == 'FP-DASH':
+                self.paragraph_with_dash(text)
             elif child.tag in ('P', 'FP'):
                 self.paragraph_no_marker(text)
             elif child.tag == 'GPH':

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -367,7 +367,7 @@ def title_label_pair(text, appendix_letter, reg_part):
                             pair[0], appendix_letter)
             pair = None
 
-    return None
+    return pair
 
 def initial_marker(text):
     parser = (grammar.paren_upper | grammar.paren_lower | grammar.paren_digit

--- a/settings.py
+++ b/settings.py
@@ -87,6 +87,13 @@ REGPATCHES_SOURCES = [
 # versions of their XML
 LOCAL_XML_PATHS = []
 
+
+# Sometimes appendices provide examples or model forms that include
+# labels that we would otherwise recognize as structural to the appendix
+# text itself. This specifies those labels to ignore by regulation
+# number, appendix, and label.
+APPENDIX_IGNORE_SUBHEADER_LABEL = {}
+
 try:
     from local_settings import *
 except ImportError:

--- a/tests/grammar_terms_tests.py
+++ b/tests/grammar_terms_tests.py
@@ -1,0 +1,30 @@
+#vim: set encoding=utf-8
+from unittest import TestCase
+
+from regparser.grammar.terms import *
+
+def parse_text(text):
+    return [m[0] for m, _, _ in token_patterns.scanString(text)]
+
+class GrammarTermsTests(TestCase):
+
+    def test_xml_term_parser(self):
+        text = u'(1) <E T="03">Damages incurred</E> means actual damages incurred'
+        result = [match for match, _, _ in xml_term_parser.scanString(text)]
+        match = result[0]
+        self.assertEqual(len(result), 1)
+        self.assertEqual(match.term[0], 'Damages')
+        self.assertEqual(match.term[1], 'incurred')
+
+        text = u'<E T="03">Damages incurred</E> means actual damages incurred'
+        result = [match for match, _, _ in xml_term_parser.scanString(text)]
+        match = result[0]
+        self.assertEqual(len(result), 1)
+        self.assertEqual(match.term[0], 'Damages')
+        self.assertEqual(match.term[1], 'incurred')
+
+        # This sort of text shouldn't match.
+        text = u"This sort of text shouldn't match."
+        result = [match for match, _, _ in xml_term_parser.scanString(text)]
+        self.assertEqual(len(result), 0)
+

--- a/tests/layer_formatting_tests.py
+++ b/tests/layer_formatting_tests.py
@@ -119,3 +119,18 @@ class LayerFormattingTests(TestCase):
         self.assertEqual(result['locations'], [0, 1])
         self.assertEqual(result['subscript_data'],
                          {'variable': 'a', 'subscript': 'subscript'})
+
+    def test_process_dashes(self):
+        node = Node("This is an fp-dash_____")
+        result = formatting.Formatting(None).process(node)
+        self.assertEqual(1, len(result))
+        result = result[0]
+        print result
+
+        self.assertEqual(result['text'], "This is an fp-dash_____")
+        self.assertEqual(result['locations'], [0])
+        self.assertEqual(result['dash_data'],
+                         {'text': 'This is an fp-dash'})
+        
+
+

--- a/tests/layer_terms_tests.py
+++ b/tests/layer_terms_tests.py
@@ -123,9 +123,7 @@ class LayerTermTest(TestCase):
 
         xml_no_defs = [
             (u'(d) Term1 or term2 means stuff',
-             u'(d) <E T="03">Term1</E> or <E T="03">term2></E> means stuff'),
-            (u'This term means should not match',
-             u'<E T="03">This term</E> means should not match')]
+             u'(d) <E T="03">Term1</E> or <E T="03">term2></E> means stuff'),]
 
         scope_term_defs = [
             ('For purposes of this section, the term blue means the color',

--- a/tests/tree_xml_parser_appendices_tests.py
+++ b/tests/tree_xml_parser_appendices_tests.py
@@ -378,24 +378,24 @@ class AppendicesTest(TestCase):
 
     def test_title_label_pair(self):
         title = u'A-1—Model Clauses'
-        self.assertEqual(('1', 2), appendices.title_label_pair(title, 'A'))
+        self.assertEqual(('1', 2), appendices.title_label_pair(title, 'A', '1000'))
 
         title = u'Part III—Construction Period'
-        self.assertEqual(('III', 2), appendices.title_label_pair(title, 'A'))
+        self.assertEqual(('III', 2), appendices.title_label_pair(title, 'A', '1000'))
 
     def test_title_label_pair_parens(self):
         title = u'G-13(A)—Has No parent'
-        self.assertEqual(('13(A)', 2), appendices.title_label_pair(title, 'G'))
+        self.assertEqual(('13(A)', 2), appendices.title_label_pair(title, 'G', '1000'))
 
         title = u'G-13(C)(1) - Some Title'
         self.assertEqual(('13(C)(1)', 2),
-                         appendices.title_label_pair(title, 'G'))
+                         appendices.title_label_pair(title, 'G', '1000'))
 
         title = u'G-13A - Some Title'
-        self.assertEqual(('13A', 2), appendices.title_label_pair(title, 'G'))
+        self.assertEqual(('13A', 2), appendices.title_label_pair(title, 'G', '1000'))
 
         title = u'G-13And Some Smashed Text'
-        self.assertEqual(('13', 2), appendices.title_label_pair(title, 'G'))
+        self.assertEqual(('13', 2), appendices.title_label_pair(title, 'G', '1000'))
 
 
 class AppendixProcessorTest(TestCase):

--- a/tests/tree_xml_parser_appendices_tests.py
+++ b/tests/tree_xml_parser_appendices_tests.py
@@ -85,6 +85,19 @@ class AppendicesTest(TestCase):
         self.assertEqual('A-3 Some header here', a3.title)
         self.assertEqual('A-4 Another header', a4.title)
 
+    def test_process_appendix_fp_dash(self):
+        xml = u"""
+        <APPENDIX>
+            <EAR>Pt. 1111, App. A</EAR>
+            <HD SOURCE="HED">Appendix A to Part 1111—Awesome</HD>
+            <FP SOURCE="FP-DASH">FP-DASH filled out with dashes</FP>
+        </APPENDIX>"""
+        appendix = appendices.process_appendix(etree.fromstring(xml), 1111)
+        self.assertEqual(1, len(appendix.children))
+        fp_dash = appendix.children[0]
+
+        self.assertEqual('FP-DASH filled out with dashes_____', fp_dash.text.strip())
+
     def test_process_appendix_header_depth(self):
         xml = u"""
         <APPENDIX>


### PR DESCRIPTION
These correspond to @willbarton's
* https://github.com/cfpb/regulations-parser/pull/276 Allowing appendices to display `FP-DASH` differently
* https://github.com/cfpb/regulations-parser/pull/279 Allowing terms in unmarked paragraphs
* https://github.com/cfpb/regulations-parser/pull/280 Adds a configuration for ignoring headers in certain regulations

These have already been reviewed once, so no need for deep review.