### PR TITLE
Refactor regtext processor to be more generic

### DIFF
--- a/regparser/tree/depth/derive.py
+++ b/regparser/tree/depth/derive.py
@@ -80,6 +80,10 @@ def derive_depths(marker_list, additional_constraints=[]):
             problem.addConstraint(rules.depth_check, pairs)
             problem.addConstraint(rules.stars_check, pairs)
 
+        if idx > 1:
+            pairs = all_vars[3*(idx-2):]
+            problem.addConstraint(rules.markerless_sandwich, pairs)
+
     # separate loop so that the simpler checks run first
     for idx in range(1, len(marker_list)):
         # start with the current idx

--- a/regparser/tree/depth/heuristics.py
+++ b/regparser/tree/depth/heuristics.py
@@ -20,24 +20,6 @@ def prefer_multiple_children(solutions, weight=1.0):
     return result
 
 
-def prefer_same_types_same_levels(solutions, weight=1.0):
-    """Dock solutions which have the same type of marker appearing at multiple
-    depths. This _does_ occur, but it's not often."""
-    result = []
-    for solution in solutions:
-        type_depths = defaultdict(set)
-        for par in solution.assignment:
-            type_depths[par.typ].add(par.depth)
-
-        flags, total = 0, 0
-        for depths in type_depths.values():
-            total += len(depths)
-            flags += len(depths) - 1
-
-        result.append(solution.copy_with_penalty(weight * flags / total))
-    return result
-
-
 def prefer_diff_types_diff_levels(solutions, weight=1.0):
     """Dock solutions which have different markers appearing at the same
     level. This also occurs, but not often."""

--- a/regparser/tree/depth/heuristics.py
+++ b/regparser/tree/depth/heuristics.py
@@ -1,8 +1,7 @@
 """Set of heuristics for trimming down the set of solutions. Each heuristic
 works by penalizing a solution; it's then up to the caller to grab the
 solution with the least penalties."""
-
-
+from collections import defaultdict
 from itertools import takewhile
 
 
@@ -18,4 +17,40 @@ def prefer_multiple_children(solutions, weight=1.0):
             if len(filter(lambda d: d == depth + 1, children)) == 1:
                 flags += 1
         result.append(solution.copy_with_penalty(weight * flags / len(depths)))
+    return result
+
+
+def prefer_same_types_same_levels(solutions, weight=1.0):
+    """Dock solutions which have the same type of marker appearing at multiple
+    depths. This _does_ occur, but it's not often."""
+    result = []
+    for solution in solutions:
+        type_depths = defaultdict(set)
+        for par in solution.assignment:
+            type_depths[par.typ].add(par.depth)
+
+        flags, total = 0, 0
+        for depths in type_depths.values():
+            total += len(depths)
+            flags += len(depths) - 1
+
+        result.append(solution.copy_with_penalty(weight * flags / total))
+    return result
+
+
+def prefer_diff_types_diff_levels(solutions, weight=1.0):
+    """Dock solutions which have different markers appearing at the same
+    level. This also occurs, but not often."""
+    result = []
+    for solution in solutions:
+        depth_types = defaultdict(set)
+        for par in solution.assignment:
+            depth_types[par.depth].add(par.typ)
+
+        flags, total = 0, 0
+        for types in depth_types.values():
+            total += len(types)
+            flags += len(types) - 1
+
+        result.append(solution.copy_with_penalty(weight * flags / total))
     return result

--- a/regparser/tree/depth/markers.py
+++ b/regparser/tree/depth/markers.py
@@ -21,5 +21,6 @@ stars = (STARS_TAG, INLINE_STARS)
 
 # Account for paragraphs without a marker at all
 MARKERLESS = 'MARKERLESS'
+markerless = (MARKERLESS,)
 
-types = [lower, upper, ints, roman, em_ints, em_roman, stars]
+types = [lower, upper, ints, roman, em_ints, em_roman, stars, markerless]

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -32,6 +32,9 @@ class ParagraphProcessor(object):
         while nodes and nodes[-1].label[0] in mtypes.stars:
             nodes = nodes[:-1]
 
