### PR TITLE
Refactor terms layer

### DIFF
--- a/regparser/layer/def_finders.py
+++ b/regparser/layer/def_finders.py
@@ -1,0 +1,122 @@
+# vim: set fileencoding=utf-8
+"""Parsers for finding a term that's being defined within a node"""
+from itertools import chain
+import re
+
+from regparser.citations import Label
+from regparser.grammar import terms as grammar
+import settings
+
+
+class Ref(object):
+    def __init__(self, term, label, start):
+        self.term = unicode(term)
+        self.label = label
+        self.start = start
+        self.end = self.start + len(term)
+        self.position = (self.start, self.end)
+
+    def __eq__(self, other):
+        """Equality depends on equality of the fields"""
+        return isinstance(other, Ref) and repr(self) == repr(other)
+
+    def __repr__(self):
+        return 'Ref( term=%s, label=%s, start=%s )' % (
+            repr(self.term), repr(self.label), repr(self.start))
+
+
+class ExplicitIncludes(object):
+    """Definitions can be explicitly included in the settings"""
+    def find(self, node):
+        refs = []
+        cfr_part = node.label[0] if node.label else None
+        for included_term, context in settings.INCLUDE_DEFINITIONS_IN.get(
+                cfr_part, []):
+            if context in node.text and included_term in node.text:
+                pos_start = node.text.index(included_term)
+                term = included_term.lower()
+                refs.append(Ref(term, node.label_id(), pos_start))
+        return refs
+
+
+class SmartQuotes(object):
+    """Definitions indicated via smart quotes"""
+    def __init__(self, stack):
+        """Stack (which references ancestors of a node) is used to determine
+        whether or not to apply smart quotes"""
+        self.stack = stack
+
+    def find(self, node):
+        refs = []
+        if self.stack and self.has_vague_definition_indicator_in_parent():
+            for match, _, _ in grammar.smart_quotes.scanString(node.text):
+                term = match.term.tokens[0].lower().strip(',.;')
+                refs.append(Ref(term, node.label_id(), match.term.pos[0]))
+        return refs
+
+    def has_vague_definition_indicator_in_parent(self):
+        """With smart quotes, we catch some false positives, phrases in quotes
+        that are not terms. This extra test lets us know that a parent of the
+        node looks like it would contain definitions."""
+        for node in self.stack.lineage():
+            lower_text = node.text.lower()
+            in_text = 'Definition' in node.text
+            in_title = 'Definition' in (node.title or '')
+            pattern1 = re.search('the term .* (means|refers to)', lower_text)
+            pattern2 = re.search(u'“[^”]+” (means|refers to)', lower_text)
+            if in_text or in_title or pattern1 or pattern2:
+                return True
+        return False
+
+
+class ScopeMatch(object):
+    """We know these will be definitions because the scope of the definition
+    is spelled out. E.g. 'for the purposes of XXX, the term YYY means'"""
+    def __init__(self, finder):
+        """Finder is an instance of ScopeFinder"""
+        self.finder = finder
+
+    def find(self, node):
+        refs = []
+        for match, _, _ in grammar.scope_term_type_parser.scanString(
+                node.text):
+            valid_scope = self.finder.scope_of_text(
+                match.scope, Label.from_node(node), verify_prefix=False)
+            valid_term = re.match("^[a-z ]+$", match.term.tokens[0])
+            if valid_scope and valid_term:
+                term = match.term.tokens[0].strip()
+                pos_start = node.text.index(term, match.term.pos[0])
+                refs.append(Ref(term, node.label_id(), pos_start))
+        return refs
+
+
+class XMLTermMeans(object):
+    """Namespace for a matcher for e.g. '<E>XXX</E> means YYY'"""
+    def __init__(self, existing_refs):
+        """Existing refs will be used to exclude certain matches"""
+        self.exclusions = existing_refs
+
+    def find(self, node):
+        refs = []
+        tagged_text = getattr(node, 'tagged_text', '')
+        for match, _, _ in grammar.xml_term_parser.scanString(tagged_text):
+            """Position in match reflects XML tags, so its dropped in
+            preference of new values based on node.text."""
+            for match in chain([match.head], match.tail):
+                pos_start = self.pos_start(match.term.tokens[0], node.text)
+                term = node.tagged_text[
+                    match.term.pos[0]:match.term.pos[1]].lower()
+                refs.append(Ref(term, node.label_id(), pos_start))
+        return refs
+
+    def pos_start(self, needle, haystack):
+        """Search for the first instance of `needle` in the `haystack`
+        excluding any overlaps from `self.exclusions`. Implicitly returns None
+        if it can't be found"""
+        start = 0
+        while start >= 0:
+            start = haystack.find(needle, start)
+            if not any(r.start <= start and r.end >= start
+                       for r in self.exclusions):
+                return start
+            start += 1

--- a/regparser/layer/def_finders.py
+++ b/regparser/layer/def_finders.py
@@ -1,5 +1,6 @@
 # vim: set fileencoding=utf-8
 """Parsers for finding a term that's being defined within a node"""
+import abc
 from itertools import chain
 import re
 
@@ -27,7 +28,19 @@ class Ref(object):
             repr(self.term), repr(self.label), repr(self.start))
 
 
-class ExplicitIncludes(object):
+class FinderBase(object):
+    """Base class for all of the definition finder classes. Defines the
+    interface they must implement"""
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def find(self, node):
+        """Given a Node, pull out any definitions it may contain as a list of
+        Refs"""
+        raise NotImplementedError()
+
+
+class ExplicitIncludes(FinderBase):
     """Definitions can be explicitly included in the settings. For example,
     say that a paragraph doesn't indicate that a certain phrase is a
     definition; we can define INCLUDE_DEFINITIONS_IN in our settings file,
@@ -43,7 +56,7 @@ class ExplicitIncludes(object):
         return refs
 
 
-class SmartQuotes(object):
+class SmartQuotes(FinderBase):
     """Definitions indicated via smart quotes"""
     def __init__(self, stack):
         """Stack (which references ancestors of a node) is used to determine
@@ -73,7 +86,7 @@ class SmartQuotes(object):
         return False
 
 
-class ScopeMatch(object):
+class ScopeMatch(FinderBase):
     """We know these will be definitions because the scope of the definition
     is spelled out. E.g. 'for the purposes of XXX, the term YYY means'"""
     def __init__(self, finder):
@@ -94,7 +107,7 @@ class ScopeMatch(object):
         return refs
 
 
-class XMLTermMeans(object):
+class XMLTermMeans(FinderBase):
     """Namespace for a matcher for e.g. '<E>XXX</E> means YYY'"""
     def __init__(self, existing_refs=None):
         """Existing refs will be used to exclude certain matches"""

--- a/regparser/layer/def_finders.py
+++ b/regparser/layer/def_finders.py
@@ -9,6 +9,8 @@ import settings
 
 
 class Ref(object):
+    """A reference to a defined term. Keeps track of the term, where it was
+    found and the term's position in that node's text"""
     def __init__(self, term, label, start):
         self.term = unicode(term).lower()
         self.label = label
@@ -26,7 +28,10 @@ class Ref(object):
 
 
 class ExplicitIncludes(object):
-    """Definitions can be explicitly included in the settings"""
+    """Definitions can be explicitly included in the settings. For example,
+    say that a paragraph doesn't indicate that a certain phrase is a
+    definition; we can define INCLUDE_DEFINITIONS_IN in our settings file,
+    which will be checked here."""
     def find(self, node):
         refs = []
         cfr_part = node.label[0] if node.label else None

