### PR TITLE
Allow subjgrps to be at the top level

### DIFF
--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -74,14 +74,12 @@ def build_tree(reg_xml):
     part = reg_xml.xpath('//PART')[0]
 
     # Build a list of SUBPARTs, then pull SUBJGRPs into that list:
-    subpart_xmls = [c for c in part.getchildren() if c.tag == 'SUBPART']
     subpart_and_subjgrp_xmls = []
-    if len(subpart_xmls) > 0:
-        for subpart in subpart_xmls:
-            subpart_and_subjgrp_xmls.append(subpart)
-            subjgrps = [c for c in subpart.getchildren() if c.tag == 'SUBJGRP']
-            for subjgrp in subjgrps:
-                subpart_and_subjgrp_xmls.append(subjgrp)
+    for subpart in part.xpath('./SUBPART|./SUBJGRP'):
+        subpart_and_subjgrp_xmls.append(subpart)
+        # SUBJGRPS can be nested, particularly inside SUBPARTs
+        for subjgrp in subpart.xpath('./SUBJGRP'):
+            subpart_and_subjgrp_xmls.append(subjgrp)
 
     if len(subpart_and_subjgrp_xmls) > 0:
         subthings = []


### PR DESCRIPTION
Existing code assumes that `SUBJGRP`s were within `SUBPART`s. This patch allows `SUBJGRP`s to be at the top level (as they are in ATF's 646)