+        for node in nodes:
+            node.node_type = self.NODE_TYPE
+
         return nodes
 
     def select_depth(self, depths):
@@ -91,7 +94,7 @@ class ParagraphProcessor(object):
             root.tagged_text += " " + intro_node.tagged_text
         if nodes:
             markers = [node.label[0] for node in nodes]
-            depths = derive_depths(markers, self.additional_constraints())
+            depths = derive_depths(markers)
             if not depths:
                 logging.error(
                     "Could not determine paragraph depths:\n%s", markers)
@@ -99,9 +102,6 @@ class ParagraphProcessor(object):
             return self.build_hierarchy(root, nodes, depths)
         else:
             return root
-
-    def additional_constraints(self):
-        return []
 
 
 class StarsMatcher(object):
@@ -111,3 +111,17 @@ class StarsMatcher(object):
 
     def derive_nodes(self, xml):
         return [Node(label=[mtypes.STARS_TAG])]
+
+
+class SimpleTagMatcher(object):
+    """Simple example tag matcher -- it listens for a specific tag and derives
+    a single node with the associated body"""
+    def __init__(self, tag):
+        self.tag = tag
+
+    def matches(self, xml):
+        return xml.tag == self.tag
+
+    def derive_nodes(self, xml):
+        return [Node(text=tree_utils.get_node_text(xml).strip(),
+                     label=[mtypes.MARKERLESS])]

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -1,0 +1,114 @@
+import logging
+
+from regparser.tree.depth import heuristics, markers as mtypes
+from regparser.tree.depth.derive import derive_depths
+from regparser.tree.struct import Node
+from regparser.tree.xml_parser import tree_utils
+
+
+class ParagraphProcessor(object):
+    """Processing paragraphs in a generic manner requires a lot of state to be
+    carried in between xml nodes. Use a class to wrap that state so we can
+    compartmentalize processing with various tags. This is an abstract class;
+    regtext, interpretations, appendices, etc. should inherit and override
+    where needed"""
+
+    # Subclasses should override the following interface
+    NODE_TYPE = None
+    MATCHERS = []
+
+    def parse_nodes(self, xml):
+        """Derive a flat list of nodes from this xml chunk. This does nothing
+        to determine node depth"""
+        nodes = []
+
+        for child in xml.getchildren():
+            matching = (m for m in self.MATCHERS if m.matches(child))
+            tag_matcher = next(matching, None)
+            if tag_matcher:
+                nodes.extend(tag_matcher.derive_nodes(child))
+
+        # Trailing stars don't matter; slightly more efficient to ignore them
+        while nodes and nodes[-1].label[0] in mtypes.stars:
+            nodes = nodes[:-1]
+
+        return nodes
+
+    def select_depth(self, depths):
+        """There might be multiple solutions to our depth processing problem.
+        Use heuristics to select one."""
+        depths = heuristics.prefer_same_types_same_levels(depths, 0.8)
+        depths = heuristics.prefer_diff_types_diff_levels(depths, 0.8)
+        depths = heuristics.prefer_multiple_children(depths, 0.4)
+        depths = sorted(depths, key=lambda d: d.weight, reverse=True)
+        return depths[0]
+
+    def build_hierarchy(self, root, nodes, depths):
+        """Given a root node, a flat list of child nodes, and a list of
+        depths, build a node hierarchy around the root"""
+        cnt = 0   # number of nodes we've seen without a marker
+        stack = tree_utils.NodeStack()
+        stack.add(0, root)
+        for node, par in zip(nodes, depths):
+            if par.typ != mtypes.stars:
+                # Note that nodes still only have the one label part
+                label, cnt = self.clean_label(node.label[0], cnt)
+                node.label = [label]
+                stack.add(1 + par.depth, node)
+
+        return stack.collapse()
+
+    def clean_label(self, label, unlabeled_counter):
+        """There are some artifacts from parsing and deriving the depth that
+        we remove here"""
+        if label == mtypes.MARKERLESS:
+            unlabeled_counter += 1
+            label = 'p{0}'.format(unlabeled_counter)
+
+        label = label.replace('<E T="03">', '').replace('</E>', '')
+        return label, unlabeled_counter
+
+    def separate_intro(self, nodes):
+        """In many situations the first unlabeled paragraph is the "intro"
+        text for a section. We separate that out here"""
+        labels = [n.label[0] for n in nodes]    # label is only one part long
+
+        only_one = labels == [mtypes.MARKERLESS]
+        switches_after_first = (
+            len(nodes) > 1
+            and labels[0] == mtypes.MARKERLESS
+            and labels[1] != mtypes.MARKERLESS)
+
+        if only_one or switches_after_first:
+            return nodes[0], nodes[1:]
+        else:
+            return None, nodes
+
+    def process(self, xml, root):
+        nodes = self.parse_nodes(xml)
+        intro_node, nodes = self.separate_intro(nodes)
+        if intro_node:
+            root.text += " " + intro_node.text
+            root.tagged_text += " " + intro_node.tagged_text
+        if nodes:
+            markers = [node.label[0] for node in nodes]
+            depths = derive_depths(markers, self.additional_constraints())
+            if not depths:
+                logging.error(
+                    "Could not determine paragraph depths:\n%s", markers)
+            depths = self.select_depth(depths)
+            return self.build_hierarchy(root, nodes, depths)
+        else:
+            return root
+
+    def additional_constraints(self):
+        return []
+
+
+class StarsMatcher(object):
+    """<STARS> indicates a chunk of text which is being skipped over"""
+    def matches(self, xml):
+        return xml.tag == 'STARS'
+
+    def derive_nodes(self, xml):
+        return [Node(label=[mtypes.STARS_TAG])]

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -37,7 +37,6 @@ class ParagraphProcessor(object):
     def select_depth(self, depths):
         """There might be multiple solutions to our depth processing problem.
         Use heuristics to select one."""
