### PR TITLE
Allow explicit labels in AMDPARs

### DIFF
--- a/regparser/grammar/amdpar.py
+++ b/regparser/grammar/amdpar.py
@@ -4,7 +4,7 @@ import logging
 import string
 
 from pyparsing import CaselessLiteral, FollowedBy, OneOrMore, Optional
-from pyparsing import Suppress, Word, LineEnd
+from pyparsing import Suppress, Word, LineEnd, ZeroOrMore
 
 from regparser.grammar import atomic, tokens, unified
 from regparser.grammar.utils import Marker, WordBoundaries
@@ -400,6 +400,36 @@ multiple_paragraphs = (
         m.plaintext_p6]))
 
 
+
+def tokenize_override_ps(match):
+    """ Create token.Paragraphs for the given override match """
+    # Part, Section or Appendix, p1, p2, p3, p4, p5, p6
+    match_list = list(match)
+    par_list = [match.part, None, None, None, None, None, None, None]
+
+    if match.section:
+        par_list[1] = match.section
+    elif match.appendix:
+        par_list[1] = "Appendix:" + match.appendix
+
+    # Set paragraph depths
+    for p in match_list[2:]:
+        par_list[match_list.index(p)] = p
+
+    par = tokens.Paragraph(par_list)
+    return [par]
+
+override_label = (
+    Suppress("[")
+    + Marker("label") + Suppress(":")
+    + atomic.part
+    + Suppress("-")
+    + (atomic.section | atomic.appendix)
+    + ZeroOrMore(Suppress("-") + Word(string.ascii_lowercase + string.digits))
+    + Suppress("]")
+    ).setParseAction(tokenize_override_ps)
+    
+
 #   grammar which captures all of these possibilities
 token_patterns = (
     put_active | put_passive | post_active | post_passive
@@ -430,6 +460,9 @@ token_patterns = (
     | section
     #   Must come after intro_text_of
     | intro_text
+
+    # Finally allow for an explicit override label
+    | override_label
 
     | paragraph_context
     | and_token

--- a/tests/grammar_amdpar_tests.py
+++ b/tests/grammar_amdpar_tests.py
@@ -490,6 +490,15 @@ class GrammarAmdParTests(TestCase):
             tokens.Context([None, 'Subpart:C'], certain=True)
         ])
 
+    def test_example36(self):
+        text = u'In Appendix A to Part 1002 revise [label:1002-A-p1-2-d] to read:'
+        result = parse_text(text)
+        self.assertEqual(result, [
+            tokens.Context(['1002', 'Appendix:A'], certain=True),
+            tokens.Verb(tokens.Verb.PUT, active=True, and_prefix=False),
+            tokens.Paragraph([ '1002', 'Appendix:A', 'p1', '2', 'd' ], field = None )
+        ])
+
     def test_paragraph_of(self):
         text = u"12. Paragraph (c)(1)(iv) of § 4.9 is revised"
         result = parse_text(text)

--- a/tests/grammar_amdpar_tests.py
+++ b/tests/grammar_amdpar_tests.py
@@ -491,13 +491,22 @@ class GrammarAmdParTests(TestCase):
         ])
 
     def test_example36(self):
-        text = u'In Appendix A to Part 1002 revise [label:1002-A-p1-2-d] to read:'
+        text = u'In Appendix A to Part 1002 revise [label:1002-A-p1-2-d]:'
         result = parse_text(text)
         self.assertEqual(result, [
             tokens.Context(['1002', 'Appendix:A'], certain=True),
             tokens.Verb(tokens.Verb.PUT, active=True, and_prefix=False),
-            tokens.Paragraph([ '1002', 'Appendix:A', 'p1', '2', 'd' ], field = None )
+            tokens.Paragraph(['1002', 'Appendix:A', 'p1', '2', 'd'],
+                             field=None)
         ])
+
+    def test_explicit_regtext(self):
+        """Verify that the explicit label syntax works for regtext, too"""
+        result = parse_text("Revise [label:479-11-a-3-p1]")
+        self.assertEqual(2, len(result))
+        verb, label = result
+        self.assertTrue(label.match(
+            tokens.Paragraph, ['479', None, '11', 'a', '3', 'p1']))
 
     def test_paragraph_of(self):
         text = u"12. Paragraph (c)(1)(iv) of § 4.9 is revised"


### PR DESCRIPTION
Pulls in a changeset from @willbarton (originally merged at https://github.com/cfpb/regulations-parser/pull/284) which allows AMDPARs to spell out exactly which paragraph they are referencing