--- a/regparser/layer/def_finders.py
+++ b/regparser/layer/def_finders.py
@@ -10,7 +10,7 @@ import settings
 
 class Ref(object):
     def __init__(self, term, label, start):
-        self.term = unicode(term)
+        self.term = unicode(term).lower()
         self.label = label
         self.start = start
         self.end = self.start + len(term)
@@ -34,8 +34,7 @@ class ExplicitIncludes(object):
                 cfr_part, []):
             if context in node.text and included_term in node.text:
                 pos_start = node.text.index(included_term)
-                term = included_term.lower()
-                refs.append(Ref(term, node.label_id(), pos_start))
+                refs.append(Ref(included_term, node.label_id(), pos_start))
         return refs
 
 
@@ -92,8 +91,10 @@ class ScopeMatch(object):
 
 class XMLTermMeans(object):
     """Namespace for a matcher for e.g. '<E>XXX</E> means YYY'"""
-    def __init__(self, existing_refs):
+    def __init__(self, existing_refs=None):
         """Existing refs will be used to exclude certain matches"""
+        if existing_refs is None:
+            existing_refs = []
         self.exclusions = list(existing_refs)
 
     def find(self, node):

--- a/regparser/layer/def_finders.py
+++ b/regparser/layer/def_finders.py
@@ -48,13 +48,13 @@ class SmartQuotes(object):
 
     def find(self, node):
         refs = []
-        if self.stack and self.has_vague_definition_indicator_in_parent():
+        if self.stack and self.has_def_indicator():
             for match, _, _ in grammar.smart_quotes.scanString(node.text):
                 term = match.term.tokens[0].lower().strip(',.;')
                 refs.append(Ref(term, node.label_id(), match.term.pos[0]))
         return refs
 
-    def has_vague_definition_indicator_in_parent(self):
+    def has_def_indicator(self):
         """With smart quotes, we catch some false positives, phrases in quotes
         that are not terms. This extra test lets us know that a parent of the
         node looks like it would contain definitions."""
@@ -94,7 +94,7 @@ class XMLTermMeans(object):
     """Namespace for a matcher for e.g. '<E>XXX</E> means YYY'"""
     def __init__(self, existing_refs):
         """Existing refs will be used to exclude certain matches"""
-        self.exclusions = existing_refs
+        self.exclusions = list(existing_refs)
 
     def find(self, node):
         refs = []
@@ -106,7 +106,9 @@ class XMLTermMeans(object):
                 pos_start = self.pos_start(match.term.tokens[0], node.text)
                 term = node.tagged_text[
                     match.term.pos[0]:match.term.pos[1]].lower()
-                refs.append(Ref(term, node.label_id(), pos_start))
+                ref = Ref(term, node.label_id(), pos_start)
+                refs.append(ref)
+                self.exclusions.append(ref)
         return refs
 
     def pos_start(self, needle, haystack):

--- a/regparser/layer/scope_finder.py
+++ b/regparser/layer/scope_finder.py
@@ -1,0 +1,91 @@
+from collections import defaultdict
+import re
+
+from regparser.citations import internal_citations, Label
+from regparser.tree import struct
+
+
+class ScopeFinder(object):
+    """Useful for determining the scope of a term"""
+    #   Regexes used in determining scope
+    _PART_RE, _SUBPART_RE = re.compile(r"\bpart\b"), re.compile(r"\bsubpart\b")
+    _SECT_RE = re.compile(r"\bsection\b")
+    _PAR_RE = re.compile(r"\bparagraph\b")
+    #   Regex to confirm scope indicator
+    _SCOPE_RE = re.compile(r".*purposes of( this)?\s*$", re.DOTALL)
+    _SCOPE_USED_RE = re.compile(
+        r".*as used in( this)?\s*$", re.DOTALL | re.IGNORECASE)
+
+    def __init__(self):
+        #   subpart -> list[section]
+        self.subpart_map = defaultdict(list)
+
+    def add_subparts(self, root):
+        """Document the relationship between sections and subparts"""
+        # Need a reference for maintaining state
+        self.__current_subpart = None
+        struct.walk(root, self._subpart_per_node)
+
+    def _subpart_per_node(self, node):
+        if node.node_type == struct.Node.SUBPART:
+            self.__current_subpart = node.label[2]
+        elif node.node_type == struct.Node.EMPTYPART:
+            self.__current_subpart = None
+        if (node.node_type in (struct.Node.REGTEXT, struct.Node.APPENDIX)
+                and len(node.label) == 2):
+            # Subparts
+            section = node.label[-1]
+            self.subpart_map[self.__current_subpart].append(section)
+
+    def scope_of_text(self, text, label_struct, verify_prefix=True):
+        """Given specific text, try to determine the definition scope it
+        indicates. Implicit return None if none is found."""
+        scopes = []
+        #   First, make a list of potential scope indicators
+        citations = internal_citations(text, label_struct, require_marker=True)
+        indicators = [(c.full_start, c.label.to_list()) for c in citations]
+        text = text.lower()
+        label_list = label_struct.to_list()
+        indicators.extend((m.start(), label_list[:1])
+                          for m in self._PART_RE.finditer(text))
+        indicators.extend((m.start(), label_list[:2])
+                          for m in self._SECT_RE.finditer(text))
+        indicators.extend((m.start(), label_list)
+                          for m in self._PAR_RE.finditer(text))
+        #   Subpart's a bit more complicated, as it gets expanded into a
+        #   list of sections
+        for match in self._SUBPART_RE.finditer(text):
+            indicators.extend(
+                (match.start(), subpart_label)
+                for subpart_label in self.subpart_scope(label_list))
+
+        #   Finally, add the scope if we verify its prefix
+        for start, label in indicators:
+            if not verify_prefix or self._SCOPE_RE.match(text[:start]):
+                scopes.append(label)
+            elif self._SCOPE_USED_RE.match(text[:start]):
+                scopes.append(label)
+
+        #   Add interpretation to scopes
+        scopes = scopes + [s + [struct.Node.INTERP_MARK] for s in scopes]
+        if scopes:
+            return [tuple(s) for s in scopes]
+
+    def subpart_scope(self, label_parts):
+        """Given a label, determine which sections fall under the same
+        subpart"""
+        reg = label_parts[0]
+        section = label_parts[1]
+        for subpart in self.subpart_map:
+            if section in self.subpart_map[subpart]:
+                return [[reg, sect] for sect in self.subpart_map[subpart]]
+        return []
+
+    def determine_scope(self, stack):
+        for node in stack.lineage():
+            scopes = self.scope_of_text(node.text, Label.from_node(node))
+            if scopes:
+                return [tuple(s) for s in scopes]
+
+        #   Couldn't determine scope; default to the entire reg
+        return [tuple(node.label[:1])]

--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -140,6 +140,8 @@ class Terms(Layer):
         return layer_el
 
     def _word_matches(self, term, text):
+        """Return the start and end indexes of the term within the text,
+        accounting for word boundaries"""
         return [(match.start(), match.end()) for match in
                 re.finditer(r'\b' + re.escape(term) + r'\b', text)]
 

--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -57,7 +57,7 @@ class Terms(Layer):
                                   struct.Node.EMPTYPART):
                 included, excluded = self.node_definitions(node, stack)
                 if included:
