### PR TITLE
Generate a fake notice when explicitly providing the document number

### DIFF
--- a/regparser/notice/fake.py
+++ b/regparser/notice/fake.py
@@ -1,0 +1,19 @@
+"""Generate a minimal notice without hitting the FR"""
+
+
+def build(doc_number, effective_on, cfr_title, cfr_part):
+    return {
+        "document_number": doc_number,
+        "effective_on": effective_on,
+        "initial_effective_on": effective_on,
+        "publication_date": effective_on,
+        "cfr_title": cfr_title,
+        "cfr_parts": [cfr_part],
+        "fr_url": None
+    }
+
+
+def effective_date_for(xml_tree):
+    """Return the date associated with an annual edition of regulation XML"""
+    nodes = xml_tree.xpath('//DATE') or xml_tree.xpath('//ORIGINALDATE')
+    return nodes[0].text

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -64,15 +64,14 @@ def preprocess_xml(xml):
 
 
 def build_tree(reg_xml):
-    doc = etree.fromstring(reg_xml)
-    preprocess_xml(doc)
+    preprocess_xml(reg_xml)
 
-    reg_part = get_reg_part(doc)
-    title = get_title(doc)
+    reg_part = get_reg_part(reg_xml)
+    title = get_title(reg_xml)
 
     tree = Node("", [], [reg_part], title)
 
-    part = doc.xpath('//PART')[0]
+    part = reg_xml.xpath('//PART')[0]
 
     subpart_xmls = [c for c in part.getchildren() if c.tag == 'SUBPART']
     if len(subpart_xmls) > 0:
@@ -87,7 +86,7 @@ def build_tree(reg_xml):
         empty_part.children = sections
         tree.children = [empty_part]
 
-    non_reg_sections = build_non_reg_text(doc, reg_part)
+    non_reg_sections = build_non_reg_text(reg_xml, reg_part)
     tree.children += non_reg_sections
 
     return tree

--- a/tests/builder_tests.py
+++ b/tests/builder_tests.py
@@ -103,8 +103,9 @@ class BuilderTests(TestCase):
             <FRDOC>[FR Doc. 2011-31715 Filed 12-21-11; 8:45 am]</FRDOC>
             <BILCOD>BILLING CODE 4810-AM-P</BILCOD>
         </RULE>"""
+        xml = etree.fromstring(xml_str)
         self.assertEqual(
-            '2011-31715', Builder.determine_doc_number(xml_str, '00', '00'))
+            '2011-31715', Builder.determine_doc_number(xml, '00', '00'))
 
     @patch('regparser.builder.fetch_notice_json')
     def test_determine_doc_number_annual(self, fetch_notice_json):
@@ -123,8 +124,9 @@ class BuilderTests(TestCase):
                 <ORIGINALDATE>2012-01-01</ORIGINALDATE>
             </FDSYS>
         </CFRGRANULE>"""
+        xml = etree.fromstring(xml_str)
         self.assertEqual(
-            '111-111', Builder.determine_doc_number(xml_str, '12', '34'))
+            '111-111', Builder.determine_doc_number(xml, '12', '34'))
         args = fetch_notice_json.call_args
         self.assertEqual(('12', '34'), args[0])     # positional args
         self.assertEqual({'max_effective_date': '2012-01-01',

--- a/tests/notice_fake_tests.py
+++ b/tests/notice_fake_tests.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+
+from lxml import etree
+
+from regparser.notice import fake
+
+
+class NoticeFakeTests(TestCase):
+    def test_effective_date_for(self):
+        """This function should be able to pull the effective date out of a
+        few places"""
+        xml = etree.fromstring("""
+            <ROOT>
+                <P>CONTENT</P>
+                <DATE>1999-02-03</DATE>
+                <ORIGINALDATE>1988-06-07</ORIGINALDATE>
+            </ROOT>""")
+        self.assertEqual(fake.effective_date_for(xml), '1999-02-03')
+
+        xml = etree.fromstring("""
+            <ROOT>
+                <P>CONTENT</P>
+                <ORIGINALDATE>1988-06-07</ORIGINALDATE>
+            </ROOT>""")
+        self.assertEqual(fake.effective_date_for(xml), '1988-06-07')


### PR DESCRIPTION
This resolves #32 by inserting a fake notice into the system when parsing a regulation which has had no changes since the federal register began digitizing final rules.

It also removes duplicate string-to-xml conversions and removes `Builder.reg_tree` in favor of a direct call to the underlying library. Unlike #34, this has been tested from parsing to display (along with changes to -core and -site)