### PR TITLE
Allow collapsed markers in MARKERLESS paragraphs

### DIFF
--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -93,7 +93,14 @@ class ParagraphProcessor(object):
         intro_node, nodes = self.separate_intro(nodes)
         if intro_node:
             root.text += " " + intro_node.text
-            root.tagged_text += " " + intro_node.tagged_text
+            # @todo - this is ugly. Make tagged_text a legitimate field on Node
+            tagged_text_list = []
+            if hasattr(root, 'tagged_text'):
+                tagged_text_list.append(root.tagged_text)
+            if hasattr(intro_node, 'tagged_text'):
+                tagged_text_list.append(intro_node.tagged_text)
+            if tagged_text_list:
+                root.tagged_text = ' '.join(tagged_text_list)
         if nodes:
             markers = [node.label[0] for node in nodes]
             depths = derive_depths(markers, self.additional_constraints())

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -269,7 +269,7 @@ class MarkerMatcher(object):
         for m, node_text in get_markers_and_text(xml, markers_list):
             text, tagged_text = node_text
             node = Node(text=text.strip(), label=[m], source_xml=xml)
-            node.tagged_text = unicode(tagged_text)
+            node.tagged_text = unicode(tagged_text.strip())
             nodes.append(node)
         if text.endswith('* * *'):
             nodes.append(Node(label=[mtypes.INLINE_STARS]))
@@ -289,19 +289,12 @@ class MarkerMatcher(object):
             node = node.getnext()
 
 
-class NoMarkerMatcher(object):
+class NoMarkerMatcher(MarkerMatcher):
     """<P> or <FP> which has no initial paragraph markers. FP is a "flush
     paragraph", a display-oriented distinction which we will ignore"""
     def matches(self, xml):
         tagged_text = tree_utils.get_node_text_tags_preserved(xml).strip()
         return xml.tag in ('P', 'FP') and not bool(get_markers(tagged_text))
-
-    def derive_nodes(self, xml):
-        text = tree_utils.get_node_text(xml, add_spaces=True).strip()
-        tagged_text = tree_utils.get_node_text_tags_preserved(xml).strip()
-        node = Node(text=text, label=[mtypes.MARKERLESS])
-        node.tagged_text = unicode(tagged_text.strip())
-        return [node]
 
 
 class RegtextParagraphProcessor(paragraph_processor.ParagraphProcessor):

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -255,11 +255,10 @@ def build_from_section(reg_part, section_xml):
     return section_nodes
 
 
-class MarkerMatcher(object):
-    """<P> with initial paragraph markers -- (a)(1)(i) etc."""
+class ParagraphMatcher(object):
+    """<P>/<FP> with or without initial paragraph markers -- (a)(1)(i) etc."""
     def matches(self, xml):
-        tagged_text = tree_utils.get_node_text_tags_preserved(xml).strip()
-        return xml.tag == 'P' and bool(get_markers(tagged_text))
+        return xml.tag in ('P', 'FP')
 
     def derive_nodes(self, xml):
         text = ''
@@ -289,21 +288,12 @@ class MarkerMatcher(object):
             node = node.getnext()
 
 
-class NoMarkerMatcher(MarkerMatcher):
-    """<P> or <FP> which has no initial paragraph markers. FP is a "flush
-    paragraph", a display-oriented distinction which we will ignore"""
-    def matches(self, xml):
-        tagged_text = tree_utils.get_node_text_tags_preserved(xml).strip()
-        return xml.tag in ('P', 'FP') and not bool(get_markers(tagged_text))
-
-
 class RegtextParagraphProcessor(paragraph_processor.ParagraphProcessor):
     NODE_TYPE = Node.REGTEXT
     MATCHERS = [paragraph_processor.StarsMatcher(),
                 paragraph_processor.TableMatcher(),
                 paragraph_processor.FencedMatcher(),
-                MarkerMatcher(),
-                NoMarkerMatcher()]
+                ParagraphMatcher()]
 
     def additional_constraints(self):
         return [rules.depth_type_inverses]

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -440,7 +440,7 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
         self.assertEqual(subjgrp_2.label, ['123', 'Subjgrp', 'ATL'])
 
 
-class MarkerMatcherTests(XMLBuilderMixin, TestCase):
+class ParagraphMatcherTests(XMLBuilderMixin, TestCase):
     def test_next_marker_found(self):
         """Find the first paragraph marker following a paragraph"""
         with self.tree.builder("ROOT") as root:
@@ -449,7 +449,7 @@ class MarkerMatcherTests(XMLBuilderMixin, TestCase):
             root.P("(d) ddd")
             root.P("(1) 111")
         xml = self.tree.render_xml()[1]
-        self.assertEqual(reg_text.MarkerMatcher().next_marker(xml), 'd')
+        self.assertEqual(reg_text.ParagraphMatcher().next_marker(xml), 'd')
 
     def test_next_marker_stars(self):
         """STARS tag has special significance."""
@@ -460,7 +460,7 @@ class MarkerMatcherTests(XMLBuilderMixin, TestCase):
             root.P("(d) ddd")
             root.P("(1) 111")
         xml = self.tree.render_xml()[1]
-        self.assertEqual(reg_text.MarkerMatcher().next_marker(xml),
+        self.assertEqual(reg_text.ParagraphMatcher().next_marker(xml),
                          mtypes.STARS_TAG)
 
     def test_next_marker_none(self):
@@ -469,7 +469,7 @@ class MarkerMatcherTests(XMLBuilderMixin, TestCase):
             root.P("(1) 111")
             root.P("Content")
         xml = self.tree.render_xml()[0]
-        self.assertIsNone(reg_text.MarkerMatcher().next_marker(xml))
+        self.assertIsNone(reg_text.ParagraphMatcher().next_marker(xml))
 
 
 class RegtextParagraphProcessorTests(XMLBuilderMixin, NodeAccessorMixin,


### PR DESCRIPTION
* Combine markerless and marker-full paragraph processing (`get_markers_and_text`) had been updated previously to account for markerless introductions
* Updated to strip whitespace from the tagged text (matching the Markerless processor)
* Account for corner cases where the root node didn't have `tagged_text`
* Test

Resolves 18F/atf-eregs#32