-                    for scope in self.determine_scope(stack):
+                    for scope in self.scope_finder.determine_scope(stack):
                         self.scoped_terms[scope].extend(included)
                 self.scoped_terms['EXCLUDED'].extend(excluded)
 
@@ -109,8 +109,8 @@ class Terms(Layer):
             references.extend(finder.find(node))
 
         return (
-            [r for r in references if self.is_exclusion(r.term, node)],
-            [r for r in references if not self.is_exclusion(r.term, node)])
+            [r for r in references if not self.is_exclusion(r.term, node)],
+            [r for r in references if self.is_exclusion(r.term, node)])
 
     def process(self, node):
         """Determine which (if any) definitions would apply to this node,
@@ -139,7 +139,7 @@ class Terms(Layer):
                 })
         return layer_el
 
-    def _word_matches(self, term, text, lst):
+    def _word_matches(self, term, text):
         return [(match.start(), match.end()) for match in
                 re.finditer(r'\b' + re.escape(term) + r'\b', text)]
 

--- a/tests/layer_def_finders_tests.py
+++ b/tests/layer_def_finders_tests.py
@@ -1,5 +1,8 @@
 # vim: set fileencoding=utf-8
+import re
+
 from regparser.layer import def_finders
+from regparser.layer.scope_finder import ScopeFinder
 from regparser.layer.terms import ParentStack
 from regparser.tree.struct import Node
 
@@ -54,3 +57,116 @@ class SmartQuotesTest(TestCase):
 
         self.pop_and_check()
         self.check_indicator(True, "(a) The term Bob refers to")
+
+    def assert_finds_definition(self, text, *expected):
+        """Check that the definition is _not_ found when it has no
+        "Definition" parent and _is_ found when such a parent exists"""
+        self.stack.add(0, Node(label=['999']))
+        node = Node(text)
+        self.assertEqual([], self.finder.find(node))
+
+        self.stack.add(1, Node("Definitions", label=['999', '1']))
+        actual = self.finder.find(node)
+        self.assertEqual(len(expected), len(actual))
+        for expected_ref, actual_ref in zip(expected, actual):
+            self.assertEqual(expected_ref.term, actual_ref.term)
+            self.assertEqual(expected_ref.start, actual_ref.start)
+
+        self.stack.pop()
+
+    def test_find(self):
+        """Tests several examples involving smart quotes"""
+        self.assert_finds_definition(
+            u'This has a “worD” and then more',
+            def_finders.Ref('word', None, 12))
+        self.assert_finds_definition(
+            u'I have “anotheR word” term and “moree”',
+            def_finders.Ref('another word', None, 8),
+            def_finders.Ref('moree', None, 32))
+        self.assert_finds_definition(
+            u'But the child “DoeS sEe”?',
+            def_finders.Ref('does see', None, 15))
+        self.assert_finds_definition(
+            u'Start with “this,”', def_finders.Ref('this', None, 12))
+        self.assert_finds_definition(
+            u'Start with “this;”', def_finders.Ref('this', None, 12))
+        self.assert_finds_definition(
+            u'Start with “this.”', def_finders.Ref('this', None, 12))
+        self.assert_finds_definition(
+            u'As do “subchildren”', def_finders.Ref('subchildren', None, 7))
+
+
+class XMLTermMeansTest(TestCase):
+    def assert_finds_result(self, tagged_text, term, start):
+        """Check that the definition is found and matches the position"""
+        self._assert_finds(tagged_text, def_finders.Ref(term, None, start))
+
+    def assert_finds_no_result(self, tagged_text):
+        self._assert_finds(tagged_text)   # no references
+
+    def _assert_finds(self, tagged_text, *refs):
+        """Compare the derived results to an expected number of references"""
+        finder = def_finders.XMLTermMeans()
+        text = re.sub(r"<[^>]*>", "", tagged_text)  # removes tags
+        node = Node(text)
+        node.tagged_text = tagged_text
+        actual = finder.find(node)
+        self.assertEqual(len(refs), len(actual))
+        for ref, actual in zip(refs, actual):
+            self.assertEqual(ref.term, actual.term)
+            self.assertEqual(ref.start, actual.start)
+
+    def test_find(self):
+        """Test several examples that would result in a definition found"""
+        self.assert_finds_result(
+            '(4) <E T="03">Thing</E> means a thing that is defined',
+            'thing', 4)
+        self.assert_finds_result(
+            '(e) <E T="03">Well-meaning lawyers</E> means people who do '
+            'weird things',
+            'well-meaning lawyers', 4)
+        self.assert_finds_result(
+            '(e) <E T="03">Words</E> have the same meaning as in a dictionary',
+            'words', 4)
+        self.assert_finds_result(
+            '(e) <E T="03">Banana</E> has the same meaning as bonono',
+            'banana', 4)
+        self.assert_finds_result(
+            '(f) <E T="03">Huge billowy clouds</E> means I want to take a nap',
+            'huge billowy clouds', 4)
+        self.assert_finds_result(
+            '(v) <E T="03">Lawyers</E>, in relation to coders, means '
+            'something very different',
+            'lawyers', 4)
+
+    def test_find_no_results(self):
+        """Test several examples where we are expecting no definitions to be
+        found"""
+        self.assert_finds_no_result(
+            '(d) <E T="03">Term1</E> or <E T="03">term2></E> means stuff')
+
+
+class ScopeMatchTest(TestCase):
+    def setUp(self):
+        self.finder = def_finders.ScopeMatch(ScopeFinder())
+
+    def assert_finds_result(self, text, term, start):
+        """Check that the definition is found and matches the position"""
+        actual = self.finder.find(Node(text))
+        self.assertEqual(1, len(actual))
+        actual = actual[0]
+        self.assertEqual(term, actual.term)
+        self.assertEqual(start, actual.start)
+
+    def test_find(self):
+        """Test several examples that would result in a definition found"""
+        self.assert_finds_result(
+            'For purposes of this section, the term blue means the color',
+            'blue', 39)
+        self.assert_finds_result(
+            'For purposes of paragraph (a)(1) of this section, the term cool '
+            'bro means hip cat',
+            'cool bro', 59),
+        self.assert_finds_result(
+            'For purposes of this paragraph, po jo means "poor Joe"',
+            'po jo', 32)

--- a/tests/layer_def_finders_tests.py
+++ b/tests/layer_def_finders_tests.py
@@ -1,0 +1,56 @@
+# vim: set fileencoding=utf-8
+from regparser.layer import def_finders
+from regparser.layer.terms import ParentStack
+from regparser.tree.struct import Node
+
+from unittest import TestCase
+
+
+class SmartQuotesTest(TestCase):
+    def setUp(self):
+        self.stack = ParentStack()
+        self.finder = def_finders.SmartQuotes(self.stack)
+        self.depth = 0
+
+    def check_indicator(self, expected, text, title=None):
+        """Common pattern for adding a node to the stack and then verifying
+        the `has_def_indicator` method"""
+        self.stack.add(self.depth, Node(text, title=title))
+        self.assertEqual(self.finder.has_def_indicator(), expected)
+        self.depth += 1
+
+    def pop_and_check(self, expected=False):
+        """Common pattern for popping the stack and then verifying the
+        `has_def_indicator` method"""
+        self.stack.pop()
+        self.assertEqual(self.finder.has_def_indicator(), expected)
+        self.depth -= 1
+
+    def test_has_def_indicator(self):
+        self.check_indicator(False, "This has no defs")
+        self.check_indicator(False, "No Def", title="No def")
+        self.check_indicator(
+            False, "Tomatoes do not meet the definition 'vegetable'")
+        self.check_indicator(True, "Definition. This has a definition.")
+        self.pop_and_check()
+        self.check_indicator(True, "Definitions. This has multiple!")
+        self.pop_and_check()
+        self.check_indicator(True, "No body",
+                             title="But Definition is in the title")
+
+    def test_has_def_indicator_p_marker(self):
+        self.check_indicator(
+            True,
+            "(a) Definitions. For purposes of this section except blah")
+
+    def test_has_def_indicator_the_term_means(self):
+        self.check_indicator(False, 'Contains no terms or definitions')
+        self.check_indicator(True, "(a) The term Bob means awesome")
+        self.check_indicator(True, "No defs either")
+
+        self.pop_and_check(expected=True)
+        self.pop_and_check()
+        self.check_indicator(True, u"(a) “Term” means some stuff")
+
+        self.pop_and_check()
+        self.check_indicator(True, "(a) The term Bob refers to")

--- a/tests/layer_scope_finder_tests.py
+++ b/tests/layer_scope_finder_tests.py
@@ -1,0 +1,108 @@
+# vim: set fileencoding=utf-8
+from unittest import TestCase
+
+from regparser.tree.struct import Node
+from regparser.layer.scope_finder import ScopeFinder
+from regparser.layer.terms import ParentStack
+
+
+class ScopeFinderTest(TestCase):
+    def setUp(self):
+        self.finder = ScopeFinder()
+        self.stack = ParentStack()
+
+    def add_nodes(self, length):
+        """There's a common prefix of nodes we'll add"""
+        label = ['1000', '3', 'd', '6', 'iii']
+        for i in range(length):
+            self.stack.add(i, Node(label=label[:i+1]))
+
+    def assert_scope(self, *scopes):
+        self.assertEqual(list(scopes), self.finder.determine_scope(self.stack))
+
+    def test_determine_scope_default(self):
+        """Defaults to the entire reg"""
+        self.add_nodes(2)
+        self.assert_scope(('1000',))
+
+    def test_determine_scope_this_part(self):
+        """Definitions scoped to a part also cover the interpretations for
+        that part"""
+        self.add_nodes(1)
+        self.stack.add(1, Node('For the purposes of this part, blah blah',
+                               label=['1001', '3']))
+        self.assert_scope(('1001',), ('1001', Node.INTERP_MARK))
+
+    def test_determine_scope_this_subpart(self):
+        """Subpart scope gets expanded to include other sections in the same
+        subpart"""
+        self.finder.subpart_map = {
+            'SubPart 1': ['A', '3'],
+            'Other': []
+        }
+        self.add_nodes(2)
+        self.stack.add(2, Node('For the purposes of this subpart, yada yada',
+                               label=['1000', '3', 'c']))
+        self.assert_scope(('1000', 'A'), ('1000', '3'),
+                          ('1000', 'A', Node.INTERP_MARK),
+                          ('1000', '3', Node.INTERP_MARK))
+
+    def test_determine_scope_this_section(self):
+        """Section scope can be triggered in a child paragraph"""
+        self.add_nodes(2)
+        self.stack.add(2, Node('For the purposes of this section, blah blah',
+                               label=['1000', '3', 'd']))
+        self.assert_scope(('1000', '3'), ('1000', '3', Node.INTERP_MARK))
+
+    def test_determine_scope_this_paragraph(self):
+        """Paragraph scope is tied to the paragraph that determined it.
+        Previous paragraph scopes won't apply to adjacent children"""
+        self.add_nodes(2)
+        self.stack.add(2, Node('For the purposes of this section, blah blah',
+                               label=['1000', '3', 'd']))
+        self.stack.add(3, Node('For the purposes of this paragraph, blah blah',
+                               label=['1000', '3', 'd', '5']))
+        self.assert_scope(('1000', '3', 'd', '5'),
+                          ('1000', '3', 'd', '5', Node.INTERP_MARK))
+
+        self.stack.add(3, Node(label=['1002', '3', 'd', '6']))
+        self.assert_scope(('1000', '3'), ('1000', '3', Node.INTERP_MARK))
+
+        self.stack.add(3, Node('Blah as used in this paragraph, blah blah',
+                               label=['1000', '3', 'd', '7']))
+        self.assert_scope(('1000', '3', 'd', '7'),
+                          ('1000', '3', 'd', '7', Node.INTERP_MARK))
+
+    def test_determine_scope_purposes_of_specific_paragraph(self):
+        self.add_nodes(4)
+        self.stack.add(
+            4, Node(u'For the purposes of this § 1000.3(d)(6)(i), blah',
+                    label=['1000', '3', 'd', '6', 'i']))
+        self.assert_scope(('1000', '3', 'd', '6', 'i'),
+                          ('1000', '3', 'd', '6', 'i', Node.INTERP_MARK))
+
+    def test_determine_scope_purposes_of_specific_section(self):
+        self.add_nodes(4)
+        self.stack.add(4, Node(u'For the purposes of § 1000.3, blah',
+                               label=['1000', '3', 'd', '6', 'ii']))
+        self.assert_scope(('1000', '3'), ('1000', '3', Node.INTERP_MARK))
+
+    def test_determine_scope_as_used_in_thi_section(self):
+        self.add_nodes(4)
+        self.stack.add(4, Node('As used in this section, blah blah',
+                               label=['1000', '3', 'd', '6', 'iii']))
+        self.assert_scope(('1000', '3'), ('1000', '3', Node.INTERP_MARK))
+
+    def test_subpart_scope(self):
+        self.finder.subpart_map = {
+            None: ['1', '2', '3'],
+            'A': ['7', '5', '0'],
+            'Q': ['99', 'abc', 'q']
+        }
+        self.assertEqual([['111', '1'], ['111', '2'], ['111', '3']],
+                         self.finder.subpart_scope(['111', '3']))
+        self.assertEqual([['115', '7'], ['115', '5'], ['115', '0']],
+                         self.finder.subpart_scope(['115', '5']))
+        self.assertEqual([['62', '99'], ['62', 'abc'], ['62', 'q']],
+                         self.finder.subpart_scope(['62', 'abc']))
+        self.assertEqual([], self.finder.subpart_scope(['71', 'Z']))

