### PR TITLE
Remove node-dict-node conversion

### DIFF
--- a/regparser/notice/changes.py
+++ b/regparser/notice/changes.py
@@ -147,7 +147,7 @@ def match_labels_and_changes(amendments, section_node):
 def format_node(node, amendment):
     """ Format a node into a dict, and add in amendment information. """
     node_as_dict = {
-        'node': node_to_dict(node),
+        'node': node,
         'action': amendment['action'],
     }
 

--- a/regparser/notice/changes.py
+++ b/regparser/notice/changes.py
@@ -14,19 +14,6 @@ from regparser.tree import struct
 from regparser.tree.paragraph import p_levels
 
 
-def node_to_dict(node):
-    """ Convert a node to a dictionary representation. We skip the
-    children, turning them instead into a list of labels instead. """
-    if not hasattr(node, 'child_labels'):
-        node.child_labels = [c.label_id() for c in node.children]
-
-    node_dict = {}
-    for k, v in node.__dict__.items():
-        if k not in ('children', 'source_xml'):
-            node_dict[k] = v
-    return node_dict
-
-
 def bad_label(node):
     """ Look through a node label, and return True if it's a badly formed
     label. We can do this because we know what type of character should up at
@@ -148,7 +135,7 @@ def match_labels_and_changes(amendments, section_node):
 
 def format_node(node, amendment):
     """ Format a node and add in amendment information. """
-    
+
     # Copy the node, remove it's children, and dump its XML to string
     node_no_kids = copy.deepcopy(node)
     node_no_kids.children = []

--- a/regparser/notice/changes.py
+++ b/regparser/notice/changes.py
@@ -6,6 +6,8 @@ import logging
 import copy
 from collections import defaultdict
 
+from lxml import etree
+
 from regparser.grammar.tokens import Verb
 from regparser.layer.paragraph_markers import marker_of
 from regparser.tree import struct
@@ -145,9 +147,20 @@ def match_labels_and_changes(amendments, section_node):
 
 
 def format_node(node, amendment):
-    """ Format a node into a dict, and add in amendment information. """
+    """ Format a node and add in amendment information. """
+    
+    # Copy the node, remove it's children, and dump its XML to string
+    node_no_kids = copy.deepcopy(node)
+    node_no_kids.children = []
+
+    try:
+        node_no_kids.source_xml = etree.tostring(node_no_kids.source_xml)
+    except TypeError:
+        # source_xml wasn't serializable
+        pass
+
     node_as_dict = {
-        'node': node,
+        'node': node_no_kids,
         'action': amendment['action'],
     }
 

--- a/regparser/notice/compiler.py
+++ b/regparser/notice/compiler.py
@@ -7,6 +7,8 @@ import copy
 import itertools
 import logging
 
+from lxml import etree
+
 from regparser.grammar.tokens import Verb
 from regparser.tree.struct import Node, find
 from regparser.tree.xml_parser import interpretations
@@ -478,6 +480,14 @@ def one_change(reg, label, change):
     single change to the tree."""
     field_list = ['[text]', '[title]', '[heading]']
     replace_subtree = 'field' not in change
+
+    # Conver the change's node's source_xml to Element in place if needed
+    if 'node' in change:
+        try:
+            change['node'].source_xml = etree.fromstring(
+                    change['node'].source_xml)
+        except ValueError:
+            pass
 
     if change['action'] == 'PUT' and replace_subtree:
         node = change['node']

--- a/regparser/notice/compiler.py
+++ b/regparser/notice/compiler.py
@@ -331,8 +331,8 @@ class RegulationTree(object):
             if existing:
                 logging.warning(
                     'Adding a node that already exists: %s' % node.label_id())
-                print '%s %s' % (existing.text, node.label)
-                print '----'
+                # print '%s %s' % (existing.text, node.label)
+                # print '----'
 
             if ((node.node_type == Node.APPENDIX and len(node.label) == 2)
                     or node.node_type == Node.SUBPART):
@@ -364,23 +364,23 @@ class RegulationTree(object):
         """ Replace just a node's text. """
 
         node = find(self.tree, label)
-        node.text = change['node']['text']
+        node.text = change['node'].text
 
     def replace_node_title(self, label, change):
         """ Replace just a node's title. """
 
         node = find(self.tree, label)
-        node.title = change['node']['title']
+        node.title = change['node'].title
 
     def replace_node_heading(self, label, change):
         """ A node's heading is it's keyterm. We handle this here, but not
         well, I think. """
         node = find(self.tree, label)