-        depths = heuristics.prefer_same_types_same_levels(depths, 0.8)
         depths = heuristics.prefer_diff_types_diff_levels(depths, 0.8)
         depths = heuristics.prefer_multiple_children(depths, 0.4)
         depths = sorted(depths, key=lambda d: d.weight, reverse=True)

--- a/tests/tree_depth_derive_tests.py
+++ b/tests/tree_depth_derive_tests.py
@@ -6,127 +6,119 @@ from regparser.tree.depth.markers import STARS_TAG, INLINE_STARS
 
 
 class DeriveTests(TestCase):
+    def assert_depth_match(self, markers, *depths_set):
+        """Verify that the set of markers resolves to the provided set of
+        depths (in any order)"""
+        solutions = derive_depths(markers)
+        results = [[a.depth for a in s] for s in solutions]
+        self.assertEqual(len(depths_set), len(results))
+        self.assertItemsEqual(results, depths_set)
+
     def test_ints(self):
-        results = derive_depths(['1', '2', '3', '4'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 0, 0, 0], [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['1', '2', '3', '4'],
+            [0, 0, 0, 0])
 
     def test_alpha_ints(self):
-        results = derive_depths(['A', '1', '2', '3'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 1, 1, 1], [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['A', '1', '2', '3'],
+            [0, 1, 1, 1])
 
     def test_alpha_ints_jump_back(self):
-        results = derive_depths(['A', '1', '2', '3', 'B', '1', '2', '3', 'C'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 1, 1, 1, 0, 1, 1, 1, 0],
-                         [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['A', '1', '2', '3', 'B', '1', '2', '3', 'C'],
+            [0, 1, 1, 1, 0, 1, 1, 1, 0])
 
     def test_roman_alpha(self):
-        results = derive_depths(['a', '1', '2', 'b', '1', '2', '3', '4', 'i',
-                                 'ii', 'iii', '5', 'c', 'd', '1', '2', 'e'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 1, 1, 0, 1, 1, 1, 1, 2, 2, 2, 1, 0, 0, 1, 1, 0],
-                         [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['a', '1', '2', 'b', '1', '2', '3', '4', 'i', 'ii', 'iii', '5',
+             'c', 'd', '1', '2', 'e'],
+            [0, 1, 1, 0, 1, 1, 1, 1, 2, 2, 2, 1, 0, 0, 1, 1, 0])
 
     def test_mix_levels_roman_alpha(self):
-        results = derive_depths(['A', '1', '2', 'i', 'ii', 'iii', 'iv', 'B',
-                                 '1', 'a', 'b', '2', 'a', 'b', 'i', 'ii',
-                                 'iii', 'c'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 1, 1, 2, 2, 2, 2, 0, 1, 2, 2, 1, 2, 2, 3, 3, 3,
-                          2], [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['A', '1', '2', 'i', 'ii', 'iii', 'iv', 'B', '1', 'a', 'b', '2',
+             'a', 'b', 'i', 'ii', 'iii', 'c'],
+            [0, 1, 1, 2, 2, 2, 2, 0, 1, 2, 2, 1, 2, 2, 3, 3, 3, 2])
 
     def test_i_ambiguity(self):
-        results = derive_depths(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
-        self.assertEqual(2, len(results))
-        results = [[r.depth for r in result] for result in results]
-        self.assertTrue([0, 0, 0, 0, 0, 0, 0, 0, 0] in results)
-        self.assertTrue([0, 0, 0, 0, 0, 0, 0, 0, 1] in results)
+        self.assert_depth_match(
+            ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 1])
 
-        results = derive_depths(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
-                                 'j'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                         [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
-        results = derive_depths(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
-                                 'ii'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 0, 0, 0, 0, 0, 0, 0, 1, 1],
-                         [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'ii'],
+            [0, 0, 0, 0, 0, 0, 0, 0, 1, 1])
 
     def test_repeat_alpha(self):
-        results = derive_depths(['A', '1', 'a', 'i', 'ii', 'a', 'b', 'c', 'b'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 1, 2, 3, 3, 4, 4, 4, 2],
-                         [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['A', '1', 'a', 'i', 'ii', 'a', 'b', 'c', 'b'],
+            [0, 1, 2, 3, 3, 4, 4, 4, 2])
 
     def test_simple_stars(self):
-        results = derive_depths(['A', '1', STARS_TAG, 'd'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 1, 2, 2], [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['A', '1', STARS_TAG, 'd'],
+            [0, 1, 2, 2])
 
-        results = derive_depths(['A', '1', 'a', STARS_TAG, 'd'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 1, 2, 2, 2], [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['A', '1', 'a', STARS_TAG, 'd'],
+            [0, 1, 2, 2, 2])
 
     def test_ambiguous_stars(self):
-        results = derive_depths(['A', '1', 'a', STARS_TAG, 'B'])
-        self.assertEqual(4, len(results))
-        results = [[r.depth for r in result] for result in results]
-        self.assertTrue([0, 1, 2, 3, 3] in results)
-        self.assertTrue([0, 1, 2, 3, 0] in results)
-        self.assertTrue([0, 1, 2, 2, 0] in results)
-        self.assertTrue([0, 1, 2, 1, 0] in results)
+        self.assert_depth_match(
+            ['A', '1', 'a', STARS_TAG, 'B'],
+            [0, 1, 2, 3, 3],
+            [0, 1, 2, 3, 0],
+            [0, 1, 2, 2, 0],
+            [0, 1, 2, 1, 0])
 
     def test_double_stars(self):
-        results = derive_depths(['A', '1', 'a', STARS_TAG, STARS_TAG, 'B'])
-        self.assertEqual(3, len(results))
-        results = [[r.depth for r in result] for result in results]
-        self.assertTrue([0, 1, 2, 2, 1, 0] in results)
-        self.assertTrue([0, 1, 2, 3, 2, 0] in results)
-        self.assertTrue([0, 1, 2, 3, 1, 0] in results)
+        self.assert_depth_match(
+            ['A', '1', 'a', STARS_TAG, STARS_TAG, 'B'],
+            [0, 1, 2, 2, 1, 0],
+            [0, 1, 2, 3, 2, 0],
+            [0, 1, 2, 3, 1, 0])
 
     def test_alpha_roman_ambiguous(self):
-        results = derive_depths(['i', 'ii', STARS_TAG, 'v', STARS_TAG, 'vii'])
-        self.assertEqual(3, len(results))
-        results = [[r.depth for r in result] for result in results]
-        self.assertTrue([0, 0, 1, 1, 2, 2] in results)
-        self.assertTrue([0, 0, 1, 1, 0, 0] in results)
-        self.assertTrue([0, 0, 0, 0, 0, 0] in results)
+        self.assert_depth_match(
+            ['i', 'ii', STARS_TAG, 'v', STARS_TAG, 'vii'],
+            [0, 0, 1, 1, 2, 2],
+            [0, 0, 1, 1, 0, 0],
+            [0, 0, 0, 0, 0, 0])
 
     def test_start_star(self):
-        results = derive_depths([STARS_TAG, 'c', '1', STARS_TAG, 'ii', 'iii',
-                                 '2', 'i', 'ii', STARS_TAG, 'v', STARS_TAG,
-                                 'vii', 'A'])
-        self.assertEqual(4, len(results))
-        results = [[r.depth for r in result] for result in results]
-        self.assertTrue([0, 0, 1, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 3] in results)
-        self.assertTrue([0, 0, 1, 2, 2, 2, 1, 2, 2, 3, 3, 2, 2, 3] in results)
-        self.assertTrue([0, 0, 1, 2, 2, 2, 1, 2, 2, 3, 3, 4, 4, 5] in results)
-        self.assertTrue([0, 0, 1, 2, 2, 2, 1, 2, 2, 0, 0, 1, 1, 2] in results)
+        self.assert_depth_match(
+            [STARS_TAG, 'c', '1', STARS_TAG, 'ii', 'iii', '2', 'i', 'ii',
+             STARS_TAG, 'v', STARS_TAG, 'vii', 'A'],
+            [0, 0, 1, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 3],
+            [0, 0, 1, 2, 2, 2, 1, 2, 2, 3, 3, 2, 2, 3],
+            [0, 0, 1, 2, 2, 2, 1, 2, 2, 3, 3, 4, 4, 5],
+            [0, 0, 1, 2, 2, 2, 1, 2, 2, 0, 0, 1, 1, 2])
 
     def test_inline_star(self):
-        results = derive_depths(['1', STARS_TAG, '2'])
-        self.assertEqual(1, len(results))
-        self.assertEqual([0, 1, 0], [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['1', STARS_TAG, '2'],
+            [0, 1, 0])
 
-        results = derive_depths(['1', INLINE_STARS, '2'])
-        self.assertEqual(2, len(results))
-        results = [[r.depth for r in result] for result in results]
-        self.assertTrue([0, 0, 0] in results)
-        self.assertTrue([0, 1, 0] in results)
+        self.assert_depth_match(
+            ['1', INLINE_STARS, '2'],
+            [0, 0, 0],
+            [0, 1, 0])
 
     def test_star_star(self):
-        results = derive_depths(['A', STARS_TAG, STARS_TAG, 'D'])
-        self.assertEqual(1, len(results))
-        self.assertTrue([0, 1, 0, 0], [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['A', STARS_TAG, STARS_TAG, 'D'],
+            [0, 1, 0, 0])
 
-        results = derive_depths(['A', INLINE_STARS, STARS_TAG, 'D'])
-        self.assertEqual(2, len(results))
-        self.assertTrue([0, 1, 2, 2], [r.depth for r in results[0]])
-        self.assertTrue([0, 1, 0, 0], [r.depth for r in results[0]])
+        self.assert_depth_match(
+            ['A', INLINE_STARS, STARS_TAG, 'D'],
+            [0, 1, 2, 2],
+            [0, 1, 0, 0])
 
     def test_depth_type_order(self):
         extra = rules.depth_type_order([markers.ints, markers.lower])

--- a/tests/tree_depth_derive_tests.py
+++ b/tests/tree_depth_derive_tests.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from regparser.tree.depth import markers, rules
 from regparser.tree.depth.derive import derive_depths
-from regparser.tree.depth.markers import STARS_TAG, INLINE_STARS
+from regparser.tree.depth.markers import INLINE_STARS, MARKERLESS, STARS_TAG
 
 
 class DeriveTests(TestCase):
@@ -11,7 +11,6 @@ class DeriveTests(TestCase):
         depths (in any order)"""
         solutions = derive_depths(markers)
         results = [[a.depth for a in s] for s in solutions]
-        self.assertEqual(len(depths_set), len(results))
         self.assertItemsEqual(results, depths_set)
 
     def test_ints(self):
@@ -106,6 +105,19 @@ class DeriveTests(TestCase):
         self.assert_depth_match(['A', INLINE_STARS, STARS_TAG, 'D'],
                                 [0, 1, 2, 2],
                                 [0, 1, 0, 0])
+
+    def test_markerless_outermost(self):
+        """A pattern often seen in definitions sections"""
+        self.assert_depth_match(
+            [MARKERLESS, MARKERLESS, 'a', 'b', MARKERLESS, 'a', 'b'],
+            [0, 0, 1, 1, 0, 1, 1])
+
+    def test_markerless_repeated(self):
+        """Repeated markerless paragraphs must be on the same level"""
+        self.assert_depth_match(
+            [MARKERLESS, 'a', MARKERLESS, MARKERLESS],
+            [0, 1, 0, 0],
+            [0, 1, 2, 2])
 
     def test_depth_type_order(self):
         extra = rules.depth_type_order([markers.ints, markers.lower])

--- a/tests/tree_depth_derive_tests.py
+++ b/tests/tree_depth_derive_tests.py
@@ -15,19 +15,16 @@ class DeriveTests(TestCase):
         self.assertItemsEqual(results, depths_set)
 
     def test_ints(self):
-        self.assert_depth_match(
-            ['1', '2', '3', '4'],
-            [0, 0, 0, 0])
+        self.assert_depth_match(['1', '2', '3', '4'],
+                                [0, 0, 0, 0])
 
     def test_alpha_ints(self):
-        self.assert_depth_match(
-            ['A', '1', '2', '3'],
-            [0, 1, 1, 1])
+        self.assert_depth_match(['A', '1', '2', '3'],
+                                [0, 1, 1, 1])
 
     def test_alpha_ints_jump_back(self):
-        self.assert_depth_match(
-            ['A', '1', '2', '3', 'B', '1', '2', '3', 'C'],
-            [0, 1, 1, 1, 0, 1, 1, 1, 0])
+        self.assert_depth_match(['A', '1', '2', '3', 'B', '1', '2', '3', 'C'],
+                                [0, 1, 1, 1, 0, 1, 1, 1, 0])
 
     def test_roman_alpha(self):
         self.assert_depth_match(
@@ -42,10 +39,9 @@ class DeriveTests(TestCase):
             [0, 1, 1, 2, 2, 2, 2, 0, 1, 2, 2, 1, 2, 2, 3, 3, 3, 2])
 
     def test_i_ambiguity(self):
-        self.assert_depth_match(
-            ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'],
-            [0, 0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0, 1])
+        self.assert_depth_match(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                [0, 0, 0, 0, 0, 0, 0, 0, 1])
 
         self.assert_depth_match(
             ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
@@ -61,35 +57,30 @@ class DeriveTests(TestCase):
             [0, 1, 2, 3, 3, 4, 4, 4, 2])
 
     def test_simple_stars(self):
-        self.assert_depth_match(
-            ['A', '1', STARS_TAG, 'd'],
-            [0, 1, 2, 2])
+        self.assert_depth_match(['A', '1', STARS_TAG, 'd'],
+                                [0, 1, 2, 2])
 
-        self.assert_depth_match(
-            ['A', '1', 'a', STARS_TAG, 'd'],
-            [0, 1, 2, 2, 2])
+        self.assert_depth_match(['A', '1', 'a', STARS_TAG, 'd'],
+                                [0, 1, 2, 2, 2])
 
     def test_ambiguous_stars(self):
-        self.assert_depth_match(
-            ['A', '1', 'a', STARS_TAG, 'B'],
-            [0, 1, 2, 3, 3],
-            [0, 1, 2, 3, 0],
-            [0, 1, 2, 2, 0],
-            [0, 1, 2, 1, 0])
+        self.assert_depth_match(['A', '1', 'a', STARS_TAG, 'B'],
+                                [0, 1, 2, 3, 3],
+                                [0, 1, 2, 3, 0],
+                                [0, 1, 2, 2, 0],
+                                [0, 1, 2, 1, 0])
 
     def test_double_stars(self):
-        self.assert_depth_match(
-            ['A', '1', 'a', STARS_TAG, STARS_TAG, 'B'],
-            [0, 1, 2, 2, 1, 0],
-            [0, 1, 2, 3, 2, 0],
-            [0, 1, 2, 3, 1, 0])
+        self.assert_depth_match(['A', '1', 'a', STARS_TAG, STARS_TAG, 'B'],
+                                [0, 1, 2, 2, 1, 0],
+                                [0, 1, 2, 3, 2, 0],
+                                [0, 1, 2, 3, 1, 0])
 
     def test_alpha_roman_ambiguous(self):
-        self.assert_depth_match(
-            ['i', 'ii', STARS_TAG, 'v', STARS_TAG, 'vii'],
-            [0, 0, 1, 1, 2, 2],
-            [0, 0, 1, 1, 0, 0],
-            [0, 0, 0, 0, 0, 0])
+        self.assert_depth_match(['i', 'ii', STARS_TAG, 'v', STARS_TAG, 'vii'],
+                                [0, 0, 1, 1, 2, 2],
+                                [0, 0, 1, 1, 0, 0],
+                                [0, 0, 0, 0, 0, 0])
 
     def test_start_star(self):
         self.assert_depth_match(
@@ -101,24 +92,20 @@ class DeriveTests(TestCase):
             [0, 0, 1, 2, 2, 2, 1, 2, 2, 0, 0, 1, 1, 2])
 
     def test_inline_star(self):
-        self.assert_depth_match(
-            ['1', STARS_TAG, '2'],
-            [0, 1, 0])
+        self.assert_depth_match(['1', STARS_TAG, '2'],
+                                [0, 1, 0])
 
-        self.assert_depth_match(
-            ['1', INLINE_STARS, '2'],
-            [0, 0, 0],
-            [0, 1, 0])
+        self.assert_depth_match(['1', INLINE_STARS, '2'],
+                                [0, 0, 0],
+                                [0, 1, 0])
 
     def test_star_star(self):
-        self.assert_depth_match(
-            ['A', STARS_TAG, STARS_TAG, 'D'],
-            [0, 1, 0, 0])
+        self.assert_depth_match(['A', STARS_TAG, STARS_TAG, 'D'],
+                                [0, 1, 0, 0])
 
-        self.assert_depth_match(
-            ['A', INLINE_STARS, STARS_TAG, 'D'],
-            [0, 1, 2, 2],
-            [0, 1, 0, 0])
+        self.assert_depth_match(['A', INLINE_STARS, STARS_TAG, 'D'],
+                                [0, 1, 2, 2],
+                                [0, 1, 0, 0])
 
     def test_depth_type_order(self):
         extra = rules.depth_type_order([markers.ints, markers.lower])

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -236,8 +236,7 @@ class RegTextTest(TestCase):
         <SECTION>
             <SECTNO>§ 8675.309a</SECTNO>
             <SUBJECT>Definitions.</SUBJECT>
-            <P><E T="03">Transfers </E>—(1) <E T="03">Notice.</E> follow
-            </P>
+            <P>Intro content here</P>
         </SECTION>
         """
         node = reg_text.build_from_section('8675', etree.fromstring(xml))[0]


### PR DESCRIPTION
This builds on #51 ([diff](https://github.com/cmc333333/regulations-parser/compare/markerless...cmc333333:markerless-regtext)) to use the updated depth processing for regtext. Effectively, this allows regtext to contain paragraphs without markers.

It does this by

1. Creating a `ParagraphProcessor` class, similar to the `AppendixProcessor`, but with more plugability regarding xml node types. This processor can handle paragraphs without markers
2. Removing the existing regtext parsing in favor of a subclass of `ParagraphProcessor`
3. Adding some additional heuristics around the relationship between paragraph types and depths

~~This needs some additional tests and perhaps a bit of cleanup before it can be merged~~