--- a/tests/layer_terms_tests.py
+++ b/tests/layer_terms_tests.py
@@ -68,32 +68,32 @@ class LayerTermTest(TestCase):
         n = Node('ex ex ex', label=['1111', '2'])
         self.assertFalse(t.is_exclusion('ex', n))
 
-        t.scoped_terms = {('1111',): [Ref('abc', '1', (0, 0))]}
+        t.scoped_terms = {('1111',): [Ref('abc', '1', 0)]}
         self.assertFalse(t.is_exclusion('ex', n))
 
-        t.scoped_terms = {('1111',): [Ref('ex', '1', (0, 0))]}
+        t.scoped_terms = {('1111',): [Ref('ex', '1', 0)]}
         self.assertFalse(t.is_exclusion('ex', n))
         n.text = u'Something something the term “ex” does not include potato'
         self.assertTrue(t.is_exclusion('ex', n))
 
-        t.scoped_terms = {('1111',): [Ref('abc', '1', (0, 0))]}
+        t.scoped_terms = {('1111',): [Ref('abc', '1', 0)]}
         self.assertFalse(t.is_exclusion('ex', n))
 
     def test_node_definitions(self):
         t = Terms(None)
         smart_quotes = [
             (u'This has a “worD” and then more',
-             [Ref('word', 'aaa', (12, 16))]),
+             [Ref('word', 'aaa', 12)]),
             (u'I have “anotheR word” term and “moree”',
-             [Ref('another word', 'bbb', (8, 20)),
-              Ref('moree', 'bbb', (32, 37))]),
+             [Ref('another word', 'bbb', 8),
+              Ref('moree', 'bbb', 32)]),
             (u'But the child “DoeS sEe”?',
-             [Ref('does see', 'ccc', (15, 23))]),
-            (u'Start with “this,”', [Ref('this', 'hhh', (12, 16))]),
-            (u'Start with “this;”', [Ref('this', 'iii', (12, 16))]),
-            (u'Start with “this.”', [Ref('this', 'jjj', (12, 16))]),
+             [Ref('does see', 'ccc', 15)]),
+            (u'Start with “this,”', [Ref('this', 'hhh', 12)]),
+            (u'Start with “this;”', [Ref('this', 'iii', 12)]),
+            (u'Start with “this.”', [Ref('this', 'jjj', 12)]),
             (u'As do “subchildren”',
-             [Ref('subchildren', 'ddd', (7, 18))])]
+             [Ref('subchildren', 'ddd', 7)])]
 
         no_defs = [
             u'This has no defs',
@@ -104,25 +104,25 @@ class LayerTermTest(TestCase):
         xml_defs = [
                 (u'(4) Thing means a thing that is defined',
                     u'(4) <E T="03">Thing</E> means a thing that is defined',
-                    Ref('thing', 'eee', (4, 9))),
+                    Ref('thing', 'eee', 4)),
                 (u'(e) Well-meaning lawyers means people who do weird things',
                     u'(e) <E T="03">Well-meaning lawyers</E> means people who do '
                     + 'weird things',
-                    Ref('well-meaning lawyers', 'fff', (4, 24))),
+                    Ref('well-meaning lawyers', 'fff', 4)),
                 (u'(e) Words have the same meaning as in a dictionary',
                     u'(e) <E T="03">Words</E> have the same meaning as in a '
                     + 'dictionary',
-                    Ref('words', 'ffg', (4, 9))),
+                    Ref('words', 'ffg', 4)),
                 (u'(e) Banana has the same meaning as bonono',
                     u'(e) <E T="03">Banana</E> has the same meaning as bonono',
-                    Ref('banana', 'fgf', (4, 10))),
+                    Ref('banana', 'fgf', 4)),
                 (u'(f) Huge billowy clouds means I want to take a nap',
                     u'(f) <E T="03">Huge billowy clouds</E> means I want to take a '
                     + 'nap',
-                    Ref('huge billowy clouds', 'ggg', (4, 23))),
+                    Ref('huge billowy clouds', 'ggg', 4)),
                 (u'(v) Lawyers, in relation to coders, means something very different',
                     u'(v) <E T="03">Lawyers</E>, in relation to coders, means something very different',
-                    Ref(u'lawyers', '', (4, 11))),
+                    Ref(u'lawyers', '', 4)),
             ]
 
         xml_no_defs = [
@@ -131,11 +131,11 @@ class LayerTermTest(TestCase):
 
         scope_term_defs = [
             ('For purposes of this section, the term blue means the color',
-             Ref('blue', '11-11', (39, 43))),
+             Ref('blue', '11-11', 39)),
             ('For purposes of paragraph (a)(1) of this section, the term '
-             + 'cool bro means hip cat', Ref('cool bro', '11-22', (59, 67))),
+             + 'cool bro means hip cat', Ref('cool bro', '11-22', 59)),
             ('For purposes of this paragraph, po jo means "poor Joe"',
-             Ref('po jo', '11-33', (32, 37)))]
+             Ref('po jo', '11-33', 32))]
 
         stack = ParentStack()
         stack.add(0, Node(label=['999']))
