### PR TITLE
Allow MARKERLESS paragraphs in the depth-parsing code

### DIFF
--- a/regparser/tree/depth/derive.py
+++ b/regparser/tree/depth/derive.py
@@ -80,6 +80,10 @@ def derive_depths(marker_list, additional_constraints=[]):
             problem.addConstraint(rules.depth_check, pairs)
             problem.addConstraint(rules.stars_check, pairs)
 
+        if idx > 1:
+            pairs = all_vars[3*(idx-2):]
+            problem.addConstraint(rules.markerless_sandwich, pairs)
+
     # separate loop so that the simpler checks run first
     for idx in range(1, len(marker_list)):
         # start with the current idx

--- a/regparser/tree/depth/markers.py
+++ b/regparser/tree/depth/markers.py
@@ -21,5 +21,6 @@ stars = (STARS_TAG, INLINE_STARS)
 
 # Account for paragraphs without a marker at all
 MARKERLESS = 'MARKERLESS'
+markerless = (MARKERLESS,)
 
-types = [lower, upper, ints, roman, em_ints, em_roman, stars]
+types = [lower, upper, ints, roman, em_ints, em_roman, stars, markerless]

--- a/tests/tree_depth_derive_tests.py
+++ b/tests/tree_depth_derive_tests.py
@@ -6,127 +6,119 @@ from regparser.tree.depth.markers import STARS_TAG, INLINE_STARS
 
 
 class DeriveTests(TestCase):
+    def assert_depth_match(self, markers, *depths_set):
+        """Verify that the set of markers resolves to the provided set of
+        depths (in any order)"""
+        solutions = derive_depths(markers)
+        results = [[a.depth for a in s] for s in solutions]
+        self.assertEqual(len(depths_set), len(results))
+        self.assertItemsEqual(results, depths_set)
+
     def test_ints(self):
