### PR TITLE
Allow regtext to contain tables

### DIFF
--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -1,5 +1,6 @@
 import logging
 
+from regparser.layer.formatting import table_xml_to_plaintext
 from regparser.tree.depth import heuristics, markers as mtypes
 from regparser.tree.depth.derive import derive_depths
 from regparser.tree.struct import Node
@@ -125,3 +126,13 @@ class SimpleTagMatcher(object):
     def derive_nodes(self, xml):
         return [Node(text=tree_utils.get_node_text(xml).strip(),
                      label=[mtypes.MARKERLESS])]
+
+
+class TableMatcher(object):
+    """Matches the GPOTABLE tag"""
+    def matches(self, xml):
+        return xml.tag == 'GPOTABLE'
+
+    def derive_nodes(self, xml):
+        return [Node(table_xml_to_plaintext(xml), label=[mtypes.MARKERLESS],
+                     source_xml=xml)]

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -253,5 +253,6 @@ class NoMarkerMatcher(object):
 class RegtextParagraphProcessor(paragraph_processor.ParagraphProcessor):
     NODE_TYPE = Node.REGTEXT
     MATCHERS = [paragraph_processor.StarsMatcher(),
+                paragraph_processor.TableMatcher(),
                 MarkerMatcher(),
                 NoMarkerMatcher()]

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -6,13 +6,10 @@ from mock import patch
 
 from regparser.tree.depth import markers as mtypes
 from regparser.tree.xml_parser import reg_text
-from tests.xml_builder import LXMLBuilder
+from tests.xml_builder import XMLBuilderMixin
 
 
-class RegTextTest(TestCase):
-    def setUp(self):
-        self.tree = LXMLBuilder()
-
+class RegTextTest(XMLBuilderMixin, TestCase):
     def test_build_from_section_intro_text(self):
         with self.tree.builder("SECTION") as root:
             root.SECTNO(u"§ 8675.309")

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -218,6 +218,29 @@ class RegTextTest(TestCase):
         self.assertEqual(node.label, ['8675', '309a'])
         self.assertEqual(0, len(node.children))
 
+    def test_build_from_section_table(self):
+        """Account for regtext with a table"""
+        with self.tree.builder("SECTION") as root:
+            root.SECTNO(u"§ 8675.309")
+            root.SUBJECT("Definitions.")
+            root.P("(a) aaaa")
+            with root.GPOTABLE(CDEF="s25,10", COLS=2, OPTS="L2,i1") as table:
+                with table.BOXHD() as hd:
+                    hd.CHED(H=1)
+                    hd.CHED("Header", H=1)
+                with table.ROW() as row:
+                    row.ENT("Left content", I="01")
+                    row.ENT("Right content")
+        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+
+        a = node.children[0]
+        self.assertEqual(1, len(a.children))
+        table = a.children[0]
+        self.assertEqual(['8675', '309', 'a', 'p1'], table.label)
+        self.assertEqual("||Header|\n|---|---|\n|Left content|Right content|",
+                         table.text)
+        self.assertEqual("GPOTABLE", table.source_xml.tag)
+
     def test_get_title(self):
         with self.tree.builder("PART") as root:
             root.HD("regulation title")

--- a/tests/xml_builder.py
+++ b/tests/xml_builder.py
@@ -30,9 +30,16 @@ class LXMLRenderer(Renderer):
     """Outputs lxml tree nodes. Based on the etree renderer"""
     friendly_names = ['lxml']
 
-    def render_verbatim(self, tag, xml_str):
+    def render_verbatim(self, node):
         """It's sometimes easier to describe the node with raw XML"""
-        return etree.fromstring(u'<{0}>{1}</{0}>'.format(tag, xml_str))
+        element = etree.fromstring(u'<{0}>{1}</{0}>'.format(
+            node.__node_name__, node.__attrs__['_xml']))
+
+        for key, value in node.__attrs__.iteritems():
+            if key != '_xml':
+                element.attrib[key] = str(value)
+
+        return element
 
     def render_attributes(self, node):
         """Normal path: attributes are described via __attrs__"""
@@ -47,8 +54,7 @@ class LXMLRenderer(Renderer):
         """Generate the current node, potentially adding it to a parent, then
         recurse on children"""
         if '_xml' in node.__attrs__:
-            element = self.render_verbatim(node.__node_name__,
-                                           node.__attrs__['_xml'])
+            element = self.render_verbatim(node)
         else:
             element = self.render_attributes(node)
 
@@ -63,3 +69,10 @@ class LXMLRenderer(Renderer):
     def render_final(self, rendered, options={}):
         """Part of the Renderer interface"""
         return rendered
+
+
+class XMLBuilderMixin(object):
+    """Mix in to tests to provide access to a builder via self.tree"""
+    def setUp(self):
+        super(XMLBuilderMixin, self).setUp()
+        self.tree = LXMLBuilder()


### PR DESCRIPTION
Builds on #54 ([diff](https://github.com/cmc333333/regulations-parser/compare/cmc333333:xml-dsl...cmc333333:regtext-table)).

We've been able to process tables as defined in the CFR XML, but only in the appendix. This extends the now-pluggable paragraph parser to account for the tables in regulation text as well.