@@ -220,13 +220,13 @@ class LayerTermTest(TestCase):
         stack.add(1, Node('Definitions'))
 
         included, excluded = t.node_definitions(n1, stack)
-        self.assertEqual([Ref('bologna', '111-1', (1, 8))], included)
+        self.assertEqual([Ref('bologna', '111-1', 1)], included)
         self.assertEqual([], excluded)
         t.scoped_terms[('111', '1')] = included
 
         included, excluded = t.node_definitions(n2, stack)
         self.assertEqual([], included)
-        self.assertEqual([Ref('bologna', '111-1-a', (33, 40))], excluded)
+        self.assertEqual([Ref('bologna', '111-1-a', 33)], excluded)
 
     def test_node_definitions_multiple_xml(self):
         t = Terms(None)
@@ -240,8 +240,8 @@ class LayerTermTest(TestCase):
         inc, _ = t.node_definitions(winter, stack)
         self.assertEqual(len(inc), 2)
         cold, dreary = inc
-        self.assertEqual(cold, Ref('cold', '9999-4', (4, 8)))
-        self.assertEqual(dreary, Ref('dreary', '9999-4', (13, 19)))
+        self.assertEqual(cold, Ref('cold', '9999-4', 4))
+        self.assertEqual(dreary, Ref('dreary', '9999-4', 13))
 
         summer = Node("(i) Hot, humid, or dry means summer.",
                       label=['9999', '4'])
@@ -251,9 +251,9 @@ class LayerTermTest(TestCase):
         inc, _ = t.node_definitions(summer, stack)
         self.assertEqual(len(inc), 3)
         hot, humid, dry = inc
-        self.assertEqual(hot, Ref('hot', '9999-4', (4, 7)))
-        self.assertEqual(humid, Ref('humid', '9999-4', (9, 14)))
-        self.assertEqual(dry, Ref('dry', '9999-4', (19, 22)))
+        self.assertEqual(hot, Ref('hot', '9999-4', 4))
+        self.assertEqual(humid, Ref('humid', '9999-4', 9))
+        self.assertEqual(dry, Ref('dry', '9999-4', 19))
 
         tamale = Node("(i) Hot tamale or tamale means nom nom",
                       label=['9999', '4'])
@@ -263,8 +263,8 @@ class LayerTermTest(TestCase):
         inc, _ = t.node_definitions(tamale, stack)
         self.assertEqual(len(inc), 2)
         hot, tamale = inc
-        self.assertEqual(hot, Ref('hot tamale', '9999-4', (4, 14)))
-        self.assertEqual(tamale, Ref('tamale', '9999-4', (18, 24)))
+        self.assertEqual(hot, Ref('hot tamale', '9999-4', 4))
+        self.assertEqual(tamale, Ref('tamale', '9999-4', 18))
 
     def test_subpart_scope(self):
         t = Terms(None)
@@ -378,13 +378,13 @@ class LayerTermTest(TestCase):
         t.pre_process()
 
         self.assertTrue(('88',) in t.scoped_terms)
