### PR TITLE
Pull in CFPB #282, #283, #284, #286

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,11 @@ All of the settings listed in ```settings.py``` can be overridden in a
   'state' is a defined term, it may be useful to exclude the phrase 'shall
   state'. Terms associated with the constant, `ALL`, will be ignored in all
   CFR parts parsed.
+* ```INCLUDE_DEFINITIONS_IN``` - a dictionary mapping CFR part numbers to a
+  list of terms that *absolutely do* contain definitions. For example,
+  a term that isn't necessary succeeded by subparagraphs that define it
+  rather than phraseology like "is defined as". Terms associated with the 
+  constant, `ALL`, will be included in all CFR parts parsed.
 * ```OVERRIDES_SOURCES``` - a list of python modules (represented via
   string) which should be consulted when determining image urls. Useful if
   the Federal Register versions aren't pretty. Defaults to a `regcontent`

--- a/README.md
+++ b/README.md
@@ -196,10 +196,10 @@ All of the settings listed in ```settings.py``` can be overridden in a
   CFR parts parsed.
 * ```INCLUDE_DEFINITIONS_IN``` - a dictionary mapping CFR part numbers to a
   list of tuples containing (term, context) for terms that *are
-  definitely definitions*. For example, a term that isn't necessary 
-  succeeded by subparagraphs that define it rather than phraseology 
-  like "is defined as". Terms associated with the constant, `ALL`, will 
-  be included in all CFR parts parsed.
+  definitely definitions*. For example, a term that is succeeded by 
+  subparagraphs that define it rather than phraseology like "is defined as". 
+  Terms associated with the constant, `ALL`, will  be included in all CFR 
+  parts parsed.
 * ```OVERRIDES_SOURCES``` - a list of python modules (represented via
   string) which should be consulted when determining image urls. Useful if
   the Federal Register versions aren't pretty. Defaults to a `regcontent`

--- a/README.md
+++ b/README.md
@@ -195,10 +195,11 @@ All of the settings listed in ```settings.py``` can be overridden in a
   state'. Terms associated with the constant, `ALL`, will be ignored in all
   CFR parts parsed.
 * ```INCLUDE_DEFINITIONS_IN``` - a dictionary mapping CFR part numbers to a
-  list of terms that *absolutely do* contain definitions. For example,
-  a term that isn't necessary succeeded by subparagraphs that define it
-  rather than phraseology like "is defined as". Terms associated with the 
-  constant, `ALL`, will be included in all CFR parts parsed.
+  list of tuples containing (term, context) for terms that *are
+  definitely definitions*. For example, a term that isn't necessary 
+  succeeded by subparagraphs that define it rather than phraseology 
+  like "is defined as". Terms associated with the constant, `ALL`, will 
+  be included in all CFR parts parsed.
 * ```OVERRIDES_SOURCES``` - a list of python modules (represented via
   string) which should be consulted when determining image urls. Useful if
   the Federal Register versions aren't pretty. Defaults to a `regcontent`

--- a/regparser/grammar/amdpar.py
+++ b/regparser/grammar/amdpar.py
@@ -4,7 +4,7 @@ import logging
 import string
 
 from pyparsing import CaselessLiteral, FollowedBy, OneOrMore, Optional
-from pyparsing import Suppress, Word, LineEnd
+from pyparsing import Suppress, Word, LineEnd, ZeroOrMore
 
 from regparser.grammar import atomic, tokens, unified
 from regparser.grammar.utils import Marker, WordBoundaries
@@ -400,6 +400,36 @@ multiple_paragraphs = (
         m.plaintext_p6]))
 
 
+
+def tokenize_override_ps(match):
+    """ Create token.Paragraphs for the given override match """
+    # Part, Section or Appendix, p1, p2, p3, p4, p5, p6
+    match_list = list(match)
+    par_list = [match.part, None, None, None, None, None, None, None]
+
+    if match.section:
+        par_list[1] = match.section
+    elif match.appendix:
+        par_list[1] = "Appendix:" + match.appendix
+
+    # Set paragraph depths
+    for p in match_list[2:]:
+        par_list[match_list.index(p)] = p
+
+    par = tokens.Paragraph(par_list)
+    return [par]
+
+override_label = (
+    Suppress("[")
+    + Marker("label") + Suppress(":")
+    + atomic.part
+    + Suppress("-")
+    + (atomic.section | atomic.appendix)
+    + ZeroOrMore(Suppress("-") + Word(string.ascii_lowercase + string.digits))
+    + Suppress("]")
+    ).setParseAction(tokenize_override_ps)
+    
+
 #   grammar which captures all of these possibilities
 token_patterns = (
     put_active | put_passive | post_active | post_passive
@@ -430,6 +460,9 @@ token_patterns = (
     | section
     #   Must come after intro_text_of
     | intro_text
+
+    # Finally allow for an explicit override label
+    | override_label
 
     | paragraph_context
     | and_token

--- a/regparser/grammar/amdpar.py
+++ b/regparser/grammar/amdpar.py
@@ -400,7 +400,6 @@ multiple_paragraphs = (
         m.plaintext_p6]))
 
 
-
 def tokenize_override_ps(match):
     """ Create token.Paragraphs for the given override match """
     # Part, Section or Appendix, p1, p2, p3, p4, p5, p6
@@ -418,6 +417,7 @@ def tokenize_override_ps(match):
 
     par = tokens.Paragraph(par_list)
     return [par]
