### PR TITLE
555 fix: "approved by"

### DIFF
--- a/regparser/notice/build.py
+++ b/regparser/notice/build.py
@@ -354,5 +354,6 @@ def add_footnotes(notice, notice_xml):
             content = child.text
             for cc in child:
                 content += etree.tostring(cc)
-            content += child.tail
+            if child.tail:
+                content += child.tail
             notice['footnotes'][ref[0].text] = content.strip()

--- a/regparser/notice/build.py
+++ b/regparser/notice/build.py
@@ -3,11 +3,12 @@ from collections import defaultdict
 import os
 from urlparse import urlparse
 
-import logging 
+import logging
 
 from lxml import etree
 import requests
 
+from regparser.notice import preprocessors
 from regparser.notice.address import fetch_addresses
 from regparser.notice.build_appendix import parse_appendix_changes
 from regparser.notice.build_interp import parse_interp_changes
@@ -58,10 +59,11 @@ def build_notice(cfr_title, cfr_part, fr_notice, do_process_xml=True):
             fr_notice['full_text_xml_url'])
 
         if len(local_notices) > 0:
-            logging.warning("using local xml for %s", fr_notice['full_text_xml_url'])
+            logging.info("using local xml for %s",
+                         fr_notice['full_text_xml_url'])
             return process_local_notices(local_notices, notice)
         else:
-            logging.warning("fetching notice %s", fr_notice['full_text_xml_url'])
+            logging.info("fetching notice %s", fr_notice['full_text_xml_url'])
             notice_str = requests.get(fr_notice['full_text_xml_url']).content
             return [process_notice(notice, notice_str)]
     return [notice]
@@ -219,56 +221,8 @@ def preprocess_notice_xml(notice_xml):
     tend to instead use the files in settings.LOCAL_XML_PATHS"""
     notice_xml = deepcopy(notice_xml)   # We will be destructive
 
-    # Last amdpar in a section; probably meant to add the amdpar to the
-    # next section
-    for amdpar in notice_xml.xpath("//AMDPAR"):
-        if amdpar.getnext() is None:
-            parent = amdpar.getparent()
-            next_parent = parent.getnext()
-            if (next_parent is not None
-                    and parent.get('PART') == next_parent.get('PART')):
-                parent.remove(amdpar)
-                next_parent.insert(0, amdpar)
-
-    # Supplement I AMDPARs are often incorrect (labelled as Ps)
-    xpath_contains_supp = "contains(., 'Supplement I')"
-    xpath = "//REGTEXT//HD[@SOURCE='HD1' and %s]" % xpath_contains_supp
-    for supp_header in notice_xml.xpath(xpath):
-        parent = supp_header.getparent()
-        if (parent.xpath("./AMDPAR[%s]" % xpath_contains_supp)
-                or parent.xpath("./P[%s]" % xpath_contains_supp)):
-            pred = supp_header.getprevious()
-            while pred is not None:
-                if pred.tag not in ('P', 'AMDPAR'):
-                    pred = pred.getprevious()
-                else:
-                    pred.tag = 'AMDPAR'
-                    if 'supplement i' in pred.text.lower():
-                        pred = None
-                    else:
-                        pred = pred.getprevious()
-
-    # Clean up emphasized paragraph tags
-    for par in notice_xml.xpath("//P/*[position()=1 and name()='E']/.."):
-        em = par.getchildren()[0]   # must be an E from the xpath
-
-        #   wrap in a thunk to delay execution
-        par_text = lambda: par.text or ""
-        em_text, em_tail = lambda: em.text or "", lambda: em.tail or ""
-
-        par_open = par_text()[-1:] == "("
-        em_open = em_text()[:1] == "("
-        em_txt_closed = em_text()[-1:] == ")"
-        em_tail_closed = em_tail()[:1] == ")"
-
-        if (par_open or em_open) and (em_txt_closed or em_tail_closed):
-            if not par_open and em_open:                # Move '(' out
-                par.text = par_text() + "("
-                em.text = em_text()[1:]
-
-            if not em_tail_closed and em_txt_closed:    # Move ')' out
-                em.text = em_text()[:-1]
-                em.tail = ")" + em_tail()
+    for preprocessor in preprocessors.ALL:
+        preprocessor().transform(notice_xml)
 
     return notice_xml
 
@@ -357,6 +311,7 @@ def fetch_cfr_parts(notice_xml):
     cfr_elm = notice_xml.xpath('//CFR')[0]
     results = notice_cfr_p.parseString(cfr_elm.text)
     return list(results)
+
 
 def process_xml(notice, notice_xml):
     """Pull out relevant fields from the xml and add them to the notice"""

--- a/regparser/notice/preprocessors.py
+++ b/regparser/notice/preprocessors.py
@@ -1,0 +1,79 @@
+"""Set of transforms we run on notice XML to account for common inaccuracies
+in the XML"""
+import abc
+
+
+class PreProcessorBase(object):
+    """Base class for all the preprocessors. Defines the interface they must
+    implement"""
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def transform(self, xml):
+        """Transform the input xml. Mutates that xml, so be sure to make a
+        copy if needed"""
+        raise NotImplementedError()
+
+
+class MoveLastAMDPar(PreProcessorBase):
+    """If the last element in a section is an AMDPAR, odds are the authors
+    intended it to be associated with the following section"""
+    def transform(self, xml):
+        for amdpar in xml.xpath("//AMDPAR"):
+            if amdpar.getnext() is None:
+                parent = amdpar.getparent()
+                next_parent = parent.getnext()
+                if (next_parent is not None
+                        and parent.get('PART') == next_parent.get('PART')):
+                    parent.remove(amdpar)
+                    next_parent.insert(0, amdpar)
+
+
+class SupplementIAMDPar(PreProcessorBase):
+    """Supplement I AMDPARs are often incorrect (labelled as Ps)"""
+    def transform(self, xml):
+        xpath_contains_supp = "contains(., 'Supplement I')"
+        xpath = "//REGTEXT//HD[@SOURCE='HD1' and %s]" % xpath_contains_supp
+        for supp_header in xml.xpath(xpath):
+            parent = supp_header.getparent()
+            if (parent.xpath("./AMDPAR[%s]" % xpath_contains_supp)
+                    or parent.xpath("./P[%s]" % xpath_contains_supp)):
+                pred = supp_header.getprevious()
+                while pred is not None:
+                    if pred.tag not in ('P', 'AMDPAR'):
+                        pred = pred.getprevious()
+                    else:
+                        pred.tag = 'AMDPAR'
+                        if 'supplement i' in pred.text.lower():
+                            pred = None
+                        else:
+                            pred = pred.getprevious()
+
+
+class EmphasizedParagraphCleanup(PreProcessorBase):
+    """Clean up emphasized paragraph tags"""
+    def transform(self, xml):
+        for par in xml.xpath("//P/*[position()=1 and name()='E']/.."):
+            em = par.getchildren()[0]   # must be an E from the xpath
+
+            #   wrap in a thunk to delay execution
+            par_text = lambda: par.text or ""
+            em_text, em_tail = lambda: em.text or "", lambda: em.tail or ""
+
+            par_open = par_text()[-1:] == "("
+            em_open = em_text()[:1] == "("
+            em_txt_closed = em_text()[-1:] == ")"
+            em_tail_closed = em_tail()[:1] == ")"
+
+            if (par_open or em_open) and (em_txt_closed or em_tail_closed):
+                if not par_open and em_open:                # Move '(' out
+                    par.text = par_text() + "("
+                    em.text = em_text()[1:]
+
+                if not em_tail_closed and em_txt_closed:    # Move ')' out
+                    em.text = em_text()[:-1]
+                    em.tail = ")" + em_tail()
+
+
+# Surface all of the PreProcessorBase classes
+ALL = PreProcessorBase.__subclasses__()

--- a/regparser/notice/preprocessors.py
+++ b/regparser/notice/preprocessors.py
@@ -81,5 +81,16 @@ class ParenthesesCleanup(PreProcessorBase):
                     em.tail = ")" + _str(em.tail)
 
 
+class ApprovalsFP(PreProcessorBase):
+    """We expect certain text to an APPRO tag, but it is often mistakenly
+    found inside FP tags. We use PREFIX to determine which nodes need to be
+    fixed."""
+    PREFIX = "(Approved by the Office of Management and Budget under"
+
+    def transform(self, xml):
+        for fp in xml.xpath('//FP[starts-with(., "{}")]'.format(self.PREFIX)):
+            fp.tag = 'APPRO'
+
+
 # Surface all of the PreProcessorBase classes
 ALL = PreProcessorBase.__subclasses__()

--- a/regparser/notice/util.py
+++ b/regparser/notice/util.py
@@ -50,4 +50,4 @@ def body_to_string(xml_node):
     the outer tag)"""
     return (xml_node.text.lstrip()
             + ''.join(etree.tostring(c) for c in xml_node)
-            + xml_node.tail.rstrip())
+            + (xml_node.tail or '').rstrip())

