### PR TITLE
Clear command

### DIFF
--- a/regparser/commands/clear.py
+++ b/regparser/commands/clear.py
@@ -1,0 +1,16 @@
+import os
+import shutil
+
+import click
+
+from regparser import eregs_index
+
+
+@click.command()
+def clear():
+    """Delete all intermediate data. Generally not needed, but this is a
+    simple method to start fresh regarding intermediate and cached data"""
+    if os.path.exists(eregs_index.ROOT):
+        shutil.rmtree(eregs_index.ROOT)
+    if os.path.exists("fr_cache.sqlite"):
+        os.remove("fr_cache.sqlite")

--- a/tests/commands_clear_tests.py
+++ b/tests/commands_clear_tests.py
@@ -1,0 +1,36 @@
+import os
+from unittest import TestCase
+
+from click.testing import CliRunner
+
+from regparser import eregs_index
+from regparser.commands.clear import clear
+
+
+class CommandsClearTests(TestCase):
+    def setUp(self):
+        self.cli = CliRunner()
+
+    def test_no_errors_when_clear(self):
+        """Should raise no errors when no cached files are present"""
+        with self.cli.isolated_filesystem():
+            self.cli.invoke(clear)
+
+    def test_deletes_fr_cache(self):
+        with self.cli.isolated_filesystem():
+            open('fr_cache.sqlite', 'w').close()
+            self.assertTrue(os.path.exists('fr_cache.sqlite'))
+
+            self.cli.invoke(clear)
+            self.assertFalse(os.path.exists('fr_cache.sqlite'))
+
+    def test_deletes_index(self):
+        with self.cli.isolated_filesystem():
+            eregs_index.Path('aaa').write('bbb', 'ccc')
+            eregs_index.Path('bbb').write('ccc', 'ddd')
+            self.assertEqual(1, len(eregs_index.Path("aaa")))
+            self.assertEqual(1, len(eregs_index.Path("bbb")))
+
+            self.cli.invoke(clear)
+            self.assertEqual(0, len(eregs_index.Path("aaa")))
+            self.assertEqual(0, len(eregs_index.Path("bbb")))


### PR DESCRIPTION
Builds on #80 ([diff](https://github.com/cmc333333/regulations-parser/compare/preprocess_notices...cmc333333:clear-command)), to add a `clear` command, which deletes any entries in the `.eregs_index` and any related to the `requests` cache