### PR TITLE
Account for EXTRACT, NOTES, etc. tags in regtext

### DIFF
--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -137,3 +137,22 @@ class TableMatcher(object):
     def derive_nodes(self, xml):
         return [Node(table_xml_to_plaintext(xml), label=[mtypes.MARKERLESS],
                      source_xml=xml)]
+
+
+class FencedMatcher(object):
+    """Use github-like fencing to indicate this is a note/code"""
+    def matches(self, xml):
+        return xml.tag in ('NOTE', 'NOTES', 'CODE', 'EXTRACT')
+
+    def derive_nodes(self, xml):
+        texts = ["```" + self.fence_type(xml)]
+        for child in xml:
+            texts.append(tree_utils.get_node_text(child).strip())
+        texts.append("```")
+        return [Node("\n".join(texts), label=[mtypes.MARKERLESS])]
+
+    def fence_type(self, xml):
+        if xml.tag == 'CODE':
+            return xml.get('LANGUAGE', 'code')
+        else:
+            return xml.tag.lower().rstrip("s")

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -286,5 +286,6 @@ class RegtextParagraphProcessor(paragraph_processor.ParagraphProcessor):
     NODE_TYPE = Node.REGTEXT
     MATCHERS = [paragraph_processor.StarsMatcher(),
                 paragraph_processor.TableMatcher(),
+                paragraph_processor.FencedMatcher(),
                 MarkerMatcher(),
                 NoMarkerMatcher()]

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -1,4 +1,5 @@
 # vim: set encoding=utf-8
+from contextlib import contextmanager
 from unittest import TestCase
 
 from lxml import etree
@@ -10,10 +11,16 @@ from tests.xml_builder import XMLBuilderMixin
 
 
 class RegTextTest(XMLBuilderMixin, TestCase):
-    def test_build_from_section_intro_text(self):
+    @contextmanager
+    def section(self, part=8675, section=309, subject="Definitions."):
+        """Many tests need a SECTION tag followed by the SECTNO and SUBJECT"""
         with self.tree.builder("SECTION") as root:
-            root.SECTNO(u"§ 8675.309")
-            root.SUBJECT("Definitions.")
+            root.SECTNO(u"§ {}.{}".format(part, section))
+            root.SUBJECT(subject)
+            yield root
+
+    def test_build_from_section_intro_text(self):
+        with self.section() as root:
             root.P("Some content about this section.")
             root.P("(a) something something")
         node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
@@ -27,9 +34,7 @@ class RegTextTest(XMLBuilderMixin, TestCase):
         self.assertEqual(['8675', '309', 'a'], child.label)
 
     def test_build_from_section_collapsed_level(self):
-        with self.tree.builder("SECTION") as root:
-            root.SECTNO(u"§ 8675.309")
-            root.SUBJECT("Definitions.")
+        with self.section() as root:
             root.P(_xml=u"""(a) <E T="03">Transfers </E>—(1)
                            <E T="03">Notice.</E> follow""")
             root.P(_xml="""(b) <E T="03">Contents</E> (1) Here""")
@@ -45,9 +50,7 @@ class RegTextTest(XMLBuilderMixin, TestCase):
         self.assertEqual(1, len(node.children[1].children))
 
     def test_build_from_section_collapsed_level_emph(self):
-        with self.tree.builder('SECTION') as root:
-            root.SECTNO(u"§ 8675.309")
-            root.SUBJECT("Definitions.")
+        with self.section() as root:
             root.P("(a) aaaa")
             root.P("(1) 1111")
             root.P("(i) iiii")
@@ -59,9 +62,7 @@ class RegTextTest(XMLBuilderMixin, TestCase):
         self.assertEqual("(1) eeee", a1iA.children[0].text.strip())
 
     def test_build_from_section_double_collapsed(self):
-        with self.tree.builder('SECTION') as root:
-            root.SECTNO(u'§ 8675.309')
-            root.SUBJECT('Definitions.')
+        with self.section() as root:
             root.P(_xml=u"""(a) <E T="03">Keyterm</E>—(1)(i) Content""")
             root.P("(ii) Content2")
         node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
@@ -103,9 +104,7 @@ class RegTextTest(XMLBuilderMixin, TestCase):
         self.assertEqual(u'§ 8675.311 [Reserved]', n311.title)
 
     def _setup_for_ambiguous(self, final_par):
-        with self.tree.builder("SECTION") as root:
-            root.SECTNO(u"§ 8675.309")
-            root.SUBJECT("Definitions.")
+        with self.section() as root:
             root.P("(g) Some Content")
             root.P("(h) H Starts")
             root.P("(1) H-1")
@@ -145,9 +144,7 @@ class RegTextTest(XMLBuilderMixin, TestCase):
         self.assertEqual(1, len(n8675_309_h_2.children))
 
     def test_build_from_section_collapsed(self):