--- a/tests/notice_build_tests.py
+++ b/tests/notice_build_tests.py
@@ -1,4 +1,4 @@
-#vim: set encoding=utf-8
+# vim: set encoding=utf-8
 import os
 import shutil
 import tempfile
@@ -10,10 +10,12 @@ from regparser.notice import build, changes
 from regparser.notice.diff import DesignateAmendment, Amendment
 from regparser.tree.struct import Node
 import settings
+from tests.xml_builder import XMLBuilderMixin
 
 
-class NoticeBuildTest(TestCase):
+class NoticeBuildTest(XMLBuilderMixin, TestCase):
     def setUp(self):
+        super(NoticeBuildTest, self).setUp()
         self.original_local_xml_paths = settings.LOCAL_XML_PATHS
         settings.LOCAL_XML_PATHS = []
         self.dir1 = tempfile.mkdtemp()
@@ -69,27 +71,22 @@ class NoticeBuildTest(TestCase):
 
     def test_process_xml(self):
         """Integration test for xml processing"""
-        xml = """
-        <ROOT>
-            <SUPLINF>
-                <FURINF>
-                    <HD>CONTACT INFO:</HD>
-                    <P>Extra contact info here</P>
-                </FURINF>
-                <ADD>
-                    <P>Email: example@example.com</P>
-                    <P>Extra instructions</P>
-                </ADD>
-                <HD SOURCE="HED">Supplementary Info</HD>
-                <HD SOURCE="HD1">V. Section-by-Section Analysis</HD>
-                <HD SOURCE="HD2">8(q) Words</HD>
-                <P>Content</P>
-                <HD SOURCE="HD1">Section that follows</HD>
-                <P>Following Content</P>
-            </SUPLINF>
-        </ROOT>"""
+        with self.tree.builder("ROOT") as root:
+            with root.SUPLINF() as suplinf:
+                with suplinf.FURINF() as furinf:
+                    furinf.HD("CONTACT INFO:")
+                    furinf.P("Extra contact info here")
+                with suplinf.ADD() as add:
+                    add.P("Email: example@example.com")
+                    add.P("Extra instructions")
+                suplinf.HD("Supplementary Info", SOURCE="HED")
+                suplinf.HD("V. Section-by-Section Analysis", SOURCE="HD1")
+                suplinf.HD("8(q) Words", SOURCE="HD2")
+                suplinf.P("Content")
+                suplinf.HD("Section that follows", SOURCE="HD1")
+                suplinf.P("Following Content")
         notice = {'cfr_parts': ['9292'], 'meta': {'start_page': 100}}