-        self.assertEqual([Ref('abcd', '88-1', (44, 48))],
+        self.assertEqual([Ref('abcd', '88-1', 44)],
                          t.scoped_terms[('88',)])
         self.assertTrue(('88', '2') in t.scoped_terms)
-        self.assertEqual([Ref('axax', '88-2-a-1', (1, 5))],
+        self.assertEqual([Ref('axax', '88-2-a-1', 1)],
                          t.scoped_terms[('88', '2')])
         self.assertTrue(('88', '2', 'b', 'i', 'A') in t.scoped_terms)
-        self.assertEqual([Ref('awesome sauce', '88-2-b-i-A', (13, 26))],
+        self.assertEqual([Ref('awesome sauce', '88-2-b-i-A', 13)],
                          t.scoped_terms[('88', '2', 'b', 'i', 'A')])
 
         #   Check subparts are correct
@@ -447,17 +447,17 @@ class LayerTermTest(TestCase):
     def test_excluded_offsets(self):
         t = Terms(None)
         t.scoped_terms['_'] = [
-            Ref('term', 'lablab', (4, 6)), Ref('other', 'lablab', (8, 9)),
-            Ref('more', 'nonnon', (1, 8))
+            Ref('term', 'lablab', 4), Ref('other', 'lablab', 8),
+            Ref('more', 'nonnon', 1)
         ]
-        self.assertEqual([(4, 6), (8, 9)],
+        self.assertEqual([(4, 8), (8, 13)],
                          t.excluded_offsets('lablab', 'Some text'))
-        self.assertEqual([(1, 8)], t.excluded_offsets('nonnon', 'Other'))
+        self.assertEqual([(1, 5)], t.excluded_offsets('nonnon', 'Other'))
         self.assertEqual([], t.excluded_offsets('ababab', 'Ab ab ab'))
 
     def test_excluded_offsets_blacklist(self):
         t = Terms(None)
-        t.scoped_terms['_'] = [Ref('bourgeois', '12-Q-2', 'Def')]
+        t.scoped_terms['_'] = [Ref('bourgeois', '12-Q-2', 0)]
         settings.IGNORE_DEFINITIONS_IN['ALL'] = ['bourgeois pig']
         excluded = t.excluded_offsets('12-3', 'You are a bourgeois pig!')
         self.assertEqual([(10, 23)], excluded)
@@ -466,8 +466,8 @@ class LayerTermTest(TestCase):
         t = Terms(None)
 
         t.scoped_terms['_'] = [
-            Ref('bourgeois', '12-Q-2', 'Def'),
-            Ref('consumer', '12-Q-3', 'Def')]
+            Ref('bourgeois', '12-Q-2', 0),
+            Ref('consumer', '12-Q-3', 0)]
 
         settings.IGNORE_DEFINITIONS_IN['ALL'] = ['bourgeois pig']
         settings.IGNORE_DEFINITIONS_IN['12'] = ['consumer price index']
@@ -478,7 +478,7 @@ class LayerTermTest(TestCase):
 
     def test_excluded_offsets_blacklist_word_boundaries(self):
         t = Terms(None)
-        t.scoped_terms['_'] = [Ref('act', '28-6-d', 'Def def def')]
+        t.scoped_terms['_'] = [Ref('act', '28-6-d', 0)]
         settings.IGNORE_DEFINITIONS_IN['ALL'] = ['shed act']
         excluded = t.excluded_offsets('28-9', "That's a watershed act")
         self.assertEqual([], excluded)
@@ -578,15 +578,15 @@ class LayerTermTest(TestCase):
         ]))
         t.scoped_terms = {
             ("101", "22", "b", "2", "ii"): [
-                Ref("abc", "ref1", (1, 2)),
-                Ref("aabbcc", "ref2", (2, 3))],
+                Ref("abc", "ref1", 1),
+                Ref("aabbcc", "ref2", 2)],
             ("101", "22", "b"): [
-                Ref("abc", "ref3", (3, 4)),
-                Ref("aaa", "ref4", (4, 5)),
-                Ref("abcabc", "ref5", (5, 6))],
+                Ref("abc", "ref3", 3),
+                Ref("aaa", "ref4", 4),
+                Ref("abcabc", "ref5", 5)],
             ("101", "22", "b", "2", "iii"): [
-                Ref("abc", "ref6", (6, 7)),
-                Ref("zzz", "ref7", (7, 8))]}
+                Ref("abc", "ref6", 6),
+                Ref("zzz", "ref7", 7)]}
         #   Check that the return value is correct
         layer_el = t.process(Node(
             "This has abc, aabbcc, aaa, abcabc, and zzz",
@@ -614,7 +614,7 @@ class LayerTermTest(TestCase):
         ], label=['AB'])
         t = Terms(tree)
         t.scoped_terms = {
-            ('AB',): [Ref("secret phrase", "AB-a", (9, 22))]
+            ('AB',): [Ref("secret phrase", "AB-a", 9)]
         }
         #   Term is defined in the first child
         self.assertEqual([], t.process(tree.children[0]))

--- a/tests/layer_terms_tests.py
+++ b/tests/layer_terms_tests.py
@@ -30,117 +30,21 @@ class LayerTermTest(TestCase):
         t.scoped_terms = {('1111',): [Ref('abc', '1', 0)]}
         self.assertFalse(t.is_exclusion('ex', n))
 
-    def test_node_definitions(self):
+    def test_node_definitions_no_def(self):
+        """Verify that none of the matchers match certain strings"""
         t = Terms(None)
-        smart_quotes = [
-            (u'This has a “worD” and then more',
-             [Ref('word', 'aaa', 12)]),
-            (u'I have “anotheR word” term and “moree”',
-             [Ref('another word', 'bbb', 8),
-              Ref('moree', 'bbb', 32)]),
-            (u'But the child “DoeS sEe”?',
-             [Ref('does see', 'ccc', 15)]),
-            (u'Start with “this,”', [Ref('this', 'hhh', 12)]),
-            (u'Start with “this;”', [Ref('this', 'iii', 12)]),
-            (u'Start with “this.”', [Ref('this', 'jjj', 12)]),
-            (u'As do “subchildren”',
-             [Ref('subchildren', 'ddd', 7)])]
-
-        no_defs = [
-            u'This has no defs',
-            u'Also has no terms',
-            u'Still no terms, but',
-            u'the next one does']
-
-        xml_defs = [
-            (u'(4) Thing means a thing that is defined',
-                u'(4) <E T="03">Thing</E> means a thing that is defined',
-                Ref('thing', 'eee', 4)),
-            (u'(e) Well-meaning lawyers means people who do weird things',
-                u'(e) <E T="03">Well-meaning lawyers</E> means people who do '
-                + 'weird things',
-                Ref('well-meaning lawyers', 'fff', 4)),
-            (u'(e) Words have the same meaning as in a dictionary',
-                u'(e) <E T="03">Words</E> have the same meaning as in a '
-                + 'dictionary',
-                Ref('words', 'ffg', 4)),
-            (u'(e) Banana has the same meaning as bonono',
-                u'(e) <E T="03">Banana</E> has the same meaning as bonono',
-                Ref('banana', 'fgf', 4)),
-            (u'(f) Huge billowy clouds means I want to take a nap',
-                u'(f) <E T="03">Huge billowy clouds</E> means I want to take '
-                + 'a nap',
-                Ref('huge billowy clouds', 'ggg', 4)),
-            (u'(v) Lawyers, in relation to coders, means something very '
-             + 'different',
-                u'(v) <E T="03">Lawyers</E>, in relation to coders, means '
-                + 'something very different',
-                Ref(u'lawyers', '', 4)),
-        ]
-
-        xml_no_defs = [
-            (u'(d) Term1 or term2 means stuff',
-             u'(d) <E T="03">Term1</E> or <E T="03">term2></E> means stuff'),
-        ]
-
-        scope_term_defs = [
-            ('For purposes of this section, the term blue means the color',
-             Ref('blue', '11-11', 39)),
-            ('For purposes of paragraph (a)(1) of this section, the term '
-             + 'cool bro means hip cat', Ref('cool bro', '11-22', 59)),
-            ('For purposes of this paragraph, po jo means "poor Joe"',
-             Ref('po jo', '11-33', 32))]
-
         stack = ParentStack()
         stack.add(0, Node(label=['999']))
