### PR TITLE
Allow markerless paragraphs to use the FP tag

### DIFF
--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -237,10 +237,10 @@ class MarkerMatcher(object):
 
 
 class NoMarkerMatcher(object):
-    """<P> which has no initial paragraph markers"""
+    """<P> or <FP> which has no initial paragraph markers"""
     def matches(self, xml):
         tagged_text = tree_utils.get_node_text_tags_preserved(xml).strip()
-        return xml.tag == 'P' and not bool(get_markers(tagged_text))
+        return xml.tag in ('P', 'FP') and not bool(get_markers(tagged_text))
 
     def derive_nodes(self, xml):
         text = tree_utils.get_node_text(xml, add_spaces=True).strip()

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -237,7 +237,8 @@ class MarkerMatcher(object):
 
 
 class NoMarkerMatcher(object):
-    """<P> or <FP> which has no initial paragraph markers"""
+    """<P> or <FP> which has no initial paragraph markers. FP is a "flush
+    paragraph", a display-oriented distinction which we will ignore"""
     def matches(self, xml):
         tagged_text = tree_utils.get_node_text_tags_preserved(xml).strip()
         return xml.tag in ('P', 'FP') and not bool(get_markers(tagged_text))

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -218,6 +218,29 @@ class RegTextTest(TestCase):
         self.assertEqual(node.label, ['8675', '309a'])
         self.assertEqual(0, len(node.children))
 
+    def test_build_from_section_fp(self):
+        with self.tree.builder("SECTION") as root:
+            root.SECTNO(u"§ 8675.309")
+            root.SUBJECT("Definitions.")
+            root.P("(a) aaa")
+            root.P("(b) bbb")
+            root.FP("fpfpfp")
+            root.P("(c) ccc")
+        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+        self.assertEqual(3, len(node.children))
+        a, b, c = node.children
+
+        self.assertEqual(['8675', '309', 'a'], a.label)
+        self.assertEqual([], a.children)
+        self.assertEqual(['8675', '309', 'b'], b.label)
+        self.assertEqual(1, len(b.children))
+        self.assertEqual(['8675', '309', 'c'], c.label)
+        self.assertEqual([], c.children)
+
+        fp = b.children[0]
+        self.assertEqual(['8675', '309', 'b', 'p1'], fp.label)
+        self.assertEqual([], fp.children)
+
     def test_get_title(self):
         with self.tree.builder("PART") as root:
             root.HD("regulation title")


### PR DESCRIPTION
Builds on #54 ([diff](https://github.com/cmc333333/regulations-parser/compare/cmc333333:xml-dsl...cmc333333:fp-markerless)) and resolves one of the issues in #56