-        self.assertEqual(build.process_xml(notice, etree.fromstring(xml)), {
+        self.assertEqual(build.process_xml(notice, self.tree.render_xml()), {
             'cfr_parts': ['9292'],
             'footnotes': {},
             'meta': {'start_page': 100},
@@ -109,19 +106,16 @@ class NoticeBuildTest(TestCase):
         })
 
     def test_process_xml_missing_fields(self):
-        xml = """
-        <ROOT>
-            <SUPLINF>
-                <HD SOURCE="HED">Supplementary Info</HD>
-                <HD SOURCE="HD1">V. Section-by-Section Analysis</HD>
-                <HD SOURCE="HD2">8(q) Words</HD>
-                <P>Content</P>
-                <HD SOURCE="HD1">Section that follows</HD>
-                <P>Following Content</P>
-            </SUPLINF>
-        </ROOT>"""
+        with self.tree.builder("ROOT") as root:
+            with root.SUPLINF() as suplinf:
+                suplinf.HD("Supplementary Info", SOURCE="HED")
+                suplinf.HD("V. Section-by-Section Analysis", SOURCE="HD1")
+                suplinf.HD("8(q) Words", SOURCE="HD2")
+                suplinf.P("Content")
+                suplinf.HD("Section that follows", SOURCE="HD1")
+                suplinf.P("Following Content")
         notice = {'cfr_parts': ['9292'], 'meta': {'start_page': 210}}
-        self.assertEqual(build.process_xml(notice, etree.fromstring(xml)), {
+        self.assertEqual(build.process_xml(notice, self.tree.render_xml()), {
             'cfr_parts': ['9292'],
             'footnotes': {},
             'meta': {'start_page': 210},
@@ -136,13 +130,10 @@ class NoticeBuildTest(TestCase):
         })
 
     def test_process_xml_fill_effective_date(self):
-        xml = """
-        <ROOT>
-            <DATES>
-                <P>Effective January 1, 2002</P>
-            </DATES>
-        </ROOT>"""
-        xml = etree.fromstring(xml)
+        with self.tree.builder("ROOT") as root:
+            with root.DATES() as dates:
+                dates.P("Effective January 1, 2002")
+        xml = self.tree.render_xml()
 
         notice = {'cfr_parts': ['902'], 'meta': {'start_page': 10},
                   'effective_on': '2002-02-02'}
@@ -161,21 +152,16 @@ class NoticeBuildTest(TestCase):
         self.assertEqual('2002-01-01', notice['effective_on'])
 
     def test_add_footnotes(self):
-        xml = """
-        <ROOT>
-            <P>Some text</P>
-            <FTNT>
-                <P><SU>21</SU>Footnote text</P>
-            </FTNT>
-            <FTNT>
-                <P><SU>43</SU>This has a<PRTPAGE P="2222" />break</P>
-            </FTNT>
-            <FTNT>
-                <P><SU>98</SU>This one has<E T="03">emph</E>tags</P>
-            </FTNT>
-        </ROOT>"""
+        with self.tree.builder("ROOT") as root:
+            root.P("Some text")
+            with root.FTNT() as ftnt:
+                ftnt.P(_xml='<SU>21</SU>Footnote text')
+            with root.FTNT() as ftnt:
+                ftnt.P(_xml='<SU>43</SU>This has a<PRTPAGE P="2222" />break')
+            with root.FTNT() as ftnt:
+                ftnt.P(_xml='<SU>98</SU>This one has<E T="03">emph</E>tags')
         notice = {}
-        build.add_footnotes(notice, etree.fromstring(xml))
+        build.add_footnotes(notice, self.tree.render_xml())
         self.assertEqual(notice, {'footnotes': {
             '21': 'Footnote text',
             '43': 'This has a break',
@@ -196,19 +182,14 @@ class NoticeBuildTest(TestCase):
             self.assertEqual(change['action'], 'DESIGNATE')
 
     def test_process_amendments(self):
-        xml = u"""
-        <REGTEXT PART="105" TITLE="12">
-        <SUBPART>
-        <HD SOURCE="HED">Subpart A—General</HD>
-        </SUBPART>
-        <AMDPAR>
-        2. Designate §§ 105.1 through 105.3 as subpart A under the heading.
-        </AMDPAR>
-        </REGTEXT>"""
+        with self.tree.builder("REGTEXT", PART="105", TITLE="12") as regtext:
+            with regtext.SUBPART() as subpart:
+                subpart.HD(u"Subpart A—General", SOURCE="HED")
+            regtext.AMDPAR(u"2. Designate §§ 105.1 through 105.3 as subpart "
+                           "A under the heading.")
 
-        notice_xml = etree.fromstring(xml)
         notice = {'cfr_parts': ['105']}
-        build.process_amendments(notice, notice_xml)
+        build.process_amendments(notice, self.tree.render_xml())
 
         section_list = ['105-2', '105-3', '105-1']
         self.assertEqual(notice['changes'].keys(), section_list)
@@ -219,23 +200,17 @@ class NoticeBuildTest(TestCase):
             self.assertEqual(change['action'], 'DESIGNATE')
 
     def test_process_amendments_section(self):
-        xml = u"""
-            <REGTEXT PART="105" TITLE="12">
-            <AMDPAR>
-            3. In § 105.1, revise paragraph (b) to read as follows:
-            </AMDPAR>
-            <SECTION>
-                <SECTNO>§ 105.1</SECTNO>
-                <SUBJECT>Purpose.</SUBJECT>
-                <STARS/>
-                <P>(b) This part carries out.</P>
-            </SECTION>
-            </REGTEXT>
-        """
+        with self.tree.builder("REGTEXT", PART="105", TITLE="12") as regtext:
+            regtext.AMDPAR(u"3. In § 105.1, revise paragraph (b) to read as "
+                           "follows:")
+            with regtext.SECTION() as section:
+                section.SECTNO(u"§ 105.1")
+                section.SUBJECT("Purpose.")
+                section.STARS()
+                section.P("(b) This part carries out.")
 
-        notice_xml = etree.fromstring(xml)
         notice = {'cfr_parts': ['105']}
-        build.process_amendments(notice, notice_xml)
+        build.process_amendments(notice, self.tree.render_xml())
 
         self.assertEqual(notice['changes'].keys(), ['105-1-b'])
 
@@ -245,24 +220,19 @@ class NoticeBuildTest(TestCase):
             u'(b) This part carries out.'))
 
     def test_process_amendments_multiple_in_same_parent(self):
-        xml = u"""
-            <REGTEXT PART="105" TITLE="12">
-                <AMDPAR>
-                    1. In § 105.1, revise paragraph (b) to read as follows:
-                </AMDPAR>
-                <AMDPAR>2. Also, revise paragraph (c):</AMDPAR>
-                <SECTION>
-                    <SECTNO>§ 105.1</SECTNO>
-                    <SUBJECT>Purpose.</SUBJECT>
-                    <STARS/>
-                    <P>(b) This part carries out.</P>
-                    <P>(c) More stuff</P>
-                </SECTION>
-            </REGTEXT>"""
+        with self.tree.builder("REGTEXT", PART="105", TITLE="12") as regtext:
+            regtext.AMDPAR(u"1. In § 105.1, revise paragraph (b) to read as "
+                           "follows:")
+            regtext.AMDPAR("2. Also, revise paragraph (c):")
+            with regtext.SECTION() as section:
+                section.SECTNO(u"§ 105.1")
+                section.SUBJECT("Purpose.")
+                section.STARS()
+                section.P("(b) This part carries out.")
+                section.P("(c) More stuff")
 
-        notice_xml = etree.fromstring(xml)
         notice = {'cfr_parts': ['105']}
-        build.process_amendments(notice, notice_xml)
+        build.process_amendments(notice, self.tree.render_xml())
 
         self.assertEqual(notice['changes'].keys(), ['105-1-b', '105-1-c'])
 
@@ -276,30 +246,22 @@ class NoticeBuildTest(TestCase):
                         u'(c) More stuff')
 
     def test_process_amendments_restart_new_section(self):
-        xml = u"""
-        <ROOT>
-            <REGTEXT PART="104" TITLE="12">
-                <AMDPAR>
-                    1. In Supplement I to Part 104, comment 22(a) is added
-                </AMDPAR>
-                <P>Content</P>
-            </REGTEXT>
-            <REGTEXT PART="105" TITLE="12">
-                <AMDPAR>
-                3. In § 105.1, revise paragraph (b) to read as follows:
-                </AMDPAR>
-                <SECTION>
-                    <SECTNO>§ 105.1</SECTNO>
-                    <SUBJECT>Purpose.</SUBJECT>
-                    <STARS/>
-                    <P>(b) This part carries out.</P>
-                </SECTION>
-            </REGTEXT>
-        </ROOT>"""
+        with self.tree.builder("ROOT") as root:
+            with root.REGTEXT(PART="104", TITLE="12") as regtext:
+                regtext.AMDPAR("1. In Supplement I to Part 104, comment "
+                               "22(a) is added")
+                regtext.P("Content")
+            with root.REGTEXT(PART="105", TITLE="12") as regtext:
+                regtext.AMDPAR(u"3. In § 105.1, revise paragraph (b) to read "
+                               "as follows:")
+                with regtext.SECTION() as section:
+                    section.SECTNO(u"§ 105.1")
+                    section.SUBJECT("Purpose.")
+                    section.STARS()
+                    section.P("(b) This part carries out.")
 
-        notice_xml = etree.fromstring(xml)
         notice = {'cfr_parts': ['105']}
-        build.process_amendments(notice, notice_xml)
+        build.process_amendments(notice, self.tree.render_xml())
 
         self.assertEqual(2, len(notice['amendments']))
         c22a, b = notice['amendments']
@@ -309,18 +271,12 @@ class NoticeBuildTest(TestCase):
         self.assertEqual(b.label, ['105', '1', 'b'])
 
     def test_process_amendments_no_nodes(self):
-        xml = u"""
-        <ROOT>
-            <REGTEXT PART="104" TITLE="12">
-                <AMDPAR>
-                    1. In § 104.13, paragraph (b) is removed
-                </AMDPAR>
-            </REGTEXT>
-        </ROOT>"""
+        with self.tree.builder("ROOT") as root:
+            with root.REGTEXT(PART="104", TITLE="12") as regtext:
+                regtext.AMDPAR(u"1. In § 104.13, paragraph (b) is removed")
 
-        notice_xml = etree.fromstring(xml)
         notice = {'cfr_parts': ['104']}
-        build.process_amendments(notice, notice_xml)
+        build.process_amendments(notice, self.tree.render_xml())
 
         self.assertEqual(1, len(notice['amendments']))
         delete = notice['amendments'][0]
@@ -328,48 +284,34 @@ class NoticeBuildTest(TestCase):
         self.assertEqual(delete.label, ['104', '13', 'b'])
 
     def new_subpart_xml(self):
-        xml = u"""
-            <RULE>
-            <REGTEXT PART="105" TITLE="12">
-            <AMDPAR>
-            3. In § 105.1, revise paragraph (b) to read as follows:
-            </AMDPAR>
-            <SECTION>
-                <SECTNO>§ 105.1</SECTNO>
-                <SUBJECT>Purpose.</SUBJECT>
-                <STARS/>
-                <P>(b) This part carries out.</P>
-            </SECTION>
-            </REGTEXT>
-           <REGTEXT PART="105" TITLE="12">
-            <AMDPAR>
-                6. Add subpart B to read as follows:
-            </AMDPAR>
-            <CONTENTS>
-                <SUBPART>
-                    <SECHD>Sec.</SECHD>
-                    <SECTNO>105.30</SECTNO>
-                    <SUBJECT>First In New Subpart.</SUBJECT>
-                </SUBPART>
-            </CONTENTS>
-            <SUBPART>
-                <HD SOURCE="HED">Subpart B—Requirements</HD>
-                <SECTION>
-                    <SECTNO>105.30</SECTNO>
-                    <SUBJECT>First In New Subpart</SUBJECT>
-                    <P>For purposes of this subpart, the follow apply:</P>
-                    <P>(a) "Agent" means agent.</P>
-                </SECTION>
-            </SUBPART>
-           </REGTEXT>
-           </RULE>"""
-
-        return xml
+        with self.tree.builder("RULE") as rule:
+            with rule.REGTEXT(PART="105", TITLE="12") as regtext:
+                regtext.AMDPAR(u"3. In § 105.1, revise paragraph (b) to read "
+                               "as follows:")
+                with regtext.SECTION() as section:
+                    section.SECTNO(u"§ 105.1")
+                    section.SUBJECT("Purpose.")
+                    section.STARS()
+                    section.P("(b) This part carries out.")
+            with rule.REGTEXT(PART="105", TITLE="12") as regtext:
+                regtext.AMDPAR("6. Add subpart B to read as follows:")
+                with regtext.CONTENTS() as contents:
+                    with contents.SUBPART() as subpart:
+                        subpart.SECHD("Sec.")
+                        subpart.SECTNO("105.30")
+                        subpart.SUBJECT("First In New Subpart.")
+                with regtext.SUBPART() as subpart:
+                    subpart.HD(u"Subpart B—Requirements", SOURCE="HED")
+                    with subpart.SECTION() as section:
+                        section.SECTNO("105.30")
+                        section.SUBJECT("First In New Subpart")
+                        section.P("For purposes of this subpart, the follow "
+                                  "apply:")
+                        section.P('(a) "Agent" means agent.')
+        return self.tree.render_xml()
 
     def test_process_new_subpart(self):
-        xml = self.new_subpart_xml()
-        notice_xml = etree.fromstring(xml)
-        par = notice_xml.xpath('//AMDPAR')[1]
+        par = self.new_subpart_xml().xpath('//AMDPAR')[1]
 
         amended_label = Amendment('POST', '105-Subpart:B')
         notice = {'cfr_parts': ['105']}
@@ -385,11 +327,8 @@ class NoticeBuildTest(TestCase):
             subpart_changes['105-Subpart-B']['node']['node_type'], 'subpart')
 
     def test_process_amendments_subpart(self):
-        xml = self.new_subpart_xml()
-
-        notice_xml = etree.fromstring(xml)
         notice = {'cfr_parts': ['105']}
-        build.process_amendments(notice, notice_xml)
+        build.process_amendments(notice, self.new_subpart_xml())
 
         self.assertTrue('105-Subpart-B' in notice['changes'].keys())
         self.assertTrue('105-30-a' in notice['changes'].keys())
@@ -398,34 +337,24 @@ class NoticeBuildTest(TestCase):
     def test_process_amendments_mix_regs(self):
         """Some notices apply to multiple regs. For now, just ignore the
         sections not associated with the reg we're focused on"""
-        xml = u"""
-            <ROOT>
-            <REGTEXT PART="105" TITLE="12">
-                <AMDPAR>
-                3. In § 105.1, revise paragraph (a) to read as follows:
-                </AMDPAR>
-                <SECTION>
-                    <SECTNO>§ 105.1</SECTNO>
-                    <SUBJECT>105Purpose.</SUBJECT>
-                    <P>(a) 105Content</P>
-                </SECTION>
-            </REGTEXT>
-            <REGTEXT PART="106" TITLE="12">
-                <AMDPAR>
-                3. In § 106.3, revise paragraph (b) to read as follows:
-                </AMDPAR>
-                <SECTION>
-                    <SECTNO>§ 106.3</SECTNO>
-                    <SUBJECT>106Purpose.</SUBJECT>
-                    <P>(b) Content</P>
-                </SECTION>
-            </REGTEXT>
-            </ROOT>
-        """
+        with self.tree.builder("ROOT") as root:
+            with root.REGTEXT(PART="105", TITLE="12") as regtext:
+                regtext.AMDPAR(u"3. In § 105.1, revise paragraph (a) to read "
+                               "as follows:")
+                with regtext.SECTION() as section:
+                    section.SECTNO(u"§ 105.1")
+                    section.SUBJECT("105Purpose.")
+                    section.P("(a) 105Content")
+            with root.REGTEXT(PART="106", TITLE="12") as regtext:
+                regtext.AMDPAR(u"3. In § 106.3, revise paragraph (b) to read "
+                               "as follows:")
+                with regtext.SECTION() as section:
+                    section.SECTNO(u"§ 106.3")
+                    section.SUBJECT("106Purpose.")
+                    section.P("(b) Content")
 
-        notice_xml = etree.fromstring(xml)
         notice = {'cfr_parts': ['105', '106']}
-        build.process_amendments(notice, notice_xml)
+        build.process_amendments(notice, self.tree.render_xml())
 
         self.assertEqual(2, len(notice['changes']))
         self.assertTrue('105-1-a' in notice['changes'])
@@ -433,24 +362,15 @@ class NoticeBuildTest(TestCase):
 
     def test_process_amendments_context(self):
         """Context should carry over between REGTEXTs"""
-        xml = u"""
-            <ROOT>
-            <REGTEXT TITLE="12">
-                <AMDPAR>
-                3. In § 106.1, revise paragraph (a) to read as follows:
-                </AMDPAR>
-            </REGTEXT>
-            <REGTEXT TITLE="12">
-                <AMDPAR>
-                3. Add appendix C
-                </AMDPAR>
-            </REGTEXT>
-            </ROOT>
-        """
+        with self.tree.builder("ROOT") as root:
+            with root.REGTEXT(TITLE="12") as regtext:
+                regtext.AMDPAR(u"3. In § 106.1, revise paragraph (a) to "
+                               "read as follows:")
+            with root.REGTEXT(TITLE="12") as regtext:
+                regtext.AMDPAR("3. Add appendix C")
 
-        notice_xml = etree.fromstring(xml)
         notice = {'cfr_parts': ['105', '106']}
-        build.process_amendments(notice, notice_xml)
+        build.process_amendments(notice, self.tree.render_xml())
 
         self.assertEqual(2, len(notice['amendments']))
         amd1, amd2 = notice['amendments']
@@ -460,52 +380,35 @@ class NoticeBuildTest(TestCase):
     def test_introductory_text(self):
         """ Sometimes notices change just the introductory text of a paragraph
         (instead of changing the entire paragraph tree).  """
-
-        xml = u"""
-        <REGTEXT PART="106" TITLE="12">
-        <AMDPAR>
-            3. In § 106.2, revise the introductory text to read as follows:
-        </AMDPAR>
-        <SECTION>
-            <SECTNO>§ 106.2</SECTNO>
-            <SUBJECT> Definitions </SUBJECT>
-            <P> Except as otherwise provided, the following apply. </P>
-        </SECTION>
-        </REGTEXT>
-        """
-
-        notice_xml = etree.fromstring(xml)
+        with self.tree.builder("REGTEXT", PART="106", TITLE="12") as regtext:
+            regtext.AMDPAR(u"3. In § 106.2, revise the introductory text to "
+                           "read as follows:")
+            with regtext.SECTION() as section:
+                section.SECTNO(u"§ 106.2")
+                section.SUBJECT(" Definitions ")
+                section.P(" Except as otherwise provided, the following "
+                          "apply. ")
         notice = {'cfr_parts': ['106']}
-        build.process_amendments(notice, notice_xml)
+        build.process_amendments(notice, self.tree.render_xml())
 
         self.assertEqual('[text]', notice['changes']['106-2'][0]['field'])
 
     def test_multiple_changes(self):
         """ A notice can have two modifications to a paragraph. """
-
-        xml = u"""
-        <ROOT>
-        <REGTEXT PART="106" TITLE="12">
-        <AMDPAR>
-            2. Designate §§ 106.1 through 106.3 as subpart A under the heading.
-        </AMDPAR>
-        </REGTEXT>
-        <REGTEXT PART="106" TITLE="12">
-        <AMDPAR>
-            3. In § 106.2, revise the introductory text to read as follows:
-        </AMDPAR>
-        <SECTION>
-            <SECTNO>§ 106.2</SECTNO>
-            <SUBJECT> Definitions </SUBJECT>
-            <P> Except as otherwise provided, the following apply. </P>
-        </SECTION>
-        </REGTEXT>
-        </ROOT>
-        """
-
-        notice_xml = etree.fromstring(xml)
+        with self.tree.builder("ROOT") as root:
+            with root.REGTEXT(PART="106", TITLE="12") as regtext:
+                regtext.AMDPAR(u"2. Designate §§ 106.1 through 106.3 as "
+                               "subpart A under the heading.")
+            with root.REGTEXT(PART="106", TITLE="12") as regtext:
+                regtext.AMDPAR(u"3. In § 106.2, revise the introductory text "
+                               "to read as follows:")
+                with regtext.SECTION() as section:
+                    section.SECTNO(u"§ 106.2")
+                    section.SUBJECT(" Definitions ")
+                    section.P(" Except as otherwise provided, the following "
+                              "apply. ")
         notice = {'cfr_parts': ['106']}
-        build.process_amendments(notice, notice_xml)
+        build.process_amendments(notice, self.tree.render_xml())
 
         self.assertEqual(2, len(notice['changes']['106-2']))
 
@@ -672,141 +575,9 @@ class NoticeBuildTest(TestCase):
         self.assertEqual(notices[0]['document_number'], '111_20131008')
         self.assertEqual(notices[1]['document_number'], '222_20131010')
 
-    def test_preprocess_notice_xml_improper_location(self):
-        notice_xml = etree.fromstring(u"""
-            <PART>
-                <REGTEXT>
-                    <AMDPAR>1. In § 105.1, revise paragraph (b):</AMDPAR>
-                    <SECTION>
-                        <STARS />
-                        <P>(b) Content</P>
-                    </SECTION>
-                    <AMDPAR>
-                        3. In § 105.2, revise paragraph (a) to read as follows:
-                    </AMDPAR>
-                </REGTEXT>
-                <REGTEXT>
-                    <SECTION>
-                        <P>(a) Content</P>
-                    </SECTION>
-                </REGTEXT>
-            </PART>""")
-        notice_xml = build.preprocess_notice_xml(notice_xml)
-        amd1b, amd2a = notice_xml.xpath("//AMDPAR")
-        self.assertEqual(amd1b.getparent().xpath(".//P")[0].text.strip(),
-                         "(b) Content")
-        self.assertEqual(amd2a.getparent().xpath(".//P")[0].text.strip(),
-                         "(a) Content")
-
-        notice_xml = etree.fromstring(u"""
-            <PART>
-                <REGTEXT PART="105">
-                    <AMDPAR>1. In § 105.1, revise paragraph (b):</AMDPAR>
-                    <SECTION>
-                        <STARS />
-                        <P>(b) Content</P>
-                    </SECTION>
-                    <AMDPAR>
-                        3. In § 105.2, revise paragraph (a) to read as follows:
-                    </AMDPAR>
-                </REGTEXT>
-                <REGTEXT PART="107">
-                    <SECTION>
-                        <P>(a) Content</P>
-                    </SECTION>
-                </REGTEXT>
-            </PART>""")
-        notice_xml = build.preprocess_notice_xml(notice_xml)
-        amd1b, amd2a = notice_xml.xpath("//AMDPAR")
-        self.assertEqual(amd1b.getparent().xpath(".//P")[0].text.strip(),
-                         "(b) Content")
-        self.assertEqual(amd2a.getparent().xpath(".//P")[0].text.strip(),
-                         "(b) Content")
-
-    def test_preprocess_notice_xml_interp_amds_are_ps(self):
-        notice_xml = etree.fromstring(u"""
-            <PART>
-                <REGTEXT>
-                    <AMDPAR>1. In § 105.1, revise paragraph (b):</AMDPAR>
-                    <SECTION>
-                        <STARS />
-                        <P>(b) Content</P>
-                    </SECTION>
-                    <P>2. In Supplement I to Part 105,</P>
-                    <P>A. Under Section 105.1, 1(b), paragraph 2 is revised</P>
-                    <P>The revisions are as follows</P>
-                    <HD SOURCE="HD1">Supplement I to Part 105</HD>
-                    <STARS />
-                    <P><E T="03">1(b) Heading</E></P>
-                    <STARS />
-                    <P>2. New Content</P>
-                </REGTEXT>
-            </PART>""")
-        notice_xml = build.preprocess_notice_xml(notice_xml)
-        amd1, amd2, amd2A, amd_other = notice_xml.xpath("//AMDPAR")
-        self.assertEqual(amd2A.text.strip(), "A. Under Section 105.1, 1(b), "
-                                             + "paragraph 2 is revised")
-
-    def test_preprocess_notice_xml_interp_amds_are_ps2(self):
-        notice_xml = etree.fromstring(u"""
-            <PART>
-                <REGTEXT>
-                    <AMDPAR>1. In Supplement I to Part 105,</AMDPAR>
-                    <P>A. Under Section 105.1, 1(b), paragraph 2 is revised</P>
-                    <P>The revisions are as follows</P>
-                    <HD SOURCE="HD1">Supplement I to Part 105</HD>
-                    <STARS />
-                    <P><E T="03">1(b) Heading</E></P>
-                    <STARS />
-                    <P>2. New Content</P>
-                </REGTEXT>
-            </PART>""")
-        notice_xml = build.preprocess_notice_xml(notice_xml)
-        amd1, amd1A, amd_other = notice_xml.xpath("//AMDPAR")
-        self.assertEqual(amd1A.text.strip(), "A. Under Section 105.1, 1(b), "
-                                             + "paragraph 2 is revised")
-
-    def test_preprocess_emph_tags(self):
-        notice_xml = etree.fromstring(u"""
-            <PART>
-                <P>(<E T="03">a</E>) Content</P>
-                <P>(<E T="03">a)</E> Content</P>
-                <P><E T="03">(a</E>) Content</P>
-                <P><E T="03">(a)</E> Content</P>
-            </PART>""")
-        notice_xml = build.preprocess_notice_xml(notice_xml)
-        pars = notice_xml.xpath("//P")
-        self.assertEqual(4, len(pars))
-        for par in pars:
-            self.assertEqual(par.text, "(")
-            self.assertEqual(1, len(par.getchildren()))
-            em = par.getchildren()[0]
-            self.assertEqual("E", em.tag)
-            self.assertEqual("a", em.text)
-            self.assertEqual(em.tail, ") Content")
-            self.assertEqual(0, len(em.getchildren()))
-
-        notice_xml = etree.fromstring(u"""
-            <PART>
-                <P><E T="03">Paragraph 22(a)(5)</E> Content</P>
-            </PART>""")
-        notice_xml = build.preprocess_notice_xml(notice_xml)
-        pars = notice_xml.xpath("//P")
-        self.assertEqual(1, len(pars))
-        em = pars[0].getchildren()[0]
-        self.assertEqual(em.text, "Paragraph 22(a)(5)")
-        self.assertEqual(em.tail, " Content")
-
     def test_fetch_cfr_parts(self):
-        notice_xml = etree.fromstring(u"""
-            <RULE>
-                <PREAMB>
-                    <CFR>12 CFR Parts 1002, 1024, and 1026</CFR>
-                </PREAMB>
-            </RULE>
-          """)
-
-        result = build.fetch_cfr_parts(notice_xml)
+        with self.tree.builder("RULE") as rule:
+            with rule.PREAMB() as preamb:
+                preamb.CFR("12 CFR Parts 1002, 1024, and 1026")
+        result = build.fetch_cfr_parts(self.tree.render_xml())
         self.assertEqual(result, ['1002', '1024', '1026'])
-
-

--- a/tests/notice_preprocessors_tests.py
+++ b/tests/notice_preprocessors_tests.py
@@ -1,0 +1,104 @@
+# vim: set encoding=utf-8
+from unittest import TestCase
+
+from lxml import etree
+
+from regparser.notice import preprocessors
+from tests.xml_builder import XMLBuilderMixin
+
+
+class MoveLastAMDParTests(XMLBuilderMixin, TestCase):
+    def test_improper_amdpar_location(self):
+        """The second AMDPAR is in the wrong parent; it should be moved"""
+        with self.tree.builder("PART") as part:
+            with part.REGTEXT(ID="RT1") as regtext:
+                regtext.AMDPAR(u"1. In § 105.1, revise paragraph (b):")
+                with regtext.SECTION() as section:
+                    section.P("Some Content")
+                # Note this has the wrong parent
+                regtext.AMDPAR(u"3. In § 105.2, revise paragraph (a) to read:")
+            with part.REGTEXT(ID="RT2") as regtext:
+                with regtext.SECTION() as section:
+                    section.P("Other Content")
+        xml = self.tree.render_xml()
+
+        preprocessors.MoveLastAMDPar().transform(xml)
+
+        amd1, amd2 = xml.xpath("//AMDPAR")
+        self.assertEqual(amd1.getparent().get("ID"), "RT1")
+        self.assertEqual(amd2.getparent().get("ID"), "RT2")
+
+    def test_trick_amdpar_location_diff_parts(self):
+        """Similar situation to the above, except the regulations describe
+        different parts and hence the AMDPAR should not move"""
+        with self.tree.builder("PART") as part:
+            with part.REGTEXT(ID="RT1", PART="105") as regtext:
+                regtext.AMDPAR(u"1. In § 105.1, revise paragraph (b):")
+                with regtext.SECTION() as section:
+                    section.P("Some Content")
+                regtext.AMDPAR(u"3. In § 105.2, revise paragraph (a) to read:")
+            with part.REGTEXT(ID="RT2", PART="107") as regtext:
+                with regtext.SECTION() as section:
+                    section.P("Other Content")
+        xml = self.tree.render_xml()
+
+        preprocessors.MoveLastAMDPar().transform(xml)
+
+        amd1, amd2 = xml.xpath("//AMDPAR")
+        self.assertEqual(amd1.getparent().get("ID"), "RT1")
+        self.assertEqual(amd2.getparent().get("ID"), "RT1")
+
+
+class SupplementAMDParTests(XMLBuilderMixin, TestCase):
+    def test_incorrect_ps(self):
+        """Supplement I AMDPARs are not always labeled as should be"""
+        with self.tree.builder("PART") as part:
+            with part.REGTEXT() as regtext:
+                regtext.AMDPAR(u"1. In § 105.1, revise paragraph (b):")
+                with regtext.SECTION() as section:
+                    section.STARS()
+                    section.P("(b) Content")
+                regtext.P("2. In Supplement I to Part 105,")
+                regtext.P("A. Under Section 105.1, 1(b), paragraph 2 is "
+                          "revised")
+                regtext.P("The revisions are as follows")
+                regtext.HD("Supplement I to Part 105", SOURCE="HD1")
+                regtext.STARS()
+                with regtext.P() as p:
+                    p.E("1(b) Heading", T="03")
+                regtext.STARS()
+                regtext.P("2. New Context")
+        xml = self.tree.render_xml()
+
+        preprocessors.SupplementAMDPar().transform(xml)
+
+        # Note that the SECTION paragraphs were not converted
+        self.assertEqual(
+            [amd.text for amd in xml.xpath("//AMDPAR")],
+            [u"1. In § 105.1, revise paragraph (b):",
+             "2. In Supplement I to Part 105,",
+             "A. Under Section 105.1, 1(b), paragraph 2 is revised",
+             "The revisions are as follows"])
+
+
+class ParenthesesCleanupTests(XMLBuilderMixin, TestCase):
+    def assert_transformed(self, original, new_text):
+        """Helper function to verify that the XML is transformed as
+        expected"""
+        self.setUp()
+        with self.tree.builder("PART") as part:
+            part.P(_xml=original)
+        xml = self.tree.render_xml()
+        preprocessors.ParenthesesCleanup().transform(xml)
+        self.assertEqual("<P>{}</P>".format(new_text),
+                         etree.tostring(xml[0]))
+
+    def test_transform(self):
+        """The parens should always move out"""
+        expected = '(<E T="03">a</E>) Content'
+        self.assert_transformed('(<E T="03">a</E>) Content', expected)
+        self.assert_transformed('(<E T="03">a)</E> Content', expected)
+        self.assert_transformed('<E T="03">(a</E>) Content', expected)
+        self.assert_transformed('<E T="03">(a)</E> Content', expected)
+        self.assert_transformed('<E T="03">Paragraph 22(a)(5)</E> Content',
+                                '<E T="03">Paragraph 22(a)(5)</E> Content')


### PR DESCRIPTION
The XML for notices around ATF regs include a relatively common mistake -- the text describing who approved a change is supposed to use the `APPRO` tag but often uses `FP`.

This extends the existing notice pre-processing scripts to account for this. Along the way,
* Split preprocessors into separate classes (a pattern in basically all of my recent pull requests)
* Use the XML DSL in the tests
* Make some of the logic within these scripts easier to follow

Ultimately, this has led to more functionality with fewer lines of code