### PR TITLE
Speed up depth parsing

### DIFF
--- a/regparser/tree/depth/derive.py
+++ b/regparser/tree/depth/derive.py
@@ -129,7 +129,7 @@ def derive_depths(original_markers, additional_constraints=[]):
 
     # @todo: There's probably efficiency gains to making these rules over
     # prefixes (see above) rather than over the whole collection at once
-    problem.addConstraint(rules.same_depth_same_type, all_vars)
+    problem.addConstraint(rules.same_parent_same_type, all_vars)
     problem.addConstraint(rules.stars_occupy_space, all_vars)
 
     for constraint in additional_constraints:

--- a/regparser/tree/depth/derive.py
+++ b/regparser/tree/depth/derive.py
@@ -117,6 +117,7 @@ def derive_depths(original_markers, additional_constraints=[]):
         if idx > 1:
             pairs = all_vars[3*(idx-2):]
             problem.addConstraint(rules.markerless_sandwich, pairs)
+            problem.addConstraint(rules.star_sandwich, pairs)
 
     # separate loop so that the simpler checks run first
     for idx in range(1, len(marker_list)):

--- a/regparser/tree/depth/derive.py
+++ b/regparser/tree/depth/derive.py
@@ -113,7 +113,6 @@ def derive_depths(original_markers, additional_constraints=[]):
         if idx > 0:
             pairs = all_vars[3*(idx-1):]
             problem.addConstraint(rules.depth_check, pairs)
-            problem.addConstraint(rules.stars_check, pairs)
 
         if idx > 1:
             pairs = all_vars[3*(idx-2):]

--- a/regparser/tree/depth/markers.py
+++ b/regparser/tree/depth/markers.py
@@ -6,10 +6,10 @@ import string
 from regparser.utils import roman_nums
 
 
-lower = tuple(string.ascii_lowercase) + \
-        tuple(a+a for a in string.ascii_lowercase)
-upper = tuple(string.ascii_uppercase) + \
-        tuple(a+a for a in string.ascii_uppercase)
+lower = (tuple(string.ascii_lowercase)
+         + tuple(a+a for a in string.ascii_lowercase if a != 'i'))
+upper = (tuple(string.ascii_uppercase)
+         + tuple(a+a for a in string.ascii_uppercase))
 ints = tuple(str(i) for i in range(1, 51))
 roman = tuple(itertools.islice(roman_nums(), 0, 50))
 em_ints = tuple('<E T="03">' + i + '</E>' for i in ints)

--- a/regparser/tree/depth/rules.py
+++ b/regparser/tree/depth/rules.py
@@ -168,6 +168,8 @@ def global_same_depth_same_type(constrain, all_variables):
             prev_typ, prev_idx, prev_depth = all_prev[i:i+3]
             if prev_depth == depth and prev_typ not in (markers.stars, typ):
                 return False
+            if prev_typ == typ and prev_depth != depth:
+                return False
         return True
 
     for i in range(0, len(all_variables), 3):

