### PR TITLE
Make SUBJGRPs appear in TOC in just-about acceptable fashion

### DIFF
--- a/regparser/tree/reg_text.py
+++ b/regparser/tree/reg_text.py
@@ -12,7 +12,7 @@ from regparser.tree.supplement import find_supplement_start
 
 
 def build_subparts_tree(text, part, subpart_builder):
-    """ Build a tree of a subpart, and it's children sections.
+    """ Build a tree of a subpart and its child sections.
     subpart_builder can be a builder that builds a subpart or an
     emptypart. """
 
@@ -83,6 +83,27 @@ def build_subpart(text, part):
     return struct.Node(
         "", [], label, subpart_title, node_type=struct.Node.SUBPART)
 
+def build_subjgrp(text, part):
+    """
+    We're constructing a fake "letter" here by taking the first letter of
+    each word in the subjgrp's title, or using the first two letters of the
+    first word if there's just one—we're avoiding single letters to make sure we
+    don't duplicate an existing subpart, and we're hoping that the initialisms
+    created by this method are unique for this regulation.
+    We can make this more robust by accepting a list of existing initialisms and
+    returning both that list and the Node, and checking against the list as we
+    construct them.
+    """
+    def subjgrp_label(candidate_text):
+        words = candidate_text.split(" ")
+        if len(words) == 1:
+            return words[0][:2]
+        else:
+            return "".join([word[0] for word in words])
+    label = [str(part), 'Subpart', subjgrp_label(text)]
+
+    return struct.Node(
+        "", [], label, text, node_type=struct.Node.SUBPART)
 
 def find_next_subpart_start(text):
     """ Find the start of the next Subpart (e.g. Subpart B)"""

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -85,11 +85,14 @@ def build_tree(reg_xml):
 
     if len(subpart_and_subjgrp_xmls) > 0:
         subthings = []
+        letter_list = []
         for subthing in subpart_and_subjgrp_xmls:
             if subthing.tag == "SUBPART":
                 subthings.append(build_subpart(reg_part, subthing))
             elif subthing.tag == "SUBJGRP":
-                subthings.append(build_subjgrp(reg_part, subthing))
+                letter_list, built_subjgrp = build_subjgrp(
+                    reg_part, subthing, letter_list)
+                subthings.append(built_subjgrp)
 
         tree.children = subthings
     else:
@@ -129,11 +132,12 @@ def build_subpart(reg_part, subpart_xml):
     subpart.children = sections
     return subpart
 
-def build_subjgrp(reg_part, subjgrp_xml):
+def build_subjgrp(reg_part, subjgrp_xml, letter_list):
     # This handles subjgrps that have been pulled out and injected into the same
     # level as subparts.
     subjgrp_title = get_subjgrp_title(subjgrp_xml)
-    subjgrp = reg_text.build_subjgrp(subjgrp_title, reg_part)
+    letter_list, subjgrp = reg_text.build_subjgrp(subjgrp_title, reg_part,
+                                                  letter_list)
 
     sections = []
     for ch in subjgrp_xml.getchildren():
@@ -141,7 +145,7 @@ def build_subjgrp(reg_part, subjgrp_xml):
             sections.extend(build_from_section(reg_part, ch))
 
     subjgrp.children = sections
-    return subjgrp
+    return (letter_list, subjgrp)
 
 def get_markers(text):
     """ Extract all the paragraph markers from text. Do some checks on the

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -73,13 +73,27 @@ def build_tree(reg_xml):
 
     part = reg_xml.xpath('//PART')[0]
 
+    # Build a list of SUBPARTs, then pull SUBJGRPs into that list:
     subpart_xmls = [c for c in part.getchildren() if c.tag == 'SUBPART']
+    subpart_and_subjgrp_xmls = []
     if len(subpart_xmls) > 0:
-        subparts = [build_subpart(reg_part, s) for s in subpart_xmls]
-        tree.children = subparts
+        for subpart in subpart_xmls:
+            subpart_and_subjgrp_xmls.append(subpart)
+            subjgrps = [c for c in subpart.getchildren() if c.tag == 'SUBJGRP']
+            for subjgrp in subjgrps:
+                subpart_and_subjgrp_xmls.append(subjgrp)
+
+    if len(subpart_and_subjgrp_xmls) > 0:
+        subthings = []
+        for subthing in subpart_and_subjgrp_xmls:
+            if subthing.tag == "SUBPART":
+                subthings.append(build_subpart(reg_part, subthing))
+            elif subthing.tag == "SUBJGRP":
+                subthings.append(build_subjgrp(reg_part, subthing))
+
+        tree.children = subthings
     else:
-        section_xmls = [c for c in part.getchildren() if c.tag in
-                        ('SECTION', 'SUBJGRP')]
+        section_xmls = [c for c in part.getchildren() if c.tag == 'SECTION']
         sections = []
         for section_xml in section_xmls:
             sections.extend(build_from_section(reg_part, section_xml))
@@ -92,9 +106,13 @@ def build_tree(reg_xml):
 
     return tree
 
