### PR TITLE
Tighten rules around collapsed markers

### DIFF
--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -6,7 +6,7 @@ from lxml import etree
 from regparser import content
 from regparser.tree.depth import markers as mtypes
 from regparser.tree.struct import Node
-from regparser.tree.paragraph import p_level_of
+from regparser.tree.paragraph import p_level_of, p_levels
 from regparser.tree.xml_parser import paragraph_processor
 from regparser.tree.xml_parser.appendices import build_non_reg_text
 from regparser.tree import reg_text
@@ -147,26 +147,53 @@ def build_subjgrp(reg_part, subjgrp_xml, letter_list):
     subjgrp.children = sections
     return subjgrp
 
-def get_markers(text):
+
+def _deeper_level(first, second):
+    """Is the second marker deeper than the first"""
+    for level1 in p_level_of(first):
+        for level2 in p_level_of(second):
+            if level1 < level2:
+                return True
+    return False
+
+
+def _continues_collapsed(first, second):
+    """Does the second marker continue a sequence started by the first?"""
+    if second == mtypes.STARS_TAG:  # Missing data - proceed optimistically
+        return True
+    for level1, markers1 in enumerate(p_levels):
+        for level2, markers2 in enumerate(p_levels):
+            if first not in markers1 or second not in markers2:
+                continue
+            idx1, idx2 = markers1.index(first), markers2.index(second)
+            extending = level1 == level2 and idx2 == idx1 + 1
+            new_level = level2 == level1 + 1 and idx2 == 0
+            if extending or new_level:
+                return True
+    return False
+
+
+def get_markers(text, next_marker=None):
     """ Extract all the paragraph markers from text. Do some checks on the
     collapsed markers."""
-    markers = tree_utils.get_paragraph_markers(text)
-    collapsed_markers = tree_utils.get_collapsed_markers(text)
+    initial = tree_utils.get_paragraph_markers(text)
+    if next_marker is None:
+        collapsed = []
+    else:
+        collapsed = tree_utils.get_collapsed_markers(text)
 
-    #   Check that the collapsed markers make sense (i.e. are at least one
-    #   level below the initial marker)
-    if markers and collapsed_markers:
-        initial_marker_levels = p_level_of(markers[-1])
-        final_collapsed_markers = []
-        for collapsed_marker in collapsed_markers:
-            collapsed_marker_levels = p_level_of(collapsed_marker)
-            if any(c > f for f in initial_marker_levels
-                    for c in collapsed_marker_levels):
-                final_collapsed_markers.append(collapsed_marker)
-        collapsed_markers = final_collapsed_markers
-    markers_list = [m for m in markers] + [m for m in collapsed_markers]
+    #   Check that the collapsed markers make sense:
+    #   * at least one level below the initial marker
+    #   * followed by a marker in sequence
+    if initial and collapsed:
+        collapsed = [c for c in collapsed if _deeper_level(initial[-1], c)]
+        for marker in reversed(collapsed):
+            if _continues_collapsed(marker, next_marker):
+                break
+            else:
+                collapsed.pop()
 
-    return markers_list
+    return initial + collapsed
 
 
 def get_markers_and_text(node, markers_list):
@@ -183,25 +210,6 @@ def get_markers_and_text(node, markers_list):
     if len(node_text_list) > len(markers_list):     # diff can only be 1
         markers_list.insert(0, mtypes.MARKERLESS)
     return zip(markers_list, node_text_list)
-
-
-def next_marker(xml_node, remaining_markers):
-    """Try to determine the marker following the current xml_node. Remaining
-    markers is a list of other marks *within* the xml_node. May return
-    None"""
-    #   More markers in this xml node
-    if remaining_markers:
-        return remaining_markers[0][0]
-
-    #   Check the next xml node; skip over stars
-    sib = xml_node.getnext()
-    while sib is not None and sib.tag in ('STARS', 'PRTPAGE'):
-        sib = sib.getnext()
-    if sib is not None:
-        next_text = tree_utils.get_node_text(sib)
-        next_markers = get_markers(next_text)
-        if next_markers:
-            return next_markers[0]
 
 
 def build_from_section(reg_part, section_xml):
@@ -255,7 +263,7 @@ class MarkerMatcher(object):
     def derive_nodes(self, xml):
         text = ''
         tagged_text = tree_utils.get_node_text_tags_preserved(xml).strip()
-        markers_list = get_markers(tagged_text)
+        markers_list = get_markers(tagged_text, self.next_marker(xml))
         nodes = []
         for m, node_text in get_markers_and_text(xml, markers_list):
             text, tagged_text = node_text
@@ -265,6 +273,19 @@ class MarkerMatcher(object):
         if text.endswith('* * *'):
             nodes.append(Node(label=[mtypes.INLINE_STARS]))
         return nodes
+
+    def next_marker(self, xml):
+        """Find the first marker in a paragraph that follows this xml node.
+        May return None"""
+        node = xml.getnext()
+        while node is not None:
+            tagged_text = tree_utils.get_node_text_tags_preserved(node)
+            markers = get_markers(tagged_text.strip())
+            if node.tag == mtypes.STARS_TAG:
+                return node.tag
+            elif markers:
+                return markers[0]
+            node = node.getnext()
 
 
 class NoMarkerMatcher(object):

--- a/tests/node_accessor.py
+++ b/tests/node_accessor.py
@@ -1,0 +1,29 @@
+class NodeAccessor(object):
+    """Wrapper class around a node that allows us to navigate the tree via
+    dictionary access"""
+    def __init__(self, node):
+        self.node = node
+        self.child_labels = [c.label[-1] for c in node.children]
+        self._memoized = {}
+
+    def __getattr__(self, name):
+        """Pass through to self.node"""
+        return getattr(self.node, name)
+
+    def __getitem__(self, label):
+        """Access child labels as a dictionary. node['111']['a']['2'] would
+        access the node with label '111-a-2'"""
+        if label in self._memoized:
+            return self._memoized[label]
+        else:
+            for child in self.node.children:
+                if child.label[-1] == label:
+                    return NodeAccessor(child)
+        raise KeyError()
+
+
+class NodeAccessorMixin(object):
+    """Mix in to tests to setup and test a root"""
+    def node_accessor(self, root, root_label):
+        self.assertEqual(root.label, root_label)
+        return NodeAccessor(root)


### PR DESCRIPTION
* Adds a nicer interface for validating node trees
* Reworks collapsed markers remove some false positives

To understand the second, imagine a paragraph such as
> (a) Examples. (1) aaa, (2) bbb, (3) ccc. Then some closing text
> (b) Paragraph b

The existing logic would split the first paragraph into `(a)` and `(a)(1)`, which made no sense. Even splitting into `(a)`, `(a)(1)`, `(a)(2)`, and `(a)(3)` wouldn't work well as there's text at the tail that's not applicable to `(3)`.

This constrains the logic around collapsed markers to take into account the following paragraph.

> (a) Examples. (1) Some text
> (i) Paragraph i

will continue to be broken into three paragraphs, as will

> (a) Examples. (1) Some text
> (2) More text.

As the `STARS` tag is a place holder,
> (a) Examples. (1) Some text
> `<STARS />`

converts to `(a)` and `(a)(1)`

I wrote a quick sanity checking script to test this logic against existing regulations. `12 CFR 1026` was the only which caused any pause -- its paragraph `§1026.42(c)(1)` has only one child. However, that child isn't a collapsed marker in the original XML, so this shouldn't change any well-parsing regs.