--- a/regparser/tree/depth/rules.py
+++ b/regparser/tree/depth/rules.py
@@ -65,6 +65,27 @@ def markerless_sandwich(pprev_typ, pprev_idx, pprev_depth,
     return not (sandwich and inc_depth)
 
 
+def star_sandwich(pprev_typ, pprev_idx, pprev_depth,
+                  prev_typ, prev_idx, prev_depth,
+                  typ, idx, depth):
+    """Symmetry breaking constraint that places STARS tag at specific depth so
+    that the resolution of
+
+                    c
+    ?   ?   ?   ?   ?   ?   <- Potential STARS depths
+    5
+
+    can only be one of
+                                OR
+                    c                               c
+                    STARS           STARS
+    5                               5"""
+    sandwich = (pprev_typ != markers.stars and typ != markers.stars
+                and prev_typ == markers.stars and prev_idx == 0)
+    unwinding = pprev_depth > depth
+    return not (sandwich and unwinding) or (prev_depth in (pprev_depth, depth))
+
+
 def sequence(typ, idx, depth, *all_prev):
     """Constrain the current marker based on all markers leading up to it"""
     # Group (type, idx, depth) per marker

--- a/regparser/tree/depth/rules.py
+++ b/regparser/tree/depth/rules.py
@@ -79,11 +79,15 @@ def star_sandwich(pprev_typ, pprev_idx, pprev_depth,
                                 OR
                     c                               c
                     STARS           STARS
-    5                               5"""
+    5                               5
+    Stars also cannot be used to skip a level (similar to markerless sandwich,
+    above)"""
     sandwich = (pprev_typ != markers.stars and typ != markers.stars
-                and prev_typ == markers.stars and prev_idx == 0)
-    unwinding = pprev_depth > depth
-    return not (sandwich and unwinding) or (prev_depth in (pprev_depth, depth))
+                and prev_typ == markers.stars)
+    unwinding = prev_idx == 0 and pprev_depth > depth
+    bad_unwinding = unwinding and prev_depth not in (pprev_depth, depth)
+    inc_depth = depth == prev_depth + 1 and prev_depth == pprev_depth + 1
+    return not (sandwich and (bad_unwinding or inc_depth))
 
 
 def sequence(typ, idx, depth, *all_prev):
@@ -188,7 +192,7 @@ def depth_type_order(order):
     return inner
 
 
-def global_same_depth_same_type(constrain, all_variables):
+def depth_type_inverses(constrain, all_variables):
     def inner(typ, idx, depth, *all_prev):
         if typ == markers.stars:
             return True

--- a/regparser/tree/depth/rules.py
+++ b/regparser/tree/depth/rules.py
@@ -18,31 +18,38 @@ def type_match(marker):
 
 def depth_check(prev_typ, prev_idx, prev_depth, typ, idx, depth):
     """Constrain the depth of sequences of markers."""
-    # decrementing depth is always okay
-    dec = depth < prev_depth
+    # decrementing depth is okay unless inline stars
+    dec = depth < prev_depth and not (typ == markers.stars and idx == 1)
     # continuing a sequence
     cont = depth == prev_depth and prev_typ == typ and idx == prev_idx + 1
-    # stars are also allowed if at the same level
-    stars = depth == prev_depth and markers.stars in (typ, prev_typ)
+    stars = _stars_check(prev_typ, prev_idx, prev_depth, typ, idx, depth)
     # depth can be incremented if starting a new sequence
     inc = depth == prev_depth + 1 and idx == 0 and typ != prev_typ
-    # stars can also increment the depth
-    next_star = depth == prev_depth + 1 and typ == markers.stars
     # markerless in sequence must have the same level
     mless_seq = (prev_typ == typ and prev_depth == depth
                  and typ == markers.markerless)
-    return dec or cont or stars or inc or next_star or mless_seq
+    return dec or cont or stars or inc or mless_seq
 
 
-def stars_check(prev_typ, prev_idx, prev_depth, typ, idx, depth):
+def _stars_check(prev_typ, prev_idx, prev_depth, typ, idx, depth):
     """Constrain pairs of markers where one is a star."""
-    if prev_typ == typ and typ == markers.stars:
-        # Stars can't be on the same level in sequence
+    # Seq of stars
+    if prev_typ == markers.stars and typ == prev_typ:
+        # Decreasing depth is always okay
         dec = depth < prev_depth
-        # and can only increase the depth in the previous was INLINE
-        inc = prev_idx == 1 and depth == prev_depth + 1
-        return dec or inc
-    return True
+        # Can only be on the same level if prev is inline
+        same = depth == prev_depth and prev_idx == 1
+        return dec or same
+    # Marker following stars
+    elif prev_typ == markers.stars:
+        return depth == prev_depth
+    # Inline Stars following marker
+    elif typ == markers.stars and idx == 1:
+        return depth == prev_depth + 1
+    elif typ == markers.stars:
+        return depth in (prev_depth, prev_depth + 1)
+    else:
+        return False
 
 
 def markerless_sandwich(pprev_typ, pprev_idx, pprev_depth,

--- a/regparser/tree/depth/rules.py
+++ b/regparser/tree/depth/rules.py
@@ -86,7 +86,7 @@ def sequence(typ, idx, depth, *all_prev):
     return False
 
 
-def same_depth_same_type(*all_vars):
+def same_parent_same_type(*all_vars):
     """All markers in the same level (with the same parent) should have the
     same marker type"""
     elements = [tuple(all_vars[i:i+3]) for i in range(0, len(all_vars), 3)]
@@ -158,6 +158,20 @@ def depth_type_order(order):
                       ('type' + str(i), 'depth' + str(i)))
 
     return inner
+
+
+def global_same_depth_same_type(constrain, all_variables):
+    def inner(typ, idx, depth, *all_prev):
+        if typ == markers.stars:
+            return True
+        for i in range(0, len(all_prev), 3):
+            prev_typ, prev_idx, prev_depth = all_prev[i:i+3]
+            if prev_depth == depth and prev_typ not in (markers.stars, typ):
+                return False
+        return True
+
+    for i in range(0, len(all_variables), 3):
+        constrain(inner, all_variables[i:i+3] + all_variables[:i])
 
 
 def _ancestors(all_prev):

--- a/regparser/tree/depth/rules.py
+++ b/regparser/tree/depth/rules.py
@@ -193,6 +193,8 @@ def depth_type_order(order):
 
 
 def depth_type_inverses(constrain, all_variables):
+    """If paragraphs are at the same depth, they must share the same type. If
+    paragraphs are the same type, they must share the same depth"""
     def inner(typ, idx, depth, *all_prev):
         if typ == markers.stars:
             return True

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -96,7 +96,7 @@ class ParagraphProcessor(object):
             root.tagged_text += " " + intro_node.tagged_text
         if nodes:
             markers = [node.label[0] for node in nodes]
-            depths = derive_depths(markers)
+            depths = derive_depths(markers, self.additional_constraints())
             if not depths:
                 logging.error(
                     "Could not determine paragraph depths:\n%s", markers)
@@ -104,6 +104,9 @@ class ParagraphProcessor(object):
             return self.build_hierarchy(root, nodes, depths)
         else:
             return root
+
+    def additional_constraints(self):
+        return []
 
 
 class StarsMatcher(object):

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -106,6 +106,7 @@ class ParagraphProcessor(object):
             return root
 
     def additional_constraints(self):
+        """Hook for subtypes to add additional constraints"""
         return []
 
 

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -294,4 +294,4 @@ class RegtextParagraphProcessor(paragraph_processor.ParagraphProcessor):
                 NoMarkerMatcher()]
 
     def additional_constraints(self):