-
 def get_subpart_title(subpart_xml):
     hds = subpart_xml.xpath('./RESERVED|./HD')
+    if hds:
+        return [hd.text for hd in hds][0]
+
+def get_subjgrp_title(subjgrp_xml):
+    hds = subjgrp_xml.xpath('./RESERVED|./HD')
     if hds:
         return [hd.text for hd in hds][0]
 
@@ -107,14 +125,23 @@ def build_subpart(reg_part, subpart_xml):
     for ch in subpart_xml.getchildren():
         if ch.tag == 'SECTION':
             sections.extend(build_from_section(reg_part, ch))
-        elif ch.tag == 'SUBJGRP':
-            for group_child in ch.getchildren():
-                if group_child.tag == 'SECTION':
-                    sections.extend(build_from_section(reg_part, group_child))
 
     subpart.children = sections
     return subpart
 
+def build_subjgrp(reg_part, subjgrp_xml):
+    # This handles subjgrps that have been pulled out and injected into the same
+    # level as subparts.
+    subjgrp_title = get_subjgrp_title(subjgrp_xml)
+    subjgrp = reg_text.build_subjgrp(subjgrp_title, reg_part)
+
+    sections = []
+    for ch in subjgrp_xml.getchildren():
+        if ch.tag == 'SECTION':
+            sections.extend(build_from_section(reg_part, ch))
+
+    subjgrp.children = sections
+    return subjgrp
 
 def get_markers(text):
     """ Extract all the paragraph markers from text. Do some checks on the

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -90,8 +90,8 @@ def build_tree(reg_xml):
             if subthing.tag == "SUBPART":
                 subthings.append(build_subpart(reg_part, subthing))
             elif subthing.tag == "SUBJGRP":
-                letter_list, built_subjgrp = build_subjgrp(
-                    reg_part, subthing, letter_list)
+                built_subjgrp = build_subjgrp(reg_part, subthing, letter_list)
+                letter_list.append(built_subjgrp.label[-1])
                 subthings.append(built_subjgrp)
 
         tree.children = subthings
@@ -145,7 +145,7 @@ def build_subjgrp(reg_part, subjgrp_xml, letter_list):
             sections.extend(build_from_section(reg_part, ch))
 
     subjgrp.children = sections
-    return (letter_list, subjgrp)
+    return subjgrp
 
 def get_markers(text):
     """ Extract all the paragraph markers from text. Do some checks on the

--- a/tests/tree_reg_text_tests.py
+++ b/tests/tree_reg_text_tests.py
@@ -250,43 +250,40 @@ class DepthRegTextTest(TestCase):
 
     def test_subjgrp_label(self):
         # Single words:
-        result, newlist = subjgrp_label('Penalties', [])
+        result = subjgrp_label('Penalties', [])
         self.assertEqual('Pe', result)
-        result, newlist = subjgrp_label('Penalties', ['Pe'])
+        result = subjgrp_label('Penalties', ['Pe'])
         self.assertEqual('Pe.', result)
-        result, newlist = subjgrp_label('Penalties', ['Pe', 'Pe.'])
+        result = subjgrp_label('Penalties', ['Pe', 'Pe.'])
         self.assertEqual('Pen', result)
-        result, newlist = subjgrp_label('Penalties', ['Pe', 'Pe.', 'Pen'])
+        result = subjgrp_label('Penalties', ['Pe', 'Pe.', 'Pen'])
         self.assertEqual('Pen.', result)
-        result, newlist = subjgrp_label('Pe', ['Pe', 'Pe.'])
+        result = subjgrp_label('Pe', ['Pe', 'Pe.'])
+        self.assertEqual('Pe-a', result)
+        result = subjgrp_label('Pe', ['Pe', 'Pe.', 'Pe-a'])
+        self.assertEqual('Pe.-a', result)
+        result = subjgrp_label('Pe', ['Pe', 'Pe.', 'Pe-a', 'Pe.-a'])
         self.assertEqual('Pe-b', result)
-        result, newlist = subjgrp_label('Pe', ['Pe', 'Pe.', 'Pe-b'])
-        self.assertEqual('Pe.-b', result)
-        result, newlist = subjgrp_label('Pe', ['Pe', 'Pe.', 'Pe-b', 'Pe.-b'])
-        self.assertEqual('Pe-c', result)
 
         # Multiple words:
-        result, newlist = subjgrp_label('Change of Ownership', [])
+        result = subjgrp_label('Change of Ownership', [])
         self.assertEqual('CoO', result)
-        result, newlist = subjgrp_label('Change of Ownership', ['CoO'])
-        self.assertEqual('C. o. O. ', result)
-        result, newlist = subjgrp_label('Change of Ownership',
-                                        ['CoO', 'C. o. O. '])
-        self.assertEqual('C-o-O', result)
-        result, newlist = subjgrp_label('Change of Ownership',
-                                        ['CoO', 'C. o. O. ', 'C-o-O'])
+        result = subjgrp_label('Change of Ownership', ['CoO'])
+        self.assertEqual('C.o.O.', result)
+        result = subjgrp_label('Change of Ownership',
+                                        ['CoO', 'C.o.O.'])
         self.assertEqual('C_o_O', result)
