### PR TITLE
Enhanced "split text"

### DIFF
--- a/regparser/tree/depth/markers.py
+++ b/regparser/tree/depth/markers.py
@@ -19,4 +19,7 @@ STARS_TAG = 'STARS'
 INLINE_STARS = '* * *'
 stars = (STARS_TAG, INLINE_STARS)
 
+# Account for paragraphs without a marker at all
+MARKERLESS = 'MARKERLESS'
+
 types = [lower, upper, ints, roman, em_ints, em_roman, stars]

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -97,6 +97,7 @@ def get_subpart_title(subpart_xml):
     if hds:
         return [hd.text for hd in hds][0]
 
+
 def build_subpart(reg_part, subpart_xml):
     subpart_title = get_subpart_title(subpart_xml)
     subpart = reg_text.build_subpart(subpart_title, reg_part)
@@ -136,15 +137,15 @@ def get_markers_and_text(node, markers_list):
     node_text = tree_utils.get_node_text(node, add_spaces=True)
     text_with_tags = tree_utils.get_node_text_tags_preserved(node)
 
-    if len(markers_list) > 1:
-        actual_markers = ['(%s)' % m for m in markers_list]
-        plain_markers = [m.replace('<E T="03">', '').replace('</E>', '')
-                         for m in actual_markers]
-        node_texts = tree_utils.split_text(node_text, plain_markers)
-        tagged_texts = tree_utils.split_text(text_with_tags, actual_markers)
-        node_text_list = zip(node_texts, tagged_texts)
-    elif markers_list:
-        node_text_list = [(node_text, text_with_tags)]
+    actual_markers = ['(%s)' % m for m in markers_list]
+    plain_markers = [m.replace('<E T="03">', '').replace('</E>', '')
+                     for m in actual_markers]
+    node_texts = tree_utils.split_text(node_text, plain_markers)
+    tagged_texts = tree_utils.split_text(text_with_tags, actual_markers)
+    node_text_list = zip(node_texts, tagged_texts)
+
+    if len(node_text_list) > len(markers_list):     # diff can only be 1
+        markers_list.insert(0, mtypes.MARKERLESS)
     return zip(markers_list, node_text_list)
 
 
@@ -184,11 +185,14 @@ def build_from_section(reg_part, section_xml):
             section_texts.append((text, tagged_text))
         else:
             for m, node_text in get_markers_and_text(ch, markers_list):
-                n = Node(node_text[0], [], [m], source_xml=ch)
-                n.tagged_text = unicode(node_text[1])
-                nodes.append(n)
-            if node_text[0].endswith('* * *'):
-                nodes.append(Node(label=[mtypes.INLINE_STARS]))
+                if m == mtypes.MARKERLESS:
+                    section_texts.append(node_text)
+                else:
+                    n = Node(node_text[0], [], [m], source_xml=ch)
+                    n.tagged_text = unicode(node_text[1])
+                    nodes.append(n)
+                if node_text[0].endswith('* * *'):
+                    nodes.append(Node(label=[mtypes.INLINE_STARS]))
 
     # Trailing stars don't matter; slightly more efficient to ignore them
     while nodes and nodes[-1].label[0] in mtypes.stars:

--- a/regparser/tree/xml_parser/tree_utils.py
+++ b/regparser/tree/xml_parser/tree_utils.py
@@ -36,6 +36,13 @@ class NodeStack(PriorityStack):
         children = [prepend_parts(parts_prefix, c[1]) for c in children]
         self.peek_last()[1].children = children
 
+    def collapse(self):
+        """After all of the nodes have been inserted at their proper levels,
+        collapse them into a single root node"""
+        while self.size() > 1:
+            self.unwind()
+        return self.peek_last()[1]
+
 
 def split_text(text, tokens):
     """

--- a/regparser/tree/xml_parser/tree_utils.py
+++ b/regparser/tree/xml_parser/tree_utils.py
@@ -1,4 +1,4 @@
-#vim: set encoding=utf-8
+# vim: set encoding=utf-8
 from copy import deepcopy
 import HTMLParser
 from itertools import chain
@@ -43,6 +43,8 @@ def split_text(text, tokens):
         splice the text along those tokens.
     """
     starts = [text.find(t) for t in tokens]
+    if not starts or starts[0] != 0:
+        starts.insert(0, 0)
     slices = zip(starts, starts[1:])
     texts = [text[i[0]:i[1]] for i in slices] + [text[starts[-1]:]]
     return texts
@@ -152,7 +154,7 @@ def get_node_text_tags_preserved(node):
 
     for c in node:
         if c.tag == 'E':