-        return [rules.global_same_depth_same_type]
+        return [rules.depth_type_inverses]

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -4,7 +4,7 @@ import re
 from lxml import etree
 
 from regparser import content
-from regparser.tree.depth import markers as mtypes
+from regparser.tree.depth import markers as mtypes, rules
 from regparser.tree.struct import Node
 from regparser.tree.paragraph import p_level_of
 from regparser.tree.xml_parser import paragraph_processor
@@ -109,10 +109,12 @@ def build_tree(reg_xml):
 
     return tree
 
+
 def get_subpart_title(subpart_xml):
     hds = subpart_xml.xpath('./RESERVED|./HD')
     if hds:
         return [hd.text for hd in hds][0]
+
 
 def get_subjgrp_title(subjgrp_xml):
     hds = subjgrp_xml.xpath('./RESERVED|./HD')
@@ -132,9 +134,10 @@ def build_subpart(reg_part, subpart_xml):
     subpart.children = sections
     return subpart
 
+
 def build_subjgrp(reg_part, subjgrp_xml, letter_list):
-    # This handles subjgrps that have been pulled out and injected into the same
-    # level as subparts.
+    # This handles subjgrps that have been pulled out and injected into the
+    # same level as subparts.
     subjgrp_title = get_subjgrp_title(subjgrp_xml)
     letter_list, subjgrp = reg_text.build_subjgrp(subjgrp_title, reg_part,
                                                   letter_list)