-        result, newlist = subjgrp_label('Change of Ownership',
-                                        ['CoO', 'C. o. O. ', 'C-o-O', 'C_o_O'])
+        result = subjgrp_label('Change of Ownership',
+                                        ['CoO', 'C.o.O.', 'C-o-O', 'C_o_O'])
         self.assertEqual('ChofOw', result)
-        result, newlist = subjgrp_label('Change of Ownership',
-            ['CoO', 'C. o. O. ', 'C-o-O', 'C_o_O', 'ChofOw'])
-        self.assertEqual('Ch. of. Ow. ', result)
-        result, newlist = subjgrp_label('Change of Ownership',
-            ['CoO', 'C. o. O. ', 'C-o-O', 'C_o_O', 'ChofOw', 'Ch. of. Ow. '])
-        self.assertEqual('Ch-of-Ow', result)
-        result, newlist = subjgrp_label('C o O',
-            ['CoO', 'C. o. O. ', 'C-o-O', 'C_o_O'])
-        self.assertEqual('CoO-b', result)
+        result = subjgrp_label('Change of Ownership',
+            ['CoO', 'C.o.O.', 'C_o_O', 'ChofOw'])
+        self.assertEqual('Ch.of.Ow.', result)
+        result = subjgrp_label('Change of Ownership',
+            ['CoO', 'C.o.O.', 'C_o_O', 'ChofOw', 'Ch.of.Ow.'])
+        self.assertEqual('Ch_of_Ow', result)
+        result = subjgrp_label('C o O',
+            ['CoO', 'C.o.O.', 'C_o_O'])
+        self.assertEqual('CoO-a', result)
 
 

--- a/tests/tree_reg_text_tests.py
+++ b/tests/tree_reg_text_tests.py
@@ -247,3 +247,46 @@ class DepthRegTextTest(TestCase):
         self.assertEqual(['8888', 'Subpart', 'C'], tree.label)
         self.assertEqual([], tree.children)
         self.assertEqual('[Reserved]', tree.title)
+
+    def test_subjgrp_label(self):
+        # Single words:
+        result, newlist = subjgrp_label('Penalties', [])
+        self.assertEqual('Pe', result)
+        result, newlist = subjgrp_label('Penalties', ['Pe'])
+        self.assertEqual('Pe.', result)
+        result, newlist = subjgrp_label('Penalties', ['Pe', 'Pe.'])
+        self.assertEqual('Pen', result)
+        result, newlist = subjgrp_label('Penalties', ['Pe', 'Pe.', 'Pen'])
+        self.assertEqual('Pen.', result)
+        result, newlist = subjgrp_label('Pe', ['Pe', 'Pe.'])
+        self.assertEqual('Pe-b', result)
+        result, newlist = subjgrp_label('Pe', ['Pe', 'Pe.', 'Pe-b'])
+        self.assertEqual('Pe.-b', result)
+        result, newlist = subjgrp_label('Pe', ['Pe', 'Pe.', 'Pe-b', 'Pe.-b'])
+        self.assertEqual('Pe-c', result)
+
+        # Multiple words:
+        result, newlist = subjgrp_label('Change of Ownership', [])
+        self.assertEqual('CoO', result)
+        result, newlist = subjgrp_label('Change of Ownership', ['CoO'])
+        self.assertEqual('C. o. O. ', result)
+        result, newlist = subjgrp_label('Change of Ownership',
+                                        ['CoO', 'C. o. O. '])
+        self.assertEqual('C-o-O', result)
+        result, newlist = subjgrp_label('Change of Ownership',
+                                        ['CoO', 'C. o. O. ', 'C-o-O'])
+        self.assertEqual('C_o_O', result)
+        result, newlist = subjgrp_label('Change of Ownership',
+                                        ['CoO', 'C. o. O. ', 'C-o-O', 'C_o_O'])
+        self.assertEqual('ChofOw', result)
+        result, newlist = subjgrp_label('Change of Ownership',
+            ['CoO', 'C. o. O. ', 'C-o-O', 'C_o_O', 'ChofOw'])
+        self.assertEqual('Ch. of. Ow. ', result)
+        result, newlist = subjgrp_label('Change of Ownership',
+            ['CoO', 'C. o. O. ', 'C-o-O', 'C_o_O', 'ChofOw', 'Ch. of. Ow. '])
+        self.assertEqual('Ch-of-Ow', result)
+        result, newlist = subjgrp_label('C o O',
+            ['CoO', 'C. o. O. ', 'C-o-O', 'C_o_O'])
+        self.assertEqual('CoO-b', result)
+
+


### PR DESCRIPTION
Essentially by pretending they're subparts with “letters” we make up from their titles. I don't think we can do much better than this without also changing regulations-site, which is the next stage.