-        for txt in no_defs:
-            defs, exc = t.node_definitions(Node(txt), stack)
-            self.assertEqual([], defs)
-            self.assertEqual([], exc)
-        for txt, refs in smart_quotes:
-            defs, exc = t.node_definitions(Node(txt), stack)
-            self.assertEqual([], defs)
-            self.assertEqual([], exc)
-        for txt, xml in xml_no_defs:
-            node = Node(txt)
-            node.tagged_text = xml
-            defs, exc = t.node_definitions(node, stack)
-            self.assertEqual([], defs)
-            self.assertEqual([], exc)
-        for txt, xml, ref in xml_defs:
-            node = Node(txt, label=[ref.label])
-            node.tagged_text = xml
-            defs, exc = t.node_definitions(node, stack)
-            self.assertEqual([ref], defs)
-            self.assertEqual([], exc)
-        for txt, ref in scope_term_defs:
-            defs, exc = t.node_definitions(
-                Node(txt, label=ref.label.split('-')), stack)
-            self.assertEqual([ref], defs)
-            self.assertEqual([], exc)
-
-        #   smart quotes are affected by the parent
         stack.add(1, Node('Definitions', label=['999', '1']))
+
+        no_defs = ['This has no defs',
+                   'Also has no terms',
+                   'Still no terms, but',
+                   'the next one does']
+
         for txt in no_defs:
             defs, exc = t.node_definitions(Node(txt), stack)
             self.assertEqual([], defs)
-            self.assertEqual([], exc)
-        for txt, refs in smart_quotes:
-            defs, exc = t.node_definitions(Node(txt, label=[refs[0].label]),
-                                           stack)
-            self.assertEqual(refs, defs)
-            self.assertEqual([], exc)
-        for txt, xml in xml_no_defs:
-            node = Node(txt)
-            node.tagged_text = xml
-            defs, exc = t.node_definitions(node, stack)
-            self.assertEqual([], defs)
-            self.assertEqual([], exc)
-        for txt, xml, ref in xml_defs:
-            node = Node(txt, label=[ref.label])
-            node.tagged_text = xml
-            defs, exc = t.node_definitions(node, stack)
-            self.assertEqual([ref], defs)
             self.assertEqual([], exc)
 
     def test_node_defintions_act(self):

--- a/tests/layer_terms_tests.py
+++ b/tests/layer_terms_tests.py
@@ -1,67 +1,18 @@
 # vim: set fileencoding=utf-8
-from regparser.layer.terms import ParentStack, Ref, Terms
+from regparser.layer.terms import ParentStack, Terms
+from regparser.layer.def_finders import Ref
 from regparser.tree.struct import Node
 import settings
 from unittest import TestCase
 
 
 class LayerTermTest(TestCase):
-
     def setUp(self):
         self.original_ignores = settings.IGNORE_DEFINITIONS_IN
         settings.IGNORE_DEFINITIONS_IN = {'ALL': {}}
 
     def tearDown(self):
         settings.IGNORE_DEFINITIONS_IN = self.original_ignores
-
-    def test_has_parent_definitions_indicator(self):
-        t = Terms(None)
-        stack = ParentStack()
-        stack.add(0, Node("This has no defs"))
-        self.assertFalse(t.has_parent_definitions_indicator(stack))
-        stack.add(1, Node("No Def", title="No def"))
-        self.assertFalse(t.has_parent_definitions_indicator(stack))
-        stack.add(2, Node("Tomatoes do not meet the definition 'vegetable'"))
-        self.assertFalse(t.has_parent_definitions_indicator(stack))
-
-        stack.add(3, Node("Definition. This has a definition."))
-        self.assertTrue(t.has_parent_definitions_indicator(stack))
-        stack.pop()
-        self.assertFalse(t.has_parent_definitions_indicator(stack))
-
-        stack.add(3, Node("Definitions. This has multiple!"))
-        self.assertTrue(t.has_parent_definitions_indicator(stack))
-        stack.pop()
-        self.assertFalse(t.has_parent_definitions_indicator(stack))
-
-        stack.add(3, Node("No body", title="But Definition is in the title"))
-        self.assertTrue(t.has_parent_definitions_indicator(stack))
-
-    def test_has_parent_definitions_indicator_p_marker(self):
-        t = Terms(None)
-        stack = ParentStack()
-        stack.add(0, Node("(a) Definitions. For purposes of this " +
-                          "section except blah"))
-        self.assertTrue(t.has_parent_definitions_indicator(stack))
-
-    def test_has_parent_definitions_indicator_the_term_means(self):
-        t = Terms(None)
-        stack = ParentStack()
-        stack.add(0, Node('Contains no terms or definitions'))
-        self.assertFalse(t.has_parent_definitions_indicator(stack))
-        stack.add(1, Node("(a) The term Bob means awesome"))
-        self.assertTrue(t.has_parent_definitions_indicator(stack))
-        stack.add(2, Node("No defs either"))
-        self.assertTrue(t.has_parent_definitions_indicator(stack))
-
-        stack.pop()
-        stack.pop()
-        stack.add(1, Node(u"(a) “Term” means some stuff"))
-        self.assertTrue(t.has_parent_definitions_indicator(stack))
-
-        stack.pop()
-        stack.add(1, Node("(a) The term Bob refers to"))
-        self.assertTrue(t.has_parent_definitions_indicator(stack))
 
     def test_is_exclusion(self):
         t = Terms(None)