@@ -146,6 +149,7 @@ def build_subjgrp(reg_part, subjgrp_xml, letter_list):
 
     subjgrp.children = sections
     return subjgrp
+
 
 def get_markers(text):
     """ Extract all the paragraph markers from text. Do some checks on the
@@ -288,3 +292,6 @@ class RegtextParagraphProcessor(paragraph_processor.ParagraphProcessor):
                 paragraph_processor.TableMatcher(),
                 MarkerMatcher(),
                 NoMarkerMatcher()]
+
+    def additional_constraints(self):
+        return [rules.global_same_depth_same_type]

--- a/tests/tree_depth_derive_tests.py
+++ b/tests/tree_depth_derive_tests.py
@@ -65,9 +65,7 @@ class DeriveTests(TestCase):
     def test_ambiguous_stars(self):
         self.assert_depth_match(['A', '1', 'a', STARS_TAG, 'B'],
                                 [0, 1, 2, 3, 3],
-                                [0, 1, 2, 3, 0],
-                                [0, 1, 2, 2, 0],
-                                [0, 1, 2, 1, 0])
+                                [0, 1, 2, 2, 0])
 
     def test_double_stars(self):
         self.assert_depth_match(['A', '1', 'a', STARS_TAG, STARS_TAG, 'B'],

--- a/tests/tree_depth_derive_tests.py
+++ b/tests/tree_depth_derive_tests.py
@@ -95,16 +95,14 @@ class DeriveTests(TestCase):
                                 [0, 1, 0])
 
         self.assert_depth_match(['1', INLINE_STARS, '2'],
-                                [0, 0, 0],
                                 [0, 1, 0])
 
     def test_star_star(self):
         self.assert_depth_match(['A', STARS_TAG, STARS_TAG, 'D'],
                                 [0, 1, 0, 0])
 
-        self.assert_depth_match(['A', INLINE_STARS, STARS_TAG, 'D'],
-                                [0, 1, 2, 2],
-                                [0, 1, 0, 0])
+        self.assert_depth_match(['A', INLINE_STARS, STARS_TAG, '3'],
+                                [0, 1, 1, 1])
 
     def test_markerless_outermost(self):
         """A pattern often seen in definitions sections"""


### PR DESCRIPTION
This adds a set of constraints on depth parsing to account for a particularly slow resolution to a set of markers @willbarton found:
```python
markers = [u'a', u'* * *', u'2', u'* * *', u'iii', u'STARS', u'b', u'* * *', u'1', u'* * *', u'ii', u'A', u'B', u'C', u'D', u'STARS', u'vi', u'2', u'* * *', u'ii', u'A', u'B', u'C', u'D', u'STARS', u'vi', u'STARS', u'6', u'* * *', u'ii', u'STARS', u'd', u'* * *', u'1', u'* * *', u'ii', u'* * *', u'C']
```
My laptop took over 20 seconds to process only the first 25 (of 38) markers. With these new constraints, that's down to less than half a second for the whole list.

New constraints/updates:
* Assume that `ii` is the roman number 2 (rather than the 35th letter of the lowercase alphabet)
* Limit _regtext_ such that the same marker type can only appear on one level and the same depth can only have one marker type
* Constrains inline stars such that they _always_ start a new depth. This is probably the most risky of the assumptions, but I couldn't imagine a counter example
* Constrains star sandwiches (markers surround a `STARS` tag) so that the `STARS` tag must be placed in specific positions. This breaks symmetries where the  `STARS` tag could be placed at multiple levels (and would not make a difference)

~~I need to add a few tests and docstrings, but~~ this is ready for review otherwise.