-        node.text = replace_first_sentence(node.text, change['node']['text'])
+        node.text = replace_first_sentence(node.text, change['node'].text)
 
-        if hasattr(node, 'tagged_text') and 'tagged_text' in change['node']:
+        if hasattr(node, 'tagged_text') and change['node'].tagged_text is not None:
             node.tagged_text = replace_first_sentence(
-                node.tagged_text, change['node']['tagged_text'])
+                node.tagged_text, change['node'].tagged_text)
 
     def get_subparts(self):
         """ Get all the subparts and empty parts in the tree.  """
@@ -480,12 +480,12 @@ def one_change(reg, label, change):
     replace_subtree = 'field' not in change
 
     if change['action'] == 'PUT' and replace_subtree:
-        node = dict_to_node(change['node'])
+        node = change['node']
         reg.replace_node_and_subtree(node)
     elif change['action'] == 'PUT' and change['field'] in field_list:
         replace_node_field(reg, label, change)
     elif change['action'] == 'POST':
-        node = dict_to_node(change['node'])
+        node = change['node']
         if 'subpart' in change and len(node.label) == 2:
             reg.add_section(node, change['subpart'])
         else:
@@ -498,7 +498,7 @@ def one_change(reg, label, change):
     elif change['action'] == 'DELETE':
         reg.delete(label)
     elif change['action'] == 'RESERVE':
-        node = dict_to_node(change['node'])
+        node = change['node']
         reg.reserve(label, node)
     else:
         print "%s: %s" % (change['action'], label)
@@ -512,7 +512,7 @@ def _needs_delay(reg, change):
     if action == 'MOVE':
         return reg.contains(change['destination'])
     if action == 'POST':
-        existing = reg.find_node(change['node']['label'])
+        existing = reg.find_node(change['node'].label)
         return existing and not is_reserved_node(existing)
     return False
 

--- a/regparser/notice/compiler.py
+++ b/regparser/notice/compiler.py
@@ -380,7 +380,8 @@ class RegulationTree(object):
         node = find(self.tree, label)
         node.text = replace_first_sentence(node.text, change['node'].text)
 
-        if hasattr(node, 'tagged_text') and change['node'].tagged_text is not None:
+        if (hasattr(node, 'tagged_text')
+                and change['node'].tagged_text is not None):
             node.tagged_text = replace_first_sentence(
                 node.tagged_text, change['node'].tagged_text)
 
@@ -434,24 +435,6 @@ class RegulationTree(object):
                 self.delete('-'.join(subpart_with_node.label))
 
 
-def dict_to_node(node_dict):
-    """ Convert a dictionary representation of a node into a Node object if
-    it contains the minimum required fields. Otherwise, pass it through
-    unchanged. """
-    minimum_fields = set(('text', 'label', 'node_type'))
-    if minimum_fields.issubset(node_dict.keys()):
-        node = Node(
-            node_dict['text'], [], node_dict['label'],
-            node_dict.get('title', None), node_dict['node_type'])
-        if 'tagged_text' in node_dict:
-            node.tagged_text = node_dict['tagged_text']
-        if 'child_labels' in node_dict:
-            node.child_labels = node_dict['child_labels']
-        return node
-    else:
-        return node_dict
-
-
 def sort_labels(labels):
     """ Deal with higher up elements first. """
     sorted_labels = sorted(labels, key=lambda x: len(x))
@@ -485,7 +468,7 @@ def one_change(reg, label, change):
     if 'node' in change:
         try:
             change['node'].source_xml = etree.fromstring(
-                    change['node'].source_xml)
+                change['node'].source_xml)
         except ValueError:
             pass
 

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -129,7 +129,7 @@ class AppendixProcessor(object):
             label, title_depth = pair
             self.depth = title_depth - 1
             n = Node(node_type=Node.APPENDIX, label=[label],
-                     title=text)
+                     title=text, source_xml=xml_node)
         #   Look through parents to determine which level this should be
         else:
             self.header_count += 1
@@ -379,6 +379,7 @@ def initial_marker(text):
         marker = (match.paren_upper or match.paren_lower or match.paren_digit
                   or match.period_upper or match.period_lower
                   or match.period_digit)
+
         if len(marker) < 3 or all(char in 'ivxlcdm' for char in marker):
             return marker, text[:end]
 