-            #xlmns non-sense makes me do this.
+            # xlmns non-sense makes me do this.
             e_tag = '<E T="03">%s</E>' % c.text
             node_text += e_tag
         if c.tail is not None:

--- a/tests/tree_utils_tests.py
+++ b/tests/tree_utils_tests.py
@@ -1,4 +1,4 @@
-#vim: set encoding=utf-8
+# vim: set encoding=utf-8
 import unittest
 
 from lxml import etree
@@ -14,6 +14,16 @@ class TreeUtilsTest(unittest.TestCase):
 
         result = tree_utils.split_text(text, tokens)
         expected = ['(A) Apples ', '(B) Bananas (Z) Zebras']
+        self.assertEqual(expected, result)
+
+    def test_split_text_with_prefix(self):
+        """Don't wipe out the intro text, if present"""
+        text = "Some content here (A) Apples (B) Bananas (Z) Zebras"
+        tokens = ['(A)', '(B)']
+
+        result = tree_utils.split_text(text, tokens)
+        expected = ['Some content here ', '(A) Apples ',
+                    '(B) Bananas (Z) Zebras']
         self.assertEqual(expected, result)
 
     def test_consecutive_markers(self):

--- a/tests/tree_utils_tests.py
+++ b/tests/tree_utils_tests.py
@@ -103,6 +103,37 @@ class TreeUtilsTest(unittest.TestCase):
         n = m_stack.pop()[0][1]
         self.assertEqual(n.children[0].label, ['272', 'a'])
 
+    def test_collapse_stack(self):
+        """collapse() is a helper method which wraps up all of the node
+        stack's nodes with a bow"""
+        m_stack = tree_utils.NodeStack()
+        m_stack.add(0, Node(label=['272']))
+        m_stack.add(1, Node(label=['11']))
+        m_stack.add(2, Node(label=['a']))
+        m_stack.add(3, Node(label=['1']))
+        m_stack.add(3, Node(label=['2']))
+        m_stack.add(2, Node(label=['b']))
+
+        reg = m_stack.collapse()
+        self.assertEqual(reg.label, ['272'])
+        self.assertEqual(len(reg.children), 1)
+
+        section = reg.children[0]
+        self.assertEqual(section.label, ['272', '11'])
+        self.assertEqual(len(section.children), 2)
+
+        a, b = section.children
+        self.assertEqual(b.label, ['272', '11', 'b'])
+        self.assertEqual(len(b.children), 0)
+        self.assertEqual(a.label, ['272', '11', 'a'])
+        self.assertEqual(len(a.children), 2)
+
+        a1, a2 = a.children
+        self.assertEqual(a1.label, ['272', '11', 'a', '1'])
+        self.assertEqual(len(a1.children), 0)
+        self.assertEqual(a2.label, ['272', '11', 'a', '2'])
+        self.assertEqual(len(a2.children), 0)
+
     def test_get_collapsed_markers(self):
         text = u'(a) <E T="03">Transfer </E>—(1) <E T="03">Notice.</E> follow'
         markers = tree_utils.get_collapsed_markers(text)

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 from lxml import etree
 from mock import patch
 
+from regparser.tree.depth import markers as mtypes
 from regparser.tree.xml_parser import reg_text
 
 
@@ -335,6 +336,19 @@ class RegTextTest(TestCase):
         self.assertEqual(('A', ('(A) aaaa. ', '(A) aaaa. ')), a)
         self.assertEqual(('<E T="03">1</E>', ('(1) 1111',
                                               '(<E T="03">1</E>) 1111')), a1)
+
+    def test_get_markers_and_text_deceptive_single(self):
+        """Don't treat a single marker differently than multiple, there might
+        be prefix text"""
+        node = etree.fromstring('<P>Some words then (a) a subparagraph</P>')
+        results = reg_text.get_markers_and_text(node, ['a'])
+        self.assertEqual(len(results), 2)
+        prefix, subpar = results
+
+        self.assertEqual(prefix[0], mtypes.MARKERLESS)
+        self.assertEqual(prefix[1][0], 'Some words then ')
+        self.assertEqual(subpar[0], 'a')
+        self.assertEqual(subpar[1][0], '(a) a subparagraph')
 
     def test_get_markers_bad_citation(self):
         text = '(vi)<E T="03">Keyterm.</E>The information required by '


### PR DESCRIPTION
Previously, paragraphs like:
> Something something (a) subparagraph (b) another subparagraph

Were getting cut down to just the two subparagraphs. This expands the functionality to account for that extra starting text. It also adds a special marker type, `MARKERLESS`, which will be used significantly in a later update.

Finally, it adds a helper method to `NodeStack` to unwind the stack in one fell swoop.