### PR TITLE
Use what would be keyterms in place of definition

### DIFF
--- a/regparser/grammar/terms.py
+++ b/regparser/grammar/terms.py
@@ -1,7 +1,7 @@
-#vim: set encoding=utf-8
+# vim: set encoding=utf-8
 from pyparsing import (
     LineStart, Literal, OneOrMore, Optional, Regex, SkipTo, srange, Suppress,
-    Word, ZeroOrMore, NotAny)
+    Word, ZeroOrMore)
 
 from regparser.grammar import atomic, unified
 from regparser.grammar.utils import DocLiteral, keep_pos, Marker
@@ -36,6 +36,17 @@ xml_term_parser = (
        | (Marker("refers") + ZeroOrMore(Marker("only")) + Marker("to"))
        | ((Marker("has") | Marker("have")) + Marker("the") + Marker("same")
           + Marker("meaning") + Marker("as")))
+)
+
+key_term_parser = (
+    LineStart()
+    + Optional(Suppress(unified.any_depth_p))
+    + Suppress(Regex(r"<E[^>]*>"))
+    + OneOrMore(
+        Word(srange("[a-zA-Z-]"))
+    ).setParseAction(keep_pos).setResultsName("term")
+    + Optional(Suppress("."))
+    + Suppress(Literal("</E>"))
 )
 
 scope_term_type_parser = (

--- a/regparser/grammar/terms.py
+++ b/regparser/grammar/terms.py
@@ -43,7 +43,7 @@ key_term_parser = (
     + Optional(Suppress(unified.any_depth_p))
     + Suppress(Regex(r"<E[^>]*>"))
     + OneOrMore(
-        Word(srange("[a-zA-Z-]"))
+        Word(srange("[a-zA-Z-,]"))
     ).setParseAction(keep_pos).setResultsName("term")
     + Optional(Suppress("."))
     + Suppress(Literal("</E>"))

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -37,6 +37,17 @@ class Node(object):
     def label_id(self):
         return '-'.join(self.label)
 
+    def depth(self):
+        """Inspect the label and type to determine the node's depth"""
+        if len(self.label) > 1 and self.node_type == self.REGTEXT:
+            #   Add one for the subpart level
+            return len(self.label) + 1
+        elif self.node_type in (self.SUBPART, self.EMPTYPART):
+            #   Subparts all on the same level
+            return 2
+        else:
+            return len(self.label)
+
 
 class NodeEncoder(JSONEncoder):
     """Custom JSON encoder to handle Node objects"""

--- a/tests/layer_def_finders_tests.py
+++ b/tests/layer_def_finders_tests.py
@@ -203,3 +203,12 @@ class DefinitionKeytermTest(TestCase):
         self.assert_finds_result(
             '<E T="03">Another Phrase.</E>. Paragraph text', 'Definition',
             def_finders.Ref('another phrase', None, 0))
+        self.assert_finds_result(
+            '<E T="03">Officer, office.</E>. Paragraph text', 'Definition',
+            def_finders.Ref('officer, office', None, 0))
+        """ @todo
+        self.assert_finds_result(
+            '<E T="03">Frame or receiver.</E>. Paragraph text', 'Definition',
+            def_finders.Ref('frame', None, 0),
+            def_finders.Ref('receiver', None, 9))
+        """


### PR DESCRIPTION
... but only when several conditions also apply.

Builds off #63 ([diff](https://github.com/cmc333333/regulations-parser/compare/cmc333333:refactor-terms...cmc333333:term-improvements))

This also adds a `depth` method to nodes as it is probably more applicable than just the definitions layer.