--- a/tests/notice_build_tests.py
+++ b/tests/notice_build_tests.py
@@ -216,7 +216,7 @@ class NoticeBuildTest(XMLBuilderMixin, TestCase):
 
         changes = notice['changes']['105-1-b'][0]
         self.assertEqual(changes['action'], 'PUT')
-        self.assertTrue(changes['node']['text'].startswith(
+        self.assertTrue(changes['node'].text.startswith(
             u'(b) This part carries out.'))
 
     def test_process_amendments_multiple_in_same_parent(self):
@@ -238,11 +238,11 @@ class NoticeBuildTest(XMLBuilderMixin, TestCase):
 
         changes = notice['changes']['105-1-b'][0]
         self.assertEqual(changes['action'], 'PUT')
-        self.assertEqual(changes['node']['text'].strip(),
+        self.assertEqual(changes['node'].text.strip(),
                          u'(b) This part carries out.')
         changes = notice['changes']['105-1-c'][0]
         self.assertEqual(changes['action'], 'PUT')
-        self.assertTrue(changes['node']['text'].strip(),
+        self.assertTrue(changes['node'].text.strip(),
                         u'(c) More stuff')
 
     def test_process_amendments_restart_new_section(self):
@@ -324,7 +324,7 @@ class NoticeBuildTest(XMLBuilderMixin, TestCase):
             self.assertEqual(n['action'], 'POST')
 
         self.assertEqual(
-            subpart_changes['105-Subpart-B']['node']['node_type'], 'subpart')
+            subpart_changes['105-Subpart-B']['node'].node_type, 'subpart')
 
     def test_process_amendments_subpart(self):
         notice = {'cfr_parts': ['105']}
@@ -436,7 +436,7 @@ class NoticeBuildTest(XMLBuilderMixin, TestCase):
 
         reserve = notice_changes.changes['200-2-a'][0]
         self.assertEqual(reserve['action'], 'RESERVE')
-        self.assertEqual(reserve['node']['text'], u'[Reserved]')
+        self.assertEqual(reserve['node'].text, u'[Reserved]')
 
     def test_create_xml_changes_stars(self):
         labels_amended = [Amendment('PUT', '200-2-a')]

--- a/tests/notice_changes_tests.py
+++ b/tests/notice_changes_tests.py
@@ -78,9 +78,8 @@ class ChangesTests(TestCase):
             self.assertTrue(l in amends)
 
         for label, node in amends.items():
-            self.assertEqual(label, '-'.join(node['node']['label']))
+            self.assertEqual(label, '-'.join(node['node'].label))
             self.assertEqual(node['action'], 'POST')
-            self.assertFalse('children' in node['node'])
 
     def test_flatten_tree(self):
         tree = self.build_tree()

--- a/tests/notice_compiler_tests.py
+++ b/tests/notice_compiler_tests.py
@@ -402,7 +402,7 @@ class CompilerTests(TestCase):
     def test_replace_node_text(self):
         root = self.tree_with_paragraphs()
 
-        change = {'node': {'text': 'new text'}}
+        change = {'node': Node(text='new text')}
         reg_tree = compiler.RegulationTree(root)
 
         reg_tree.replace_node_text('205-2-a', change)
@@ -412,7 +412,7 @@ class CompilerTests(TestCase):
     def test_replace_node_title(self):
         root = self.tree_with_paragraphs()
 
-        change = {'node': {'title': 'new title'}}
+        change = {'node': Node(title='new title')}
         reg_tree = compiler.RegulationTree(root)
 
         reg_tree.replace_node_title('205-2-a', change)
@@ -425,7 +425,7 @@ class CompilerTests(TestCase):
         n2a.text = 'Previous keyterm. Remainder.'
         reg_tree = compiler.RegulationTree(root)
 
-        change = {'node': {'text': 'Replaced.'}}
+        change = {'node': Node(text='Replaced.')}
         reg_tree.replace_node_heading('205-2-a', change)
 
         changed_node = find(reg_tree.tree, '205-2-a')
@@ -537,17 +537,17 @@ class CompilerTests(TestCase):
 
         change2a = {
             'action': 'PUT',
-            'node': {
-                'text': 'new text',
-                'label': ['205', '2', 'a'],
-                'node_type': 'regtext'}}
+            'node': Node(
+                text='new text',
+                label=['205', '2', 'a'],
+                node_type=Node.REGTEXT)}
 
         change2a1 = {
             'action': 'PUT',
-            'node': {
-                'text': '2a1 text',
-                'label': ['205', '2', 'a', '1'],
-                'node_type': 'regtext'}}
+            'node': Node(
+                text='2a1 text',
+                label=['205', '2', 'a', '1'],
+                node_type=Node.REGTEXT)}
 
         notice_changes = {
             '205-2-a-1': [change2a1],
@@ -567,10 +567,10 @@ class CompilerTests(TestCase):
         change2a = {
             'action': 'PUT',
             'field': '[text]',
-            'node': {
-                'text': 'new text',
-                'label': ['205', '2', 'a'],
-                'node_type': 'regtext'}}
+            'node': Node(
+                text='new text',
+                label=['205', '2', 'a'],
+                node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2-a': [change2a]}
         reg = compiler.compile_regulation(root, notice_changes)
@@ -581,11 +581,11 @@ class CompilerTests(TestCase):
     def test_compile_reg_keep_root(self):
         root = self.tree_with_paragraphs()
         change2 = {'action': 'KEEP',
-                   'node': {'text': '* * *', 'label': ['205', '2'],
-                            'node_type': 'regtext'}}
+                   'node': Node(text='* * *', label=['205', '2'],
+                            node_type=Node.REGTEXT)}
         change2a = {'action': 'PUT',
-                    'node': {'text': '(a) A Test', 'label': ['205', '2', 'a'],
-                             'node_type': 'regtext'}}
+                    'node': Node(text='(a) A Test', label=['205', '2', 'a'],
+                             node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2': [change2], '205-2-a': [change2a]}
         reg = compiler.compile_regulation(root, notice_changes)
@@ -603,14 +603,14 @@ class CompilerTests(TestCase):
     def test_compile_reg_keep_child(self):
         root = self.tree_with_paragraphs()
         change2 = {'action': 'PUT',
-                   'node': {'text': 'n2n2', 'label': ['205', '2'],
-                            'node_type': 'regtext'}}
+                   'node': Node(text='n2n2', label=['205', '2'],
+                            node_type=Node.REGTEXT)}
         change2a = {'action': 'KEEP',
-                    'node': {'text': '(a) * * *', 'label': ['205', '2', 'a'],
-                             'node_type': 'regtext'}}
+                    'node': Node(text='(a) * * *', label=['205', '2', 'a'],
+                             node_type=Node.REGTEXT)}
         change2b = {'action': 'PUT',
-                    'node': {'text': '(b) A Test', 'label': ['205', '2', 'b'],
-                             'node_type': 'regtext'}}
+                    'node': Node(text='(b) A Test', label=['205', '2', 'b'],
+                             node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2': [change2], '205-2-a': [change2a],
                           '205-2-b': [change2b]}
@@ -627,10 +627,10 @@ class CompilerTests(TestCase):
         root = self.tree_with_paragraphs()
         change2a1 = {
             'action': 'POST',
-            'node': {
-                'text': '2a1 text',
-                'label': ['205', '2', 'a', '1'],
-                'node_type': 'regtext'}}
+            'node': Node(
+                text='2a1 text',
+                label=['205', '2', 'a', '1'],
+                node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2-a-1': [change2a1]}
         reg = compiler.compile_regulation(root, notice_changes)
@@ -655,10 +655,10 @@ class CompilerTests(TestCase):
         change = {
             'action': 'POST',
             'subpart': ['205', 'Subpart', 'B'],
-            'node': {
-                'text': '2 text',
-                'label': ['205', '2'],
-                'node_type': 'regtext'}}
+            'node': Node(
+                text='2 text',
+                label=['205', '2'],
+                node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2': [change]}
         reg = compiler.compile_regulation(root, notice_changes)
@@ -671,10 +671,10 @@ class CompilerTests(TestCase):
         change = {
             'action': 'POST',
             'subpart': ['205', 'Subpart', 'B'],
-            'node': {
-                'text': '2 text',
-                'label': ['205', '2'],
-                'node_type': 'regtext'}}
+            'node': Node(
+                text='2 text',
+                label=['205', '2'],
+                node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2': [change]}
         reg = compiler.compile_regulation(root, notice_changes)
@@ -884,9 +884,9 @@ class CompilerTests(TestCase):
         changes = {
             '205-2-a': [
                 {'action': 'MOVE', 'destination': ['205', '2', 'b']},
-                {'action': 'POST', 'node': {'text': 'aaa',
-                                            'label': ['205', '2', 'a'],
-                                            'node_type': Node.REGTEXT}}],
+                {'action': 'POST', 'node': Node(text='aaa',
+                                            label=['205', '2', 'a'],
+                                            node_type=Node.REGTEXT)}],
             '205-2-b': [{'action': 'DELETE'}]}
 
         class SortedKeysDict(object):

--- a/tests/notice_compiler_tests.py
+++ b/tests/notice_compiler_tests.py
@@ -6,37 +6,6 @@ from regparser.tree.struct import Node, find
 
 
 class CompilerTests(TestCase):
-    def test_dict_to_node(self):
-        dict_node = {
-            'text': 'node text',
-            'label': ['205', 'A'],
-            'node_type': 'appendix'}
-
-        node = compiler.dict_to_node(dict_node)
-
-        self.assertEqual(
-            node,
-            Node('node text', [], ['205', 'A'], None, 'appendix'))
-
-        dict_node['tagged_text'] = '<E> Tagged </E> text.'
-
-        node = compiler.dict_to_node(dict_node)
-
-        actual_node = Node('node text', [], ['205', 'A'], None, 'appendix')
-        actual_node.tagged_text = '<E> Tagged </E> text.'
-
-        created_node = compiler.dict_to_node(dict_node)
-
-        self.assertEqual(actual_node, created_node)
-        self.assertEqual(actual_node.tagged_text, created_node.tagged_text)
-
-        dict_node = {
-            'text': 'node text'
-        }
-
-        node = compiler.dict_to_node(dict_node)
-        self.assertEqual(node, dict_node)
-
     def test_sort_labels(self):
         labels = [
             ['205', '2', 'a', 'i'], ['205', 'Subpart', 'A'], ['205', '2']]
@@ -582,10 +551,10 @@ class CompilerTests(TestCase):
         root = self.tree_with_paragraphs()
         change2 = {'action': 'KEEP',
                    'node': Node(text='* * *', label=['205', '2'],
-                            node_type=Node.REGTEXT)}
+                                node_type=Node.REGTEXT)}
         change2a = {'action': 'PUT',
                     'node': Node(text='(a) A Test', label=['205', '2', 'a'],
-                             node_type=Node.REGTEXT)}
+                                 node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2': [change2], '205-2-a': [change2a]}
         reg = compiler.compile_regulation(root, notice_changes)
@@ -604,13 +573,13 @@ class CompilerTests(TestCase):
         root = self.tree_with_paragraphs()
         change2 = {'action': 'PUT',
                    'node': Node(text='n2n2', label=['205', '2'],
-                            node_type=Node.REGTEXT)}
+                                node_type=Node.REGTEXT)}
         change2a = {'action': 'KEEP',
                     'node': Node(text='(a) * * *', label=['205', '2', 'a'],
-                             node_type=Node.REGTEXT)}
+                                 node_type=Node.REGTEXT)}
         change2b = {'action': 'PUT',
                     'node': Node(text='(b) A Test', label=['205', '2', 'b'],
-                             node_type=Node.REGTEXT)}
+                                 node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2': [change2], '205-2-a': [change2a],
                           '205-2-b': [change2b]}