-        with self.tree.builder("SECTION") as root:
-            root.SECTNO(u"§ 8675.309")
-            root.SUBJECT("Definitions.")
+        with self.section() as root:
             root.P("(a) aaa")
             root.P("(1) 111")
             root.P(_xml=u"""(2) 222—(i) iii. (A) AAA""")
@@ -162,9 +159,7 @@ class RegTextTest(XMLBuilderMixin, TestCase):
         self.assertEqual(2, len(n309_a_2_i.children))
 
     def test_build_from_section_italic_levels(self):
-        with self.tree.builder("SECTION") as root:
-            root.SECTNO(u"§ 8675.309")
-            root.SUBJECT("Definitions.")
+        with self.section() as root:
             root.P("(a) aaa")
             root.P("(1) 111")
             root.P("(i) iii")
@@ -196,9 +191,7 @@ class RegTextTest(XMLBuilderMixin, TestCase):
         self.assertEqual(n2.label, ['8675', '309', 'a', '1', 'i', 'A', '2'])
 
     def test_build_from_section_bad_spaces(self):
-        with self.tree.builder("SECTION") as root:
-            root.SECTNO(u"§ 8675.16")
-            root.SUBJECT("Subby Sub Sub.")
+        with self.section() as root:
             root.STARS()
             root.P(_xml="""(b)<E T="03">General.</E>Content Content.""")
         node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
@@ -207,18 +200,14 @@ class RegTextTest(XMLBuilderMixin, TestCase):
         self.assertEqual(nb.text.strip(), "(b) General. Content Content.")
 
     def test_build_from_section_section_with_nondigits(self):
-        with self.tree.builder("SECTION") as root:
-            root.SECTNO(u"§ 8675.309a")
-            root.SUBJECT("Definitions.")
+        with self.section(section="309a") as root:
             root.P("Intro content here")
         node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
         self.assertEqual(node.label, ['8675', '309a'])
         self.assertEqual(0, len(node.children))
 
     def test_build_from_section_fp(self):
-        with self.tree.builder("SECTION") as root:
-            root.SECTNO(u"§ 8675.309")
-            root.SUBJECT("Definitions.")
+        with self.section() as root:
             root.P("(a) aaa")
             root.P("(b) bbb")
             root.FP("fpfpfp")
@@ -240,9 +229,7 @@ class RegTextTest(XMLBuilderMixin, TestCase):
 
     def test_build_from_section_table(self):
         """Account for regtext with a table"""
-        with self.tree.builder("SECTION") as root:
-            root.SECTNO(u"§ 8675.309")
-            root.SUBJECT("Definitions.")
+        with self.section() as root:
             root.P("(a) aaaa")
             with root.GPOTABLE(CDEF="s25,10", COLS=2, OPTS="L2,i1") as table:
                 with table.BOXHD() as hd:
@@ -260,6 +247,38 @@ class RegTextTest(XMLBuilderMixin, TestCase):
         self.assertEqual("||Header|\n|---|---|\n|Left content|Right content|",
                          table.text)
         self.assertEqual("GPOTABLE", table.source_xml.tag)
+
+    def test_build_form_section_extract(self):
+        """Account for paragraphs within an EXTRACT tag"""
+        with self.section() as root:
+            root.P("(a) aaaa")
+            with root.EXTRACT() as extract:
+                extract.P("1. Some content")
+                extract.P("2. Other content")
+        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+
+        a = node.children[0]
+        self.assertEqual(1, len(a.children))
+        extract = a.children[0]
+        self.assertEqual(['8675', '309', 'a', 'p1'], extract.label)
+        content = ["```extract", "1. Some content", "2. Other content", "```"]
+        self.assertEqual("\n".join(content), extract.text)
+
+    def test_build_form_section_notes(self):
+        """Account for paragraphs within a NOTES tag"""
+        with self.section() as root:
+            root.P("(a) aaaa")
+            with root.NOTES() as extract:
+                extract.P("1. Some content")
+                extract.P("2. Other content")
+        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+
+        a = node.children[0]
+        self.assertEqual(1, len(a.children))
+        extract = a.children[0]
+        self.assertEqual(['8675', '309', 'a', 'p1'], extract.label)
+        content = ["```note", "1. Some content", "2. Other content", "```"]
+        self.assertEqual("\n".join(content), extract.text)
 
     def test_get_title(self):
         with self.tree.builder("PART") as root:


### PR DESCRIPTION
Handles `EXTRACT`, `NOTES`, `NOTE`, `CODE` tags in regtext as we do in appendices. This creates a fenced node, which is converted into formatted text via a layer.

This works but does not look good in `regulations-site`