-        results = derive_depths(['1', '2', '3', '4'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 0, 0, 0], [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['1', '2', '3', '4'],
+            [0, 0, 0, 0])
 
     def test_alpha_ints(self):
-        results = derive_depths(['A', '1', '2', '3'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 1, 1, 1], [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['A', '1', '2', '3'],
+            [0, 1, 1, 1])
 
     def test_alpha_ints_jump_back(self):
-        results = derive_depths(['A', '1', '2', '3', 'B', '1', '2', '3', 'C'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 1, 1, 1, 0, 1, 1, 1, 0],
-                         [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['A', '1', '2', '3', 'B', '1', '2', '3', 'C'],
+            [0, 1, 1, 1, 0, 1, 1, 1, 0])
 
     def test_roman_alpha(self):
-        results = derive_depths(['a', '1', '2', 'b', '1', '2', '3', '4', 'i',
-                                 'ii', 'iii', '5', 'c', 'd', '1', '2', 'e'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 1, 1, 0, 1, 1, 1, 1, 2, 2, 2, 1, 0, 0, 1, 1, 0],
-                         [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['a', '1', '2', 'b', '1', '2', '3', '4', 'i', 'ii', 'iii', '5',
+             'c', 'd', '1', '2', 'e'],
+            [0, 1, 1, 0, 1, 1, 1, 1, 2, 2, 2, 1, 0, 0, 1, 1, 0])
 
     def test_mix_levels_roman_alpha(self):
-        results = derive_depths(['A', '1', '2', 'i', 'ii', 'iii', 'iv', 'B',
-                                 '1', 'a', 'b', '2', 'a', 'b', 'i', 'ii',
-                                 'iii', 'c'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 1, 1, 2, 2, 2, 2, 0, 1, 2, 2, 1, 2, 2, 3, 3, 3,
-                          2], [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['A', '1', '2', 'i', 'ii', 'iii', 'iv', 'B', '1', 'a', 'b', '2',
+             'a', 'b', 'i', 'ii', 'iii', 'c'],
+            [0, 1, 1, 2, 2, 2, 2, 0, 1, 2, 2, 1, 2, 2, 3, 3, 3, 2])
 
     def test_i_ambiguity(self):
-        results = derive_depths(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
-        self.assertEqual(2, len(results))
-        results = [[r.depth for r in result] for result in results]
-        self.assertTrue([0, 0, 0, 0, 0, 0, 0, 0, 0] in results)
-        self.assertTrue([0, 0, 0, 0, 0, 0, 0, 0, 1] in results)
+        self.assert_depth_match(
+            ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 1])
 
-        results = derive_depths(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
-                                 'j'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                         [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
-        results = derive_depths(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
-                                 'ii'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 0, 0, 0, 0, 0, 0, 0, 1, 1],
-                         [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'ii'],
+            [0, 0, 0, 0, 0, 0, 0, 0, 1, 1])
 
     def test_repeat_alpha(self):
-        results = derive_depths(['A', '1', 'a', 'i', 'ii', 'a', 'b', 'c', 'b'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 1, 2, 3, 3, 4, 4, 4, 2],
-                         [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['A', '1', 'a', 'i', 'ii', 'a', 'b', 'c', 'b'],
+            [0, 1, 2, 3, 3, 4, 4, 4, 2])
 
     def test_simple_stars(self):
-        results = derive_depths(['A', '1', STARS_TAG, 'd'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 1, 2, 2], [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['A', '1', STARS_TAG, 'd'],
+            [0, 1, 2, 2])
 
-        results = derive_depths(['A', '1', 'a', STARS_TAG, 'd'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 1, 2, 2, 2], [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['A', '1', 'a', STARS_TAG, 'd'],
+            [0, 1, 2, 2, 2])
 
     def test_ambiguous_stars(self):
-        results = derive_depths(['A', '1', 'a', STARS_TAG, 'B'])
-        self.assertEqual(4, len(results))
-        results = [[r.depth for r in result] for result in results]
-        self.assertTrue([0, 1, 2, 3, 3] in results)
-        self.assertTrue([0, 1, 2, 3, 0] in results)
-        self.assertTrue([0, 1, 2, 2, 0] in results)
-        self.assertTrue([0, 1, 2, 1, 0] in results)
+        self.assert_depth_match(
+            ['A', '1', 'a', STARS_TAG, 'B'],
+            [0, 1, 2, 3, 3],
+            [0, 1, 2, 3, 0],
+            [0, 1, 2, 2, 0],
+            [0, 1, 2, 1, 0])
 
     def test_double_stars(self):
-        results = derive_depths(['A', '1', 'a', STARS_TAG, STARS_TAG, 'B'])
-        self.assertEqual(3, len(results))
-        results = [[r.depth for r in result] for result in results]
-        self.assertTrue([0, 1, 2, 2, 1, 0] in results)
-        self.assertTrue([0, 1, 2, 3, 2, 0] in results)
-        self.assertTrue([0, 1, 2, 3, 1, 0] in results)
+        self.assert_depth_match(
+            ['A', '1', 'a', STARS_TAG, STARS_TAG, 'B'],
+            [0, 1, 2, 2, 1, 0],
+            [0, 1, 2, 3, 2, 0],
+            [0, 1, 2, 3, 1, 0])
 
     def test_alpha_roman_ambiguous(self):
-        results = derive_depths(['i', 'ii', STARS_TAG, 'v', STARS_TAG, 'vii'])
-        self.assertEqual(3, len(results))
-        results = [[r.depth for r in result] for result in results]
-        self.assertTrue([0, 0, 1, 1, 2, 2] in results)
-        self.assertTrue([0, 0, 1, 1, 0, 0] in results)
-        self.assertTrue([0, 0, 0, 0, 0, 0] in results)
+        self.assert_depth_match(
+            ['i', 'ii', STARS_TAG, 'v', STARS_TAG, 'vii'],
+            [0, 0, 1, 1, 2, 2],
+            [0, 0, 1, 1, 0, 0],
+            [0, 0, 0, 0, 0, 0])
 
     def test_start_star(self):
-        results = derive_depths([STARS_TAG, 'c', '1', STARS_TAG, 'ii', 'iii',
-                                 '2', 'i', 'ii', STARS_TAG, 'v', STARS_TAG,
-                                 'vii', 'A'])
-        self.assertEqual(4, len(results))
-        results = [[r.depth for r in result] for result in results]
-        self.assertTrue([0, 0, 1, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 3] in results)
-        self.assertTrue([0, 0, 1, 2, 2, 2, 1, 2, 2, 3, 3, 2, 2, 3] in results)
-        self.assertTrue([0, 0, 1, 2, 2, 2, 1, 2, 2, 3, 3, 4, 4, 5] in results)
-        self.assertTrue([0, 0, 1, 2, 2, 2, 1, 2, 2, 0, 0, 1, 1, 2] in results)
+        self.assert_depth_match(
+            [STARS_TAG, 'c', '1', STARS_TAG, 'ii', 'iii', '2', 'i', 'ii',
+             STARS_TAG, 'v', STARS_TAG, 'vii', 'A'],
+            [0, 0, 1, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 3],
+            [0, 0, 1, 2, 2, 2, 1, 2, 2, 3, 3, 2, 2, 3],
+            [0, 0, 1, 2, 2, 2, 1, 2, 2, 3, 3, 4, 4, 5],
+            [0, 0, 1, 2, 2, 2, 1, 2, 2, 0, 0, 1, 1, 2])
 
     def test_inline_star(self):
-        results = derive_depths(['1', STARS_TAG, '2'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 1, 0], [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['1', STARS_TAG, '2'],
+            [0, 1, 0])
 
-        results = derive_depths(['1', INLINE_STARS, '2'])
-        self.assertEqual(2, len(results))
-        results = [[r.depth for r in result] for result in results]
-        self.assertTrue([0, 0, 0] in results)
-        self.assertTrue([0, 1, 0] in results)
+        self.assert_depth_match(
+            ['1', INLINE_STARS, '2'],
+            [0, 0, 0],
+            [0, 1, 0])
 
     def test_star_star(self):
-        results = derive_depths(['A', STARS_TAG, STARS_TAG, 'D'])
-        self.assertEqual(1, len(results))
-        self.assertTrue([0, 1, 0, 0], [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['A', STARS_TAG, STARS_TAG, 'D'],
+            [0, 1, 0, 0])
 
-        results = derive_depths(['A', INLINE_STARS, STARS_TAG, 'D'])
-        self.assertEqual(2, len(results))
-        self.assertTrue([0, 1, 2, 2], [r.depth for r in results[0]])
-        self.assertTrue([0, 1, 0, 0], [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['A', INLINE_STARS, STARS_TAG, 'D'],
+            [0, 1, 2, 2],
+            [0, 1, 0, 0])
 
     def test_depth_type_order(self):
         extra = rules.depth_type_order([markers.ints, markers.lower])

--- a/tests/tree_depth_derive_tests.py
+++ b/tests/tree_depth_derive_tests.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from regparser.tree.depth import markers, rules
 from regparser.tree.depth.derive import derive_depths
-from regparser.tree.depth.markers import STARS_TAG, INLINE_STARS
+from regparser.tree.depth.markers import INLINE_STARS, MARKERLESS, STARS_TAG
 
 
 class DeriveTests(TestCase):
@@ -11,7 +11,6 @@ class DeriveTests(TestCase):
         depths (in any order)"""
         solutions = derive_depths(markers)
         results = [[a.depth for a in s] for s in solutions]
-        self.assertEqual(len(depths_set), len(results))
         self.assertItemsEqual(results, depths_set)
 
     def test_ints(self):
@@ -106,6 +105,19 @@ class DeriveTests(TestCase):
         self.assert_depth_match(['A', INLINE_STARS, STARS_TAG, 'D'],
                                 [0, 1, 2, 2],
                                 [0, 1, 0, 0])
+
+    def test_markerless_outermost(self):
+        """A pattern often seen in definitions sections"""
+        self.assert_depth_match(
+            [MARKERLESS, MARKERLESS, 'a', 'b', MARKERLESS, 'a', 'b'],
+            [0, 0, 1, 1, 0, 1, 1])
+
+    def test_markerless_repeated(self):
+        """Repeated markerless paragraphs must be on the same level"""
+        self.assert_depth_match(
+            [MARKERLESS, 'a', MARKERLESS, MARKERLESS],
+            [0, 1, 0, 0],
+            [0, 1, 2, 2])
 
     def test_depth_type_order(self):
         extra = rules.depth_type_order([markers.ints, markers.lower])

--- a/tests/tree_depth_derive_tests.py
+++ b/tests/tree_depth_derive_tests.py
@@ -15,19 +15,16 @@ class DeriveTests(TestCase):
         self.assertItemsEqual(results, depths_set)
 
     def test_ints(self):
-        self.assert_depth_match(
-            ['1', '2', '3', '4'],
-            [0, 0, 0, 0])
+        self.assert_depth_match(['1', '2', '3', '4'],
+                                [0, 0, 0, 0])
 
     def test_alpha_ints(self):
-        self.assert_depth_match(
-            ['A', '1', '2', '3'],
-            [0, 1, 1, 1])
+        self.assert_depth_match(['A', '1', '2', '3'],
+                                [0, 1, 1, 1])
 
     def test_alpha_ints_jump_back(self):
-        self.assert_depth_match(
-            ['A', '1', '2', '3', 'B', '1', '2', '3', 'C'],
-            [0, 1, 1, 1, 0, 1, 1, 1, 0])
+        self.assert_depth_match(['A', '1', '2', '3', 'B', '1', '2', '3', 'C'],
+                                [0, 1, 1, 1, 0, 1, 1, 1, 0])
 
     def test_roman_alpha(self):
         self.assert_depth_match(
@@ -42,10 +39,9 @@ class DeriveTests(TestCase):
             [0, 1, 1, 2, 2, 2, 2, 0, 1, 2, 2, 1, 2, 2, 3, 3, 3, 2])
 
     def test_i_ambiguity(self):
-        self.assert_depth_match(
-            ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'],
-            [0, 0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0, 1])
+        self.assert_depth_match(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 1])
 
         self.assert_depth_match(
             ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
@@ -61,35 +57,30 @@ class DeriveTests(TestCase):
             [0, 1, 2, 3, 3, 4, 4, 4, 2])
 
     def test_simple_stars(self):
-        self.assert_depth_match(
-            ['A', '1', STARS_TAG, 'd'],
-            [0, 1, 2, 2])
+        self.assert_depth_match(['A', '1', STARS_TAG, 'd'],
+                                [0, 1, 2, 2])
 
-        self.assert_depth_match(
-            ['A', '1', 'a', STARS_TAG, 'd'],
-            [0, 1, 2, 2, 2])
+        self.assert_depth_match(['A', '1', 'a', STARS_TAG, 'd'],
+                                [0, 1, 2, 2, 2])
 
     def test_ambiguous_stars(self):
-        self.assert_depth_match(
-            ['A', '1', 'a', STARS_TAG, 'B'],
-            [0, 1, 2, 3, 3],
-            [0, 1, 2, 3, 0],
-            [0, 1, 2, 2, 0],
-            [0, 1, 2, 1, 0])
+        self.assert_depth_match(['A', '1', 'a', STARS_TAG, 'B'],
+                                [0, 1, 2, 3, 3],
+                                [0, 1, 2, 3, 0],
+                                [0, 1, 2, 2, 0],
+                                [0, 1, 2, 1, 0])
 
     def test_double_stars(self):
-        self.assert_depth_match(
-            ['A', '1', 'a', STARS_TAG, STARS_TAG, 'B'],
-            [0, 1, 2, 2, 1, 0],
-            [0, 1, 2, 3, 2, 0],
-            [0, 1, 2, 3, 1, 0])
+        self.assert_depth_match(['A', '1', 'a', STARS_TAG, STARS_TAG, 'B'],
+                                [0, 1, 2, 2, 1, 0],
+                                [0, 1, 2, 3, 2, 0],
+                                [0, 1, 2, 3, 1, 0])
 
     def test_alpha_roman_ambiguous(self):
-        self.assert_depth_match(
-            ['i', 'ii', STARS_TAG, 'v', STARS_TAG, 'vii'],
-            [0, 0, 1, 1, 2, 2],
-            [0, 0, 1, 1, 0, 0],
-            [0, 0, 0, 0, 0, 0])
+        self.assert_depth_match(['i', 'ii', STARS_TAG, 'v', STARS_TAG, 'vii'],
+                                [0, 0, 1, 1, 2, 2],
+                                [0, 0, 1, 1, 0, 0],
+                                [0, 0, 0, 0, 0, 0])
 
     def test_start_star(self):
         self.assert_depth_match(
@@ -101,24 +92,20 @@ class DeriveTests(TestCase):
             [0, 0, 1, 2, 2, 2, 1, 2, 2, 0, 0, 1, 1, 2])
 
     def test_inline_star(self):
-        self.assert_depth_match(
-            ['1', STARS_TAG, '2'],
-            [0, 1, 0])
+        self.assert_depth_match(['1', STARS_TAG, '2'],
+                                [0, 1, 0])
 
-        self.assert_depth_match(
-            ['1', INLINE_STARS, '2'],
-            [0, 0, 0],
-            [0, 1, 0])
+        self.assert_depth_match(['1', INLINE_STARS, '2'],
+                                [0, 0, 0],
+                                [0, 1, 0])
 
     def test_star_star(self):
-        self.assert_depth_match(
-            ['A', STARS_TAG, STARS_TAG, 'D'],
-            [0, 1, 0, 0])
+        self.assert_depth_match(['A', STARS_TAG, STARS_TAG, 'D'],
+                                [0, 1, 0, 0])
 
-        self.assert_depth_match(
-            ['A', INLINE_STARS, STARS_TAG, 'D'],
-            [0, 1, 2, 2],
-            [0, 1, 0, 0])
+        self.assert_depth_match(['A', INLINE_STARS, STARS_TAG, 'D'],
+                                [0, 1, 2, 2],
+                                [0, 1, 0, 0])
 
     def test_depth_type_order(self):
         extra = rules.depth_type_order([markers.ints, markers.lower])


### PR DESCRIPTION
Extends #49 (see [diff](https://github.com/cmc333333/regulations-parser/compare/derive-depth-updates...cmc333333:markerless)) by extending the depth-parser to understand paragraphs without a marker.

There aren't many additional rules, as the rules around such paragraphs are lax:

1. Multiple MARKERLESS paragraphs in sequence must be at the same depth
2. Markers cannot be used to "skip" a paragraph depth level (see code comment for example)

Also included:
* Code to reduce computation over MARKERLESS paragraphs (we can compress multiple due to rule 1 above)
* Refactoring some of the depth parsing tests