@@ -885,8 +854,8 @@ class CompilerTests(TestCase):
             '205-2-a': [
                 {'action': 'MOVE', 'destination': ['205', '2', 'b']},
                 {'action': 'POST', 'node': Node(text='aaa',
-                                            label=['205', '2', 'a'],
-                                            node_type=Node.REGTEXT)}],
+                                                label=['205', '2', 'a'],
+                                                node_type=Node.REGTEXT)}],
             '205-2-b': [{'action': 'DELETE'}]}
 
         class SortedKeysDict(object):

--- a/watch_node.py
+++ b/watch_node.py
@@ -11,7 +11,7 @@ except ImportError:
     pass
 
 from regparser.builder import tree_and_builder
-from regparser.notice.changes import node_to_dict, pretty_change
+from regparser.notice.changes import pretty_change
 from regparser.tree.struct import find
 
 
@@ -29,8 +29,7 @@ if __name__ == "__main__":
     initial_node = find(initial_tree, args.node_label)
     if initial_node:
         print("> " + builder.doc_number)
-        print("\t" + pretty_change(
-            {'action': 'POST', 'node': node_to_dict(initial_node)}))
+        print("\t" + pretty_change({'action': 'POST', 'node': initial_node}))
 
     # search for label
     for version, changes in builder.changes_in_sequence():


### PR DESCRIPTION
Corresponds to much of @willbarton's cfpb/regulations-parser#296. Final commit removes the functions altogether and PEP8s the related files