@@ -102,32 +53,35 @@ class LayerTermTest(TestCase):
             u'the next one does']
 
         xml_defs = [
-                (u'(4) Thing means a thing that is defined',
-                    u'(4) <E T="03">Thing</E> means a thing that is defined',
-                    Ref('thing', 'eee', 4)),
-                (u'(e) Well-meaning lawyers means people who do weird things',
-                    u'(e) <E T="03">Well-meaning lawyers</E> means people who do '
-                    + 'weird things',
-                    Ref('well-meaning lawyers', 'fff', 4)),
-                (u'(e) Words have the same meaning as in a dictionary',
-                    u'(e) <E T="03">Words</E> have the same meaning as in a '
-                    + 'dictionary',
-                    Ref('words', 'ffg', 4)),
-                (u'(e) Banana has the same meaning as bonono',
-                    u'(e) <E T="03">Banana</E> has the same meaning as bonono',
-                    Ref('banana', 'fgf', 4)),
-                (u'(f) Huge billowy clouds means I want to take a nap',
-                    u'(f) <E T="03">Huge billowy clouds</E> means I want to take a '
-                    + 'nap',
-                    Ref('huge billowy clouds', 'ggg', 4)),
-                (u'(v) Lawyers, in relation to coders, means something very different',
-                    u'(v) <E T="03">Lawyers</E>, in relation to coders, means something very different',
-                    Ref(u'lawyers', '', 4)),
-            ]
+            (u'(4) Thing means a thing that is defined',
+                u'(4) <E T="03">Thing</E> means a thing that is defined',
+                Ref('thing', 'eee', 4)),
+            (u'(e) Well-meaning lawyers means people who do weird things',
+                u'(e) <E T="03">Well-meaning lawyers</E> means people who do '
+                + 'weird things',
+                Ref('well-meaning lawyers', 'fff', 4)),
+            (u'(e) Words have the same meaning as in a dictionary',
+                u'(e) <E T="03">Words</E> have the same meaning as in a '
+                + 'dictionary',
+                Ref('words', 'ffg', 4)),
+            (u'(e) Banana has the same meaning as bonono',
+                u'(e) <E T="03">Banana</E> has the same meaning as bonono',
+                Ref('banana', 'fgf', 4)),
+            (u'(f) Huge billowy clouds means I want to take a nap',
+                u'(f) <E T="03">Huge billowy clouds</E> means I want to take '
+                + 'a nap',
+                Ref('huge billowy clouds', 'ggg', 4)),
+            (u'(v) Lawyers, in relation to coders, means something very '
+             + 'different',
+                u'(v) <E T="03">Lawyers</E>, in relation to coders, means '
+                + 'something very different',
+                Ref(u'lawyers', '', 4)),
+        ]
 
         xml_no_defs = [
             (u'(d) Term1 or term2 means stuff',
-             u'(d) <E T="03">Term1</E> or <E T="03">term2></E> means stuff'),]
+             u'(d) <E T="03">Term1</E> or <E T="03">term2></E> means stuff'),
+        ]
 
         scope_term_defs = [
             ('For purposes of this section, the term blue means the color',
@@ -266,87 +220,6 @@ class LayerTermTest(TestCase):
         self.assertEqual(hot, Ref('hot tamale', '9999-4', 4))
         self.assertEqual(tamale, Ref('tamale', '9999-4', 18))
 
-    def test_subpart_scope(self):
-        t = Terms(None)
-        t.subpart_map = {
-            None: ['1', '2', '3'],
-            'A': ['7', '5', '0'],
-            'Q': ['99', 'abc', 'q']
-        }
-        self.assertEqual([['111', '1'], ['111', '2'], ['111', '3']],
-                         t.subpart_scope(['111', '3']))
-        self.assertEqual([['115', '7'], ['115', '5'], ['115', '0']],
-                         t.subpart_scope(['115', '5']))
-        self.assertEqual([['62', '99'], ['62', 'abc'], ['62', 'q']],
-                         t.subpart_scope(['62', 'abc']))
-        self.assertEqual([], t.subpart_scope(['71', 'Z']))
-
-    def test_determine_scope(self):
-        stack = ParentStack()
-        t = Terms(None)
-
-        stack.add(0, Node(label=['1000']))
-        stack.add(1, Node(label=['1000', '1']))
-
-        # Defaults to the entire reg
-        self.assertEqual([('1000',)], t.determine_scope(stack))
-
-        stack.add(1, Node('For the purposes of this part, blah blah',
-                          label=['1001', '2']))
-        self.assertEqual([('1001',), ('1001', Node.INTERP_MARK)],
-                         t.determine_scope(stack))
-
-        t.subpart_map = {
-            'SubPart 1': ['A', '3'],
-            'Other': []
-        }
-        stack.add(1, Node(label=['1000', '3']))
-        stack.add(2, Node('For the purposes of this subpart, yada yada',
-                          label=['1000', '3', 'c']))
-        self.assertEqual([('1000', 'A'), ('1000', '3'),
-                          ('1000', 'A', Node.INTERP_MARK),
-                          ('1000', '3', Node.INTERP_MARK)],
-                         t.determine_scope(stack))
-
-        stack.add(2, Node('For the purposes of this section, blah blah',
-                          label=['1000', '3', 'd']))
-        self.assertEqual([('1000', '3'), ('1000', '3', Node.INTERP_MARK)],
-                         t.determine_scope(stack))
-
-        stack.add(3, Node('For the purposes of this paragraph, blah blah',
-                          label=['1000', '3', 'd', '5']))
-        self.assertEqual([('1000', '3', 'd', '5'),
-                          ('1000', '3', 'd', '5', Node.INTERP_MARK)],
-                         t.determine_scope(stack))
-
-        stack.add(3, Node(label=['1002', '3', 'd', '6']))
-        self.assertEqual([('1000', '3'), ('1000', '3', Node.INTERP_MARK)],
-                         t.determine_scope(stack))
-
-        stack.add(3, Node('Blah as used in this paragraph, blah blah',
-                          label=['1000', '3', 'd', '7']))
-        self.assertEqual([('1000', '3', 'd', '7'),
-                          ('1000', '3', 'd', '7', Node.INTERP_MARK)],
-                         t.determine_scope(stack))
-
-        stack.add(4, Node(u'For the purposes of this § 1000.3(d)(6)(i), blah',
-                          label=['1000', '3', 'd', '6', 'i']))
-        self.assertEqual([('1000', '3', 'd', '6', 'i'),
-                          ('1000', '3', 'd', '6', 'i', Node.INTERP_MARK)],
-                         t.determine_scope(stack))
-
-        stack.add(4, Node(u'For the purposes of § 1000.3, blah',
-                          label=['1000', '3', 'd', '6', 'ii']))
-        self.assertEqual([('1000', '3'),
-                          ('1000', '3', Node.INTERP_MARK)],
-                         t.determine_scope(stack))
-
-        stack.add(4, Node('As used in this section, blah blah',
-                          label=['1000', '3', 'd', '6', 'iii']))
-        self.assertEqual(
-            [('1000', '3'), ('1000', '3', Node.INTERP_MARK)],
-            t.determine_scope(stack))
-
     def test_pre_process(self):
         noname_subpart = Node(
             '',
@@ -388,7 +261,8 @@ class LayerTermTest(TestCase):
                          t.scoped_terms[('88', '2', 'b', 'i', 'A')])
 
         #   Check subparts are correct
-        self.assertEqual({None: ['1'], 'XQXQ': ['2']}, dict(t.subpart_map))
+        self.assertEqual({None: ['1'], 'XQXQ': ['2']},
+                         dict(t.scope_finder.subpart_map))
 
         # Finally, make sure the references are added
         referenced = t.layer['referenced']
@@ -421,11 +295,11 @@ class LayerTermTest(TestCase):
                          (10, 13))
 
     def test_pre_process_subpart(self):
-        root = Node("", label=['1212'])
-        subpartA = Node("", label=['1212', 'Subpart', 'A'], title='Subpart A')
-        section2 = Node("", label=['1212', '2'], title='1212.2')
+        root = Node(label=['1212'])
+        subpartA = Node(label=['1212', 'Subpart', 'A'], title='Subpart A')
+        section2 = Node(label=['1212', '2'], title='1212.2')
         def1 = Node(u"“totes” means in total", label=['1212', '2', 'a'])
-        subpartB = Node("", label=['1212', 'Subpart', 'B'], title='Subpart B')
+        subpartB = Node(label=['1212', 'Subpart', 'B'], title='Subpart B')
         section22 = Node("\nFor the purposes of this subpart",
                          label=['1212', '22'], title='1212.22')
         def2 = Node(u"“totes” means in extremely", label=['1212', '22', 'a'])


### PR DESCRIPTION
Highlights:
* The various matchers for finding definitions have been split out into individual classes. This should be easier to maintain and extend in the future
* Similarly, the logic around determining scope for a definition has been moved to a separate class
* The `Ref` class no longer needs a pair for position (it calculates the end point by adding the term's length). It also automatically lower-cases the term (rather than relying on its caller)
* Split up tests a bit
* Flake8 all the things
* Fixed bug in `INCLUDE_DEFINITIONS_IN` code (referencing a variable which did not exist)

This should not change any functionality