+
 
 override_label = (
     Suppress("[")

--- a/regparser/grammar/atomic.py
+++ b/regparser/grammar/atomic.py
@@ -2,14 +2,14 @@
 """Atomic components; probably shouldn't use these directly"""
 import string
 
-from pyparsing import CaselessLiteral, Optional, Regex, Suppress, Word
+from pyparsing import CaselessLiteral, Optional, Regex, Suppress, Word, OneOrMore
 
 from regparser.grammar.utils import Marker, SuffixMarker, WordBoundaries
 
 
 lower_p = (
     Suppress("(")
-    + Word(string.ascii_lowercase, max=1).setResultsName("p1")
+    + Word(string.ascii_lowercase, max=2).setResultsName("p1")
     + Suppress(")"))
 digit_p = (
     Suppress("(")

--- a/regparser/grammar/atomic.py
+++ b/regparser/grammar/atomic.py
@@ -2,7 +2,7 @@
 """Atomic components; probably shouldn't use these directly"""
 import string
 
-from pyparsing import CaselessLiteral, Optional, Regex, Suppress, Word, OneOrMore
+from pyparsing import CaselessLiteral, Optional, Regex, Suppress, Word
 
 from regparser.grammar.utils import Marker, SuffixMarker, WordBoundaries
 

--- a/regparser/grammar/atomic.py
+++ b/regparser/grammar/atomic.py
@@ -9,7 +9,7 @@ from regparser.grammar.utils import Marker, SuffixMarker, WordBoundaries
 
 lower_p = (
     Suppress("(")
-    + Word(string.ascii_lowercase, max=2).setResultsName("p1")
+    + Regex(r"[ivx]{1}|[a-hj-uwyz]{1,2}").setResultsName("p1")
     + Suppress(")"))
 digit_p = (
     Suppress("(")

--- a/regparser/grammar/terms.py
+++ b/regparser/grammar/terms.py
@@ -29,6 +29,7 @@ xml_term_parser = (
     + ZeroOrMore(
         (atomic.conj_phrases + e_tag).setResultsName(
             "tail", listAllMatches=True))
+    + Suppress(ZeroOrMore(Regex(r",[a-zA-Z ]+,")))
     + ((Marker("mean") | Marker("means"))
        | (Marker("refers") + ZeroOrMore(Marker("only")) + Marker("to"))
        | ((Marker("has") | Marker("have")) + Marker("the") + Marker("same")

--- a/regparser/grammar/terms.py
+++ b/regparser/grammar/terms.py
@@ -26,7 +26,6 @@ xml_term_parser = (
     LineStart()
     + Optional(Suppress(unified.any_depth_p))
     + e_tag.setResultsName("head")
-    + Suppress(ZeroOrMore(unified.any_depth_p))
     + ZeroOrMore(
         (atomic.conj_phrases + e_tag).setResultsName(
             "tail", listAllMatches=True))

--- a/regparser/grammar/terms.py
+++ b/regparser/grammar/terms.py
@@ -26,10 +26,13 @@ xml_term_parser = (
     LineStart()
     + Optional(Suppress(unified.any_depth_p))
     + e_tag.setResultsName("head")
+    + Suppress(ZeroOrMore(unified.any_depth_p))
     + ZeroOrMore(
         (atomic.conj_phrases + e_tag).setResultsName(
             "tail", listAllMatches=True))
     + Suppress(ZeroOrMore(Regex(r",[a-zA-Z ]+,")))
+    + Suppress(ZeroOrMore(
+        (Marker("this") | Marker("the")) + Marker("term")))
     + ((Marker("mean") | Marker("means"))
        | (Marker("refers") + ZeroOrMore(Marker("only")) + Marker("to"))
        | ((Marker("has") | Marker("have")) + Marker("the") + Marker("same")

--- a/regparser/grammar/terms.py
+++ b/regparser/grammar/terms.py
@@ -30,6 +30,7 @@ xml_term_parser = (
         (atomic.conj_phrases + e_tag).setResultsName(
             "tail", listAllMatches=True))
     + ((Marker("mean") | Marker("means"))
+       | (Marker("refers") + ZeroOrMore(Marker("only")) + Marker("to"))
        | ((Marker("has") | Marker("have")) + Marker("the") + Marker("same")
           + Marker("meaning") + Marker("as")))
 )

--- a/regparser/grammar/unified.py
+++ b/regparser/grammar/unified.py
@@ -196,7 +196,7 @@ multiple_cfr_p = (
 notice_cfr_p = (
     Suppress(atomic.title)
     + Suppress("CFR")
-    + Suppress(atomic.part_marker | atomic.parts_marker)
+    + Optional(Suppress(atomic.part_marker | atomic.parts_marker))
     + OneOrMore(
         atomic.part
         + Optional(Suppress(','))

--- a/regparser/grammar/unified.py
+++ b/regparser/grammar/unified.py
@@ -33,6 +33,7 @@ section_comment = atomic.section + depth1_c
 section_paragraph = atomic.section + depth1_p
 
 mps_paragraph = marker_part_section + Optional(depth1_p)
+ps_paragraph = part_section + Optional(depth1_p)
 part_section_paragraph = (
     atomic.part + Suppress(".") + atomic.section + depth1_p)
 
@@ -104,7 +105,7 @@ marker_subpart_title = (
 marker_comment = (
     atomic.comment_marker.copy().setParseAction(keep_pos).setResultsName(
         "marker")
-    + (section_comment | section_paragraph | mps_paragraph)
+    + (section_comment | section_paragraph | ps_paragraph | mps_paragraph)
     + Optional(depth1_c)
 )
 

--- a/regparser/grammar/unified.py
+++ b/regparser/grammar/unified.py
@@ -192,3 +192,14 @@ multiple_cfr_p = (
            + atomic.section
            + Optional(depth1_p)).setParseAction(keep_pos).setResultsName(
                "tail", listAllMatches=True)))
+
+notice_cfr_p = (
+    Suppress(atomic.title)
+    + Suppress("CFR")
+    + Suppress(atomic.part_marker | atomic.parts_marker)
+    + OneOrMore(
+        atomic.part
+        + Optional(Suppress(','))
+        + Optional(Suppress('and'))
+    )
+)

--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from itertools import chain
 import re
 
-import inflection 
+import inflection
 try:
     del inflection.PLURALS[inflection.PLURALS.index(('(?i)(p)erson$', '\\1eople'))]
 except ValueError:
@@ -202,17 +202,12 @@ class Terms(Layer):
         return False
 
     def node_definitions(self, node, stack=None):
-        """Find defined terms in this node's text. 'Act' is a special case,
-        as it is also defined as an external citation."""
+        """Find defined terms in this node's text."""
         included_defs = []
         excluded_defs = []
 
         def add_match(n, term, pos):
-            if ((term == 'act' and list(uscode.scanString(n.text)))
-                    or self.is_exclusion(term, n)):
-                excluded_defs.append(Ref(term, n.label_id(), pos))
-            else:
-                included_defs.append(Ref(term, n.label_id(), pos))
+            included_defs.append(Ref(term, n.label_id(), pos))
 
         try:
             cfr_part = node.label[0]
@@ -223,7 +218,7 @@ class Terms(Layer):
             for included_term, context in settings.INCLUDE_DEFINITIONS_IN[cfr_part]:
                 if context in node.text and included_term in node.text:
                     pos_start = node.text.index(included_term)
-                    add_match(node, included_term.lower(), 
+                    add_match(node, included_term.lower(),
                             (pos_start, pos_start + len(included_term)))
 
         if stack and self.has_parent_definitions_indicator(stack):

--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -207,7 +207,10 @@ class Terms(Layer):
         excluded_defs = []
 
         def add_match(n, term, pos):
-            included_defs.append(Ref(term, n.label_id(), pos))
+            if (self.is_exclusion(term, n)):
+                excluded_defs.append(Ref(term, n.label_id(), pos))
+            else:
+                included_defs.append(Ref(term, n.label_id(), pos))
 
         try:
             cfr_part = node.label[0]

--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -215,8 +215,8 @@ class Terms(Layer):
             cfr_part = None
 
         if settings.INCLUDE_DEFINITIONS_IN.get(cfr_part):
-            for included_term in settings.INCLUDE_DEFINITIONS_IN[cfr_part]:
-                if included_term in node.text:
+            for included_term, context in settings.INCLUDE_DEFINITIONS_IN[cfr_part]:
+                if context in node.text and included_term in node.text:
                     pos_start = node.text.index(included_term)
                     add_match(node, included_term.lower(), 
                             (pos_start, pos_start + len(included_term)))
@@ -333,7 +333,7 @@ class Terms(Layer):
     def per_regulation_includes(self, inclusions, label, text):
         cfr_part = label[0]
         if settings.INCLUDE_DEFINITIONS_IN.get(cfr_part):
-            for include_term in settings.INCLUDE_DEFINITIONS_IN[cfr_part]:
+            for included_term, context in settings.INCLUDE_DEFINITIONS_IN['ALL']:
                 inclusions.extend(
                     (match.start(), match.end()) for match in
                     re.finditer(r'\b' + re.escape(include_term) + r'\b', text))
@@ -344,7 +344,7 @@ class Terms(Layer):
             words that the parser doesn't necessarily pick up as being
             defined) that should be part of a defined term """
         inclusions = []
-        for include_term in settings.INCLUDE_DEFINITIONS_IN['ALL']:
+        for included_term, context in settings.INCLUDE_DEFINITIONS_IN['ALL']:
             inclusions.extend(
                 (match.start(), match.end()) for match in
                 re.finditer(r'\b' + re.escape(include_term) + r'\b', text))

--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -3,7 +3,12 @@ from collections import defaultdict
 from itertools import chain
 import re
 
-from inflection import pluralize
+import inflection 
+try:
+    del inflection.PLURALS[inflection.PLURALS.index(('(?i)(p)erson$', '\\1eople'))]
+except ValueError:
+    pass
+
 
 from regparser.citations import internal_citations, Label
 from regparser.grammar import terms as grammar
@@ -360,7 +365,7 @@ class Terms(Layer):
         inclusions = list(inclusions)
 
         # add plurals to applicable terms
-        pluralized = [(pluralize(t[0]), t[1]) for t in applicable_terms]
+        pluralized = [(inflection.pluralize(t[0]), t[1]) for t in applicable_terms]
         applicable_terms += pluralized
 
         #   longer terms first

--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -209,6 +209,14 @@ class Terms(Layer):
             else:
                 included_defs.append(Ref(term, n.label_id(), pos))
 
+        cfr_part = node.label[0]
+        if settings.INCLUDE_DEFINITIONS_IN.get(cfr_part):
+            for included_term in settings.INCLUDE_DEFINITIONS_IN[cfr_part]:
+                if included_term in node.text:
+                    pos_start = node.text.index(included_term)
+                    add_match(node, included_term.lower(), 
+                            (pos_start, pos_start + len(included_term)))
+
         if stack and self.has_parent_definitions_indicator(stack):
             for match, _, _ in grammar.smart_quotes.scanString(node.text):
                 term = match.term.tokens[0].lower().strip(',.;')
@@ -283,6 +291,10 @@ class Terms(Layer):
         exclusions = self.per_regulation_ignores(
             exclusions, node.label, node.text)
 
+        inclusions = self.included_offsets(node.label_id(), node.text)
+        inclusions = self.per_regulation_includes(
+                inclusions, node.label, node.text)
+
         matches = self.calculate_offsets(node.text, term_list, exclusions)
         for term, ref, offsets in matches:
             layer_el.append({
@@ -314,12 +326,34 @@ class Terms(Layer):
                 re.finditer(r'\b' + re.escape(ignore_term) + r'\b', text))
         return exclusions
 
-    def calculate_offsets(self, text, applicable_terms, exclusions=[]):
+    def per_regulation_includes(self, inclusions, label, text):
+        cfr_part = label[0]
+        if settings.INCLUDE_DEFINITIONS_IN.get(cfr_part):
+            for include_term in settings.INCLUDE_DEFINITIONS_IN[cfr_part]:
+                inclusions.extend(
+                    (match.start(), match.end()) for match in
+                    re.finditer(r'\b' + re.escape(include_term) + r'\b', text))
+        return inclusions
+
+    def included_offsets(self, label, text):
+        """ We explicitly include certain chunks of text (for example,
+            words that the parser doesn't necessarily pick up as being
+            defined) that should be part of a defined term """
+        inclusions = []
+        for include_term in settings.INCLUDE_DEFINITIONS_IN['ALL']:
+            inclusions.extend(
+                (match.start(), match.end()) for match in
+                re.finditer(r'\b' + re.escape(include_term) + r'\b', text))
+        return inclusions
+
+    def calculate_offsets(self, text, applicable_terms, exclusions=[],
+            inclusions=[]):
         """Search for defined terms in this text, with a preference for all
         larger (i.e. containing) terms."""
 
         # don't modify the original
         exclusions = list(exclusions)
+        inclusions = list(inclusions)
 
         # add plurals to applicable terms
         pluralized = [(pluralize(t[0]), t[1]) for t in applicable_terms]

--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -209,7 +209,11 @@ class Terms(Layer):
             else:
                 included_defs.append(Ref(term, n.label_id(), pos))
 
-        cfr_part = node.label[0]
+        try:
+            cfr_part = node.label[0]
+        except IndexError:
+            cfr_part = None
+
         if settings.INCLUDE_DEFINITIONS_IN.get(cfr_part):
             for included_term in settings.INCLUDE_DEFINITIONS_IN[cfr_part]:
                 if included_term in node.text:

--- a/regparser/notice/build.py
+++ b/regparser/notice/build.py
@@ -59,7 +59,7 @@ def build_notice(cfr_title, cfr_part, fr_notice, do_process_xml=True):
 
         if len(local_notices) > 0:
             logging.warning("using local xml for %s", fr_notice['full_text_xml_url'])
-            return process_local_notices(local_notices, notice, cfr_part)
+            return process_local_notices(local_notices, notice)
         else:
             logging.warning("fetching notice %s", fr_notice['full_text_xml_url'])
             notice_str = requests.get(fr_notice['full_text_xml_url']).content
@@ -74,7 +74,7 @@ def split_doc_num(doc_num, effective_date):
     return '%s_%s' % (doc_num, effective_date)
 
 
-def process_local_notices(local_notices, partial_notice, cfr_part):
+def process_local_notices(local_notices, partial_notice):
     """ If we have any local notices, process them. Note that this takes into
     account split notices (a single notice split into two because of different
     effective dates"""

--- a/regparser/notice/build.py
+++ b/regparser/notice/build.py
@@ -59,11 +59,9 @@ def build_notice(cfr_title, cfr_part, fr_notice, do_process_xml=True):
             fr_notice['full_text_xml_url'])
 
         if len(local_notices) > 0:
-            print "using local notices for %s" % local_notices
             logging.info("using local notices for %s", local_notices)
             return process_local_notices(local_notices, notice, cfr_part)
         else:
-            print "fetching notice %s" % fr_notice['full_text_xml_url']
             logging.info("fetching notice %s", fr_notice['full_text_xml_url'])
             notice_str = requests.get(fr_notice['full_text_xml_url']).content
             return [process_notice(notice, notice_str)]
@@ -359,7 +357,6 @@ def fetch_cfr_parts(notice_xml):
         may not be included in each date. """
     cfr_elm = notice_xml.xpath('//CFR')[0]
     results = notice_cfr_p.parseString(cfr_elm.text)
-    print "notice applies to", list(results)
     return list(results)
 
 def process_xml(notice, notice_xml):

--- a/regparser/notice/build.py
+++ b/regparser/notice/build.py
@@ -93,7 +93,6 @@ def process_local_notices(local_notices, partial_notice, cfr_part):
     for local_notice_file in local_notices:
         with open(local_notice_file, 'r') as f:
             notice = process_notice(partial_notice, f.read())
-            import pdb; pdb.set_trace()
             notices.append(notice)
 
     notices = set_document_numbers(notices)

--- a/regparser/notice/build.py
+++ b/regparser/notice/build.py
@@ -3,6 +3,8 @@ from collections import defaultdict
 import os
 from urlparse import urlparse
 
+import logging 
+
 from lxml import etree
 import requests
 
@@ -19,6 +21,8 @@ from regparser.notice.util import spaces_then_remove, swap_emphasis_tags
 from regparser.notice import changes
 from regparser.tree import struct
 from regparser.tree.xml_parser import reg_text
+from regparser.grammar.unified import notice_cfr_p
+
 import settings
 
 
@@ -49,13 +53,18 @@ def build_notice(cfr_title, cfr_part, fr_notice, do_process_xml=True):
     for key in ('dates', 'end_page', 'start_page', 'type'):
         notice['meta'][key] = fr_notice[key]
 
+    logging.info("need to fetch notice %s?", fr_notice['full_text_xml_url'])
     if fr_notice['full_text_xml_url'] and do_process_xml:
         local_notices = _check_local_version_list(
             fr_notice['full_text_xml_url'])
 
         if len(local_notices) > 0:
-            return process_local_notices(local_notices, notice)
+            print "using local notices for %s" % local_notices
+            logging.info("using local notices for %s", local_notices)
+            return process_local_notices(local_notices, notice, cfr_part)
         else:
+            print "fetching notice %s" % fr_notice['full_text_xml_url']
+            logging.info("fetching notice %s", fr_notice['full_text_xml_url'])
             notice_str = requests.get(fr_notice['full_text_xml_url']).content
             return [process_notice(notice, notice_str)]
     return [notice]
@@ -68,7 +77,7 @@ def split_doc_num(doc_num, effective_date):
     return '%s_%s' % (doc_num, effective_date)
 
 
-def process_local_notices(local_notices, partial_notice):
+def process_local_notices(local_notices, partial_notice, cfr_part):
     """ If we have any local notices, process them. Note that this takes into
     account split notices (a single notice split into two because of different
     effective dates"""
@@ -76,12 +85,15 @@ def process_local_notices(local_notices, partial_notice):
     notices = []
 
     if len(local_notices) > 1:
-        #If the notice is split, pick up the effective date from the XML
+        # If the notice is split, pick up the effective date and the
+        # CFR parts from the XML
         partial_notice['effective_on'] = None
+        partial_notice['cfr_parts'] = None
 
     for local_notice_file in local_notices:
         with open(local_notice_file, 'r') as f:
             notice = process_notice(partial_notice, f.read())
+            import pdb; pdb.set_trace()
             notices.append(notice)
 
     notices = set_document_numbers(notices)
@@ -341,6 +353,16 @@ def process_sxs(notice, notice_xml):
     notice['section_by_section'] = sxs
 
 
+def fetch_cfr_parts(notice_xml):
+    """ Sometimes we need to read the CFR part numbers from the notice
+        XML itself. This would need to happen when we've broken up a
+        multiple-effective-date notice that has multiple CFR parts that
+        may not be included in each date. """
+    cfr_elm = notice_xml.xpath('//CFR')[0]
+    results = notice_cfr_p.parseString(cfr_elm.text)
+    print "notice applies to", list(results)
+    return list(results)
+
 def process_xml(notice, notice_xml):
     """Pull out relevant fields from the xml and add them to the notice"""
 
@@ -356,6 +378,10 @@ def process_xml(notice, notice_xml):
         dates = fetch_dates(notice_xml)
         if dates and 'effective' in dates:
             notice['effective_on'] = dates['effective'][0]
+
+    if not notice.get('cfr_parts'):
+        cfr_parts = fetch_cfr_parts(notice_xml)
+        notice['cfr_parts'] = cfr_parts
 
     process_sxs(notice, notice_xml)
     process_amendments(notice, notice_xml)

--- a/regparser/notice/build.py
+++ b/regparser/notice/build.py
@@ -53,16 +53,15 @@ def build_notice(cfr_title, cfr_part, fr_notice, do_process_xml=True):
     for key in ('dates', 'end_page', 'start_page', 'type'):
         notice['meta'][key] = fr_notice[key]
 
-    logging.info("need to fetch notice %s?", fr_notice['full_text_xml_url'])
     if fr_notice['full_text_xml_url'] and do_process_xml:
         local_notices = _check_local_version_list(
             fr_notice['full_text_xml_url'])
 
         if len(local_notices) > 0:
-            logging.info("using local notices for %s", local_notices)
+            logging.warning("using local xml for %s", fr_notice['full_text_xml_url'])
             return process_local_notices(local_notices, notice, cfr_part)
         else:
-            logging.info("fetching notice %s", fr_notice['full_text_xml_url'])
+            logging.warning("fetching notice %s", fr_notice['full_text_xml_url'])
             notice_str = requests.get(fr_notice['full_text_xml_url']).content
             return [process_notice(notice, notice_str)]
     return [notice]

--- a/regparser/tree/depth/markers.py
+++ b/regparser/tree/depth/markers.py
@@ -6,8 +6,10 @@ import string
 from regparser.utils import roman_nums
 
 
-lower = tuple(string.ascii_lowercase)
-upper = tuple(string.ascii_uppercase)
+lower = tuple(string.ascii_lowercase) + \
+        tuple(a+a for a in string.ascii_lowercase)
+upper = tuple(string.ascii_uppercase) + \
+        tuple(a+a for a in string.ascii_uppercase)
 ints = tuple(str(i) for i in range(1, 51))
 roman = tuple(itertools.islice(roman_nums(), 0, 50))
 em_ints = tuple('<E T="03">' + i + '</E>' for i in ints)

--- a/settings.py
+++ b/settings.py
@@ -64,6 +64,9 @@ DEFAULT_IMAGE_URL = (
 # list of strings: phrases which shouldn't be broken by definition links
 IGNORE_DEFINITIONS_IN = {'ALL':[]}
 
+# List of strings: phrases which should be included as definition links
+INCLUDE_DEFINITIONS_IN = {'ALL':[]}
+
 # list of modules implementing the __contains__ and __getitem__ methods
 OVERRIDES_SOURCES = [
     'regcontent.overrides'

--- a/tests/grammar_amdpar_tests.py
+++ b/tests/grammar_amdpar_tests.py
@@ -500,3 +500,12 @@ class GrammarAmdParTests(TestCase):
             tokens.Paragraph, label=['4', None, '9', 'c', '1', 'iv']))
         self.assertTrue(verb.match(
             tokens.Verb, verb=tokens.Verb.PUT))
+
+    def test_example36(self):
+        text = u'In Appendix A to Part 1002 revise [label:1002-A-p1-2-d] to read:'
+        result = parse_text(text)
+        self.assertEqual(result, [
+            tokens.Context(['1002', 'Appendix:A'], certain=True),
+            tokens.Verb(tokens.Verb.PUT, active=True, and_prefix=False),
+            tokens.Paragraph([ '1002', 'Appendix:A', 'p1', '2', 'd' ], field = None )
+        ])

--- a/tests/grammar_atomic_tests.py
+++ b/tests/grammar_atomic_tests.py
@@ -17,12 +17,6 @@ class GrammarAtomicTests(TestCase):
             self.assertEqual(p1, result.p1)
 
         for text in ['(ii)', '(iv)', '(vi)']:
-            try:
-                result = lower_p.parseString(text)
-            except ParseException:
-                pass
-            except e:
-                self.fail("Unexpected error:", e)
-            else:
-                self.fail("Didn't raise ParseException")
+            with self.assertRaises(ParseException):
+                lower_p.parseString(text)
 

--- a/tests/grammar_atomic_tests.py
+++ b/tests/grammar_atomic_tests.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+from pyparsing import ParseException
 from regparser.grammar.atomic import *
 
 
@@ -7,3 +8,21 @@ class GrammarAtomicTests(TestCase):
     def test_em_digit_p(self):
         result = em_digit_p.parseString('(<E T="03">2</E>)')
         self.assertEqual('2', result.p5)
+
+    def test_double_alpha(self):
+        # Match (aa), (bb), etc.
+        result = lower_p.parseString('(a)')
+        self.assertEqual('a', result.p1)
+
+        result = lower_p.parseString('(aa)')
+        self.assertEqual('aa', result.p1)
+
+        result = lower_p.parseString('(i)')
+        self.assertEqual('i', result.p1)
+
+        # Except for roman numerals
+        with self.assertRaises(ParseException):
+            result = lower_p.parseString('(ii)')
+        with self.assertRaises(ParseException):
+            result = lower_p.parseString('(iv)')
+

--- a/tests/grammar_atomic_tests.py
+++ b/tests/grammar_atomic_tests.py
@@ -10,19 +10,19 @@ class GrammarAtomicTests(TestCase):
         self.assertEqual('2', result.p5)
 
     def test_double_alpha(self):
-        # Match (aa), (bb), etc.
-        result = lower_p.parseString('(a)')
-        self.assertEqual('a', result.p1)
+        for text, p1 in [('(a)', 'a'),
+                     ('(aa)', 'aa'),
+                     ('(i)','i')]:
+            result = lower_p.parseString(text)
+            self.assertEqual(p1, result.p1)
 
-        result = lower_p.parseString('(aa)')
-        self.assertEqual('aa', result.p1)
-
-        result = lower_p.parseString('(i)')
-        self.assertEqual('i', result.p1)
-
-        # Except for roman numerals
-        with self.assertRaises(ParseException):
-            result = lower_p.parseString('(ii)')
-        with self.assertRaises(ParseException):
-            result = lower_p.parseString('(iv)')
+        for text in ['(ii)', '(iv)', '(vi)']:
+            try:
+                result = lower_p.parseString(text)
+            except ParseException:
+                pass
+            except e:
+                self.fail("Unexpected error:", e)
+            else:
+                self.fail("Didn't raise ParseException")
 

--- a/tests/grammar_interpretation_headers_tests.py
+++ b/tests/grammar_interpretation_headers_tests.py
@@ -16,8 +16,6 @@ class GrammarInterpretationHeadersTest(TestCase):
         self.assertEqual('11', match.section)
 
     def test_newline(self):
-        for m,s,e in parser.scanString("\nSection 100.22"):
-            print m, s, e
         starts = [start for _,start,_ in 
             parser.scanString("\nSection 100.22")]
         self.assertEqual(1, starts[0])

--- a/tests/grammar_terms_tests.py
+++ b/tests/grammar_terms_tests.py
@@ -28,3 +28,14 @@ class GrammarTermsTests(TestCase):
         result = [match for match, _, _ in xml_term_parser.scanString(text)]
         self.assertEqual(len(result), 0)
 
+    def test_comma_clauses(self):
+        text = u'(v) <E T="03">Negative factor or value</E>, in relation to the age of elderly applicants, means utilizing a factor, value, or weight'
+        result = [match for match, _, _ in xml_term_parser.scanString(text)]
+        match = result[0]
+        print match
+        self.assertEqual(len(result), 1)
+        self.assertEqual(match.term[0], 'Negative')
+        self.assertEqual(match.term[1], 'factor')
+        self.assertEqual(match.term[2], 'or')
+        self.assertEqual(match.term[3], 'value')
+

--- a/tests/grammar_terms_tests.py
+++ b/tests/grammar_terms_tests.py
@@ -32,7 +32,6 @@ class GrammarTermsTests(TestCase):
         text = u'(v) <E T="03">Negative factor or value</E>, in relation to the age of elderly applicants, means utilizing a factor, value, or weight'
         result = [match for match, _, _ in xml_term_parser.scanString(text)]
         match = result[0]
-        print match
         self.assertEqual(len(result), 1)
         self.assertEqual(match.term[0], 'Negative')
         self.assertEqual(match.term[1], 'factor')

--- a/tests/grammar_unified_tests.py
+++ b/tests/grammar_unified_tests.py
@@ -47,3 +47,17 @@ class GrammarCommonTests(TestCase):
         text = '12 CFR Parts 1024'
         result = notice_cfr_p.parseString(text)
         self.assertEqual(['1024'], list(result))
+        text = '12 CFR 1024'
+        result = notice_cfr_p.parseString(text)
+        self.assertEqual(['1024'], list(result))
+
+    def test_marker_comment(self):
+        texts = [u'comment § 1004.3-4-i',
+                 u'comment § 1004.3-4.i',
+                 u'comment 1004.3-4-i',
+                 u'comment 1004.3-4.i',
+                 u'comment 3-4-i',]
+        for t in texts:
+            result = marker_comment.parseString(t)
+            self.assertEqual("3", result.section)
+            self.assertEqual("4", result.c1)

--- a/tests/grammar_unified_tests.py
+++ b/tests/grammar_unified_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from unittest import TestCase
 
 from regparser.grammar.unified import *
@@ -14,7 +15,6 @@ class GrammarCommonTests(TestCase):
         self.assertEqual('A', result.p4)
         self.assertEqual('2', result.p5)
 
-
     def test_marker_subpart_title(self):
         # Typical case:
         text = u'Subpart K\u2014Exportation'
@@ -28,3 +28,11 @@ class GrammarCommonTests(TestCase):
         self.assertEqual(u'[Reserved]', result.subpart_title)
         self.assertEqual(u'J', result.subpart)
 
+    def test_marker_comment(self):
+        texts = [u'comment § 1004.3-4-i',
+                 u'comment 1004.3-4-i',
+                 u'comment 3-4-i',]
+        for t in texts:
+            result = marker_comment.parseString(t)
+            self.assertEqual("3", result.section)
+            self.assertEqual("4", result.c1)

--- a/tests/grammar_unified_tests.py
+++ b/tests/grammar_unified_tests.py
@@ -36,3 +36,14 @@ class GrammarCommonTests(TestCase):
             result = marker_comment.parseString(t)
             self.assertEqual("3", result.section)
             self.assertEqual("4", result.c1)
+
+    def test_notice_cfr_p(self):
+        text = '12 CFR Parts 1002, 1024, and 1026'
+        result = notice_cfr_p.parseString(text)
+        self.assertEqual(['1002', '1024', '1026'], list(result))
+        text = '12 CFR Parts 1024, and 1026'
+        result = notice_cfr_p.parseString(text)
+        self.assertEqual(['1024', '1026'], list(result))
+        text = '12 CFR Parts 1024'
+        result = notice_cfr_p.parseString(text)
+        self.assertEqual(['1024'], list(result))

--- a/tests/layer_formatting_tests.py
+++ b/tests/layer_formatting_tests.py
@@ -125,7 +125,6 @@ class LayerFormattingTests(TestCase):
         result = formatting.Formatting(None).process(node)
         self.assertEqual(1, len(result))
         result = result[0]
-        print result
 
         self.assertEqual(result['text'], "This is an fp-dash_____")
         self.assertEqual(result['locations'], [0])

--- a/tests/layer_terms_tests.py
+++ b/tests/layer_terms_tests.py
@@ -193,10 +193,6 @@ class LayerTermTest(TestCase):
         t = Terms(None)
         stack = ParentStack()
         stack.add(0, Node('Definitions', label=['9999']))
-        node = Node(u'“Act” means some reference to 99 U.S.C. 1234')
-        included, excluded = t.node_definitions(node, stack)
-        self.assertEqual([], included)
-        self.assertEqual(1, len(excluded))
 
         node = Node(u'“Act” means something else entirely')
         included, excluded = t.node_definitions(node, stack)

--- a/tests/layer_terms_tests.py
+++ b/tests/layer_terms_tests.py
@@ -102,24 +102,31 @@ class LayerTermTest(TestCase):
             u'the next one does']
 
         xml_defs = [
-            (u'(4) Thing means a thing that is defined',
-             u'(4) <E T="03">Thing</E> means a thing that is defined',
-             Ref('thing', 'eee', (4, 9))),
-            (u'(e) Well-meaning lawyers means people who do weird things',
-             u'(e) <E T="03">Well-meaning lawyers</E> means people who do '
-             + 'weird things',
-             Ref('well-meaning lawyers', 'fff', (4, 24))),
-            (u'(e) Words have the same meaning as in a dictionary',
-             u'(e) <E T="03">Words</E> have the same meaning as in a '
-             + 'dictionary',
-             Ref('words', 'ffg', (4, 9))),
-            (u'(e) Banana has the same meaning as bonono',
-             u'(e) <E T="03">Banana</E> has the same meaning as bonono',
-             Ref('banana', 'fgf', (4, 10))),
-            (u'(f) Huge billowy clouds means I want to take a nap',
-             u'(f) <E T="03">Huge billowy clouds</E> means I want to take a '
-             + 'nap',
-             Ref('huge billowy clouds', 'ggg', (4, 23)))]
+                (u'(4) Thing means a thing that is defined',
+                    u'(4) <E T="03">Thing</E> means a thing that is defined',
+                    Ref('thing', 'eee', (4, 9))),
+                (u'(e) Well-meaning lawyers means people who do weird things',
+                    u'(e) <E T="03">Well-meaning lawyers</E> means people who do '
+                    + 'weird things',
+                    Ref('well-meaning lawyers', 'fff', (4, 24))),
+                (u'(e) Words have the same meaning as in a dictionary',
+                    u'(e) <E T="03">Words</E> have the same meaning as in a '
+                    + 'dictionary',
+                    Ref('words', 'ffg', (4, 9))),
+                (u'(e) Banana has the same meaning as bonono',
+                    u'(e) <E T="03">Banana</E> has the same meaning as bonono',
+                    Ref('banana', 'fgf', (4, 10))),
+                (u'(f) Huge billowy clouds means I want to take a nap',
+                    u'(f) <E T="03">Huge billowy clouds</E> means I want to take a '
+                    + 'nap',
+                    Ref('huge billowy clouds', 'ggg', (4, 23))),
+                (u'(v) Lawyers, in relation to coders, means something very different',
+                    u'(v) <E T="03">Lawyers</E>, in relation to coders, means something very different',
+                    Ref(u'lawyers', '', (4, 11))),
+                (u'(c) Regulation (1) The term means: ',
+                    u'(c) <E T="03">Regulation</E> (1) The term means:',
+                    Ref(u'regulation', '', (4, 14))),
+            ]
 
         xml_no_defs = [
             (u'(d) Term1 or term2 means stuff',
@@ -184,6 +191,7 @@ class LayerTermTest(TestCase):
             defs, exc = t.node_definitions(node, stack)
             self.assertEqual([ref], defs)
             self.assertEqual([], exc)
+
 
     def test_node_defintions_act(self):
         t = Terms(None)

--- a/tests/layer_terms_tests.py
+++ b/tests/layer_terms_tests.py
@@ -124,7 +124,7 @@ class LayerTermTest(TestCase):
                     u'(v) <E T="03">Lawyers</E>, in relation to coders, means something very different',
                     Ref(u'lawyers', '', (4, 11))),
                 (u'(c) Regulation (1) The term means: ',
-                    u'(c) <E T="03">Regulation</E> (1) The term means:',
+                    u'(c) <E T="03">Regulation</E> (1) The term means: ',
                     Ref(u'regulation', '', (4, 14))),
             ]
 
@@ -191,7 +191,6 @@ class LayerTermTest(TestCase):
             defs, exc = t.node_definitions(node, stack)
             self.assertEqual([ref], defs)
             self.assertEqual([], exc)
-
 
     def test_node_defintions_act(self):
         t = Terms(None)

--- a/tests/layer_terms_tests.py
+++ b/tests/layer_terms_tests.py
@@ -123,9 +123,6 @@ class LayerTermTest(TestCase):
                 (u'(v) Lawyers, in relation to coders, means something very different',
                     u'(v) <E T="03">Lawyers</E>, in relation to coders, means something very different',
                     Ref(u'lawyers', '', (4, 11))),
-                (u'(c) Regulation (1) The term means: ',
-                    u'(c) <E T="03">Regulation</E> (1) The term means: ',
-                    Ref(u'regulation', '', (4, 14))),
             ]
 
         xml_no_defs = [

--- a/tests/notice_build_tests.py
+++ b/tests/notice_build_tests.py
@@ -796,3 +796,17 @@ class NoticeBuildTest(TestCase):
         em = pars[0].getchildren()[0]
         self.assertEqual(em.text, "Paragraph 22(a)(5)")
         self.assertEqual(em.tail, " Content")
+
+    def test_fetch_cfr_parts(self):
+        notice_xml = etree.fromstring(u"""
+            <RULE>
+                <PREAMB>
+                    <CFR>12 CFR Parts 1002, 1024, and 1026</CFR>
+                </PREAMB>
+            </RULE>
+          """)
+
+        result = build.fetch_cfr_parts(notice_xml)
+        self.assertEqual(result, ['1002', '1024', '1026'])
+
+

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -364,3 +364,18 @@ class RegTextTest(TestCase):
             root.P("(xi) More")
         xml = self.tree.render_xml()
         self.assertEqual('xi', reg_text.next_marker(xml.getchildren()[0], []))
+
+    def test_build_from_section_double_alpha(self):
+        # Ensure we match a hierarchy like (x), (y), (z), (aa), (bb)…
+        xml = u"""
+            <SECTION>
+                <SECTNO>§ 8675.309</SECTNO>
+                <SUBJECT>Definitions.</SUBJECT>
+                <P>(aa) This is what things mean:</P>
+            </SECTION>
+        """
+        node = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
+        child = node.children[0]
+        self.assertEqual('(aa) This is what things mean:', child.text.strip())
+        self.assertEqual(['8675', '309', 'aa'], child.label)
+        


### PR DESCRIPTION
* https://github.com/cfpb/regulations-parser/pull/282 Allows another citation format for comments
* https://github.com/cfpb/regulations-parser/pull/283 Adds a test for that
* https://github.com/cfpb/regulations-parser/pull/284 Adds an explicit label format in amdpars, along with tweaks to definition grammars
* https://github.com/cfpb/regulations-parser/pull/286 Removes "the act" as an exception in definitions

Pulling in these 4 PRs as they 1) build on each other and 2) affect definitions, which I'm about to change a bit.