### PR TITLE
Add commands for processing annual editions

### DIFF
--- a/eregs.py
+++ b/eregs.py
@@ -1,3 +1,4 @@
+import logging
 from importlib import import_module
 import pkgutil
 
@@ -16,7 +17,7 @@ except ImportError:
 
 @click.group()
 def cli():
-    pass
+    logging.basicConfig(level=logging.INFO)
 
 
 for _, command_name, _ in pkgutil.iter_modules(commands.__path__):

--- a/regparser/commands/annual_editions.py
+++ b/regparser/commands/annual_editions.py
@@ -1,0 +1,68 @@
+from collections import namedtuple
+from datetime import date
+
+import click
+
+from regparser import eregs_index
+from regparser.api_writer import AmendmentNodeEncoder
+from regparser.history import annual
+from regparser.tree import xml_parser
+
+# @todo - review this encoder -- we're using it now as it is what was used by
+# build_from
+json_encoder = AmendmentNodeEncoder(sort_keys=True, indent=4,
+                                    separators=(', ', ': '))
+
+
+LastVersionInYear = namedtuple('LastVersionInYear', ['version_id', 'year'])
+
+
+def last_versions(cfr_title, cfr_part):
+    """Run through all known versions of this regulation and pull out versions
+    which are the last to be included before an annual edition"""
+    have_annual_edition = {}
+    path = eregs_index.VersionPath(cfr_title, cfr_part)
+    if len(path) == 0:
+        raise click.UsageError("No versions found. Run `versions`?")
+    for version in path:
+        pub_date = annual.date_of_annual_after(cfr_title, version.effective)
+        if pub_date < date.today():
+            have_annual_edition[pub_date.year] = version.identifier
+    for year in sorted(have_annual_edition.keys()):
+        yield LastVersionInYear(have_annual_edition[year], year)
+
+
+def process(last_version, input_path, output_path):
+    """Parse the XML into a JSON tree; write it to disk"""
+    xml = input_path.read_xml(last_version.year)
+    tree = xml_parser.reg_text.build_tree(xml)
+    output_path.write(last_version.version_id, json_encoder.encode(tree))
+
+
+def process_if_needed(cfr_title, cfr_part, last_versions):
+    """Calculate dependencies between input and output files for these annual
+    editions. If an output is missing or out of date, process it"""
+    annual_path = eregs_index.Path("annual", cfr_title, cfr_part)
+    tree_path = eregs_index.Path("tree", cfr_title, cfr_part)
+    deps = eregs_index.DependencyGraph()
+
+    for last_version in last_versions:
+        deps.add(('tree', cfr_title, cfr_part, last_version.version_id),
+                 ('version', cfr_title, cfr_part, last_version.version_id))
+        deps.add(('tree', cfr_title, cfr_part, last_version.version_id),
+                 ('annual', cfr_title, cfr_part, last_version.year))
+
+    for last_version in last_versions:
+        deps.validate_for('tree', cfr_title, cfr_part, last_version.version_id)
+        if deps.is_stale('tree', cfr_title, cfr_part, last_version.version_id):
+            process(last_version, annual_path, tree_path)
+
+
+@click.command()
+@click.argument('cfr_title', type=int)
+@click.argument('cfr_part', type=int)
+def annual_editions(cfr_title, cfr_part):
+    """Parse available annual editions for this reg. Cycles through all known
+    versions and parses the annual edition XML when relevant"""
+    versions = list(last_versions(cfr_title, cfr_part))
+    process_if_needed(cfr_title, cfr_part, versions)

--- a/regparser/commands/fetch_annual_edition.py
+++ b/regparser/commands/fetch_annual_edition.py
@@ -1,0 +1,17 @@
+import click
+from lxml import etree
+
+from regparser import eregs_index
+from regparser.history import annual
+
+
+@click.command()
+@click.argument('cfr_title', type=int)
+@click.argument('cfr_part', type=int)
+@click.argument('year', type=int)
+def fetch_annual_edition(cfr_title, cfr_part, year):
+    """Download an annual edition of a regulation"""
+    path = eregs_index.Path('annual', cfr_title, cfr_part)
+    volume = annual.find_volume(year, cfr_title, cfr_part)
+    xml = volume.find_part_xml(cfr_part)
+    path.write(year, etree.tostring(xml))

--- a/regparser/commands/preprocess_notice.py
+++ b/regparser/commands/preprocess_notice.py
@@ -20,7 +20,7 @@ def preprocess_notice(document_number):
     for notice_xml in notice_xmls:
         file_name = document_number
         notice_xml.published = meta['publication_date']
-        notice_xml.volume = meta['volume']
+        notice_xml.fr_volume = meta['volume']
 
         if len(notice_xmls) > 1:
             effective_date = notice_xml.derive_effective_date()

--- a/regparser/commands/versions.py
+++ b/regparser/commands/versions.py
@@ -80,6 +80,9 @@ def write_if_needed(cfr_title, cfr_part, version_ids, xmls, delays):
 @click.argument('cfr_title', type=int)
 @click.argument('cfr_part', type=int)
 def versions(cfr_title, cfr_part):
+    """Find all Versions for a regulation. Accounts for locally modified
+    notice XML and rules modifying the effective date of versions of a
+    regulation"""
     cfr_title, cfr_part = str(cfr_title), str(cfr_part)
     notice_path = eregs_index.Path("notice_xml")
 

--- a/regparser/commands/versions.py
+++ b/regparser/commands/versions.py
@@ -55,12 +55,12 @@ def generate_dependencies(cfr_title, cfr_part, version_ids, delays):
     return deps
 
 
-def write_to_disk(xml, path, delay=None):
+def write_to_disk(xml, version_path, delay=None):
     """Serialize a Version instance to disk"""
     effective = xml.effective if delay is None else delay.until
     version = Version(identifier=xml.version_id, effective=effective,
                       published=xml.published)
-    path.write(xml.version_id, version.json())
+    version_path.write(version)
 
 
 def write_if_needed(cfr_title, cfr_part, version_ids, xmls, delays):
@@ -68,7 +68,7 @@ def write_if_needed(cfr_title, cfr_part, version_ids, xmls, delays):
     because their dependency has been updated) are written to disk. If any
     dependency is missing, an exception is raised"""
     deps = generate_dependencies(cfr_title, cfr_part, version_ids, delays)
-    version_path = eregs_index.Path("version", cfr_title, cfr_part)
+    version_path = eregs_index.VersionPath(cfr_title, cfr_part)
     for version_id in version_ids:
         deps.validate_for("version", cfr_title, cfr_part, version_id)
         if deps.is_stale("version", cfr_title, cfr_part, version_id):

--- a/regparser/commands/versions.py
+++ b/regparser/commands/versions.py
@@ -1,0 +1,90 @@
+from collections import namedtuple
+import re
+
+import click
+
+from regparser import eregs_index
+from regparser.federalregister import fetch_notice_json
+from regparser.history.versions import Version
+from regparser.notice.xml import NoticeXML
+
+
+def fetch_version_ids(cfr_title, cfr_part, notice_path):
+    """Returns a list of version ids after looking them up between the federal
+    register and the local filesystem"""
+    version_ids = []
+    final_rules = fetch_notice_json(cfr_title, cfr_part, only_final=True)
+
+    for document_number in (fr['document_number'] for fr in final_rules):
+        # Document number followed by a date
+        regex = re.compile(re.escape(document_number) + r"_\d{8}")
+        version_ids.extend(
+            [name for name in notice_path if regex.match(name)]
+            or [document_number])
+
+    return version_ids
+
+
+Delay = namedtuple('Delay', ['by', 'until'])
+
+
+def delays(xmls):
+    """Find all changes to effective dates. Return the latest change to each
+    version of the regulation"""
+    delays = {}
+    # Sort so that later modifications override earlier ones
+    for delayer in sorted(xmls, key=lambda xml: xml.published):
+        for delay in delayer.delays():
+            for delayed in filter(lambda x: delay.modifies_notice_xml(x),
+                                  xmls):
+                delays[delayed.version_id] = Delay(delayer.version_id,
+                                                   delay.delayed_until)
+    return delays
+
+
+def generate_dependencies(cfr_title, cfr_part, version_ids, delays):
+    """Creates a dependency graph and adds all dependencies for input xml and
+    delays between notices"""
+    deps = eregs_index.DependencyGraph()
+    for version_id in version_ids:
+        deps.add(("version", cfr_title, cfr_part, version_id),
+                 ("notice_xml", version_id))
+    for delayed, delay in delays.iteritems():
+        deps.add(("version", cfr_title, cfr_part, delayed),
+                 ("notice_xml", delay.by))
+    return deps
+
+
+def write_to_disk(xml, path, delay=None):
+    """Serialize a Version instance to disk"""
+    effective = xml.effective if delay is None else delay.until
+    version = Version(identifier=xml.version_id, effective=effective,
+                      published=xml.published)
+    path.write(xml.version_id, version.json())
+
+
+def write_if_needed(cfr_title, cfr_part, version_ids, xmls, delays):
+    """All versions which are stale (either because they were never create or
+    because their dependency has been updated) are written to disk. If any
+    dependency is missing, an exception is raised"""
+    deps = generate_dependencies(cfr_title, cfr_part, version_ids, delays)
+    version_path = eregs_index.Path("version", cfr_title, cfr_part)
+    for version_id in version_ids:
+        deps.validate_for("version", cfr_title, cfr_part, version_id)
+        if deps.is_stale("version", cfr_title, cfr_part, version_id):
+            write_to_disk(xmls[version_id], version_path,
+                          delays.get(version_id))
+
+
+@click.command()
+@click.argument('cfr_title', type=int)
+@click.argument('cfr_part', type=int)
+def versions(cfr_title, cfr_part):
+    cfr_title, cfr_part = str(cfr_title), str(cfr_part)
+    notice_path = eregs_index.Path("notice_xml")
+
+    version_ids = fetch_version_ids(cfr_title, cfr_part, notice_path)
+    xmls = {version_id: NoticeXML(notice_path.read_xml(version_id))
+            for version_id in version_ids if version_id in notice_path}
+    delays_by_version = delays(xmls.values())
+    write_if_needed(cfr_title, cfr_part, version_ids, xmls, delays_by_version)

--- a/regparser/eregs_index.py
+++ b/regparser/eregs_index.py
@@ -1,7 +1,10 @@
 """The eregs_index directory contains the output for many of the shell
 commands. This module provides a quick interface to this index"""
+import logging
 import os
+import shelve
 
+from dagger import dagger
 from lxml import etree
 
 
@@ -19,8 +22,10 @@ class Path(object):
 
     def write(self, label, content):
         self._create()
-        with open(os.path.join(self.path, label), "w") as f:
+        path_str = os.path.join(self.path, label)
+        with open(path_str, "w") as f:
             f.write(content)
+            logging.info("Wrote {} to eregs_index".format(path_str))
 
     def read(self, label):
         self._create()
@@ -31,6 +36,65 @@ class Path(object):
         return etree.fromstring(self.read(label))
 
     def __len__(self):
+        return len(list(self.__iter__()))
+
+    def __iter__(self):
         self._create()
-        return sum(1 for name in os.listdir(self.path)
-                   if os.path.isfile(os.path.join(self.path, name)))
+        return (name for name in os.listdir(self.path))
+
+
+class DependencyException(Exception):
+    def __init__(self, key, dependency):
+        super(DependencyException, self).__init__(
+            "Missing dependency. {} is needed for {}".format(
+                dependency, key))
+        self.dependency = dependency
+        self.key = key
+
+
+class DependencyGraph(object):
+    """Track dependencies between input and output files, storing them in
+    `dependencies.db` for later retrieval. This lets us know that an output
+    with dependencies needs to be updated if those dependencies have been
+    updated"""
+    def __init__(self):
+        if not os.path.exists(ROOT):
+            os.makedirs(ROOT)
+        self.graph = shelve.open(os.path.join(ROOT, "dependencies.db"))
+        self.dag = dagger()
+        self._ran = False
+        for key, dependencies in self.graph.items():
+            self.dag.add(key, dependencies)
+
+    def path_str(self, *file_path):
+        return str(os.path.join(ROOT, *file_path))
+
+    def add(self, output_tuple, input_tuple):
+        """Add a dependency where output tuple relies on input_tuple"""
+        self._ran = False
+        from_str = self.path_str(*output_tuple)
+        to_str = self.path_str(*input_tuple)
+
+        deps = self.graph.get(from_str, set())
+        deps.add(to_str)
+        self.graph[from_str] = deps
+        self.dag.add(from_str, [to_str])
+
+    def _run_if_needed(self):
+        if not self._ran:
+            self.dag.run()
+            self._ran = True
+
+    def validate_for(self, *file_path):
+        """Raise an exception if a particular output has stale dependencies"""
+        self._run_if_needed()
+        key = self.path_str(*file_path)
+        for dependency in self.graph[key]:
+            if self.dag.get(dependency).stale:
+                raise DependencyException(key, dependency)
+
+    def is_stale(self, *file_path):
+        """Determine if a file needs to be rebuilt"""
+        self._run_if_needed()
+        key = self.path_str(*file_path)
+        return bool(self.dag.get(key).stale)

--- a/regparser/eregs_index.py
+++ b/regparser/eregs_index.py
@@ -74,6 +74,9 @@ class VersionPath(_PathBase):
     def read(self, label):
         return Version.from_json(self._read(label))
 
+    def __len__(self):
+        return len(list(self._paths()))
+
     def __iter__(self):
         """Deserialize all Version objects we're aware of."""
         versions = [self.read(path) for path in self._paths()]

--- a/regparser/eregs_index.py
+++ b/regparser/eregs_index.py
@@ -15,7 +15,7 @@ ROOT = ".eregs_index"
 class Path(object):
     """Encapsulates access to a particular directory within the index"""
     def __init__(self, *dirs):
-        self.path = os.path.join(ROOT, *dirs)
+        self.path = os.path.join(ROOT, *[str(d) for d in dirs])
 
     def _create(self):
         if not os.path.exists(self.path):
@@ -23,14 +23,14 @@ class Path(object):
 
     def write(self, label, content):
         self._create()
-        path_str = os.path.join(self.path, label)
+        path_str = os.path.join(self.path, str(label))
         with open(path_str, "w") as f:
             f.write(content)
             logging.info("Wrote {} to eregs_index".format(path_str))
 
     def read(self, label):
         self._create()
-        with open(os.path.join(self.path, label)) as f:
+        with open(os.path.join(self.path, str(label))) as f:
             return f.read()
 
     def read_xml(self, label):
@@ -71,7 +71,7 @@ class DependencyGraph(object):
             self.dag.add(key, dependencies)
 
     def path_str(self, *file_path):
-        return str(os.path.join(ROOT, *file_path))
+        return str(os.path.join(ROOT, *[str(path) for path in file_path]))
 
     def add(self, output_tuple, input_tuple):
         """Add a dependency where output tuple relies on input_tuple"""

--- a/regparser/eregs_index.py
+++ b/regparser/eregs_index.py
@@ -1,5 +1,6 @@
 """The eregs_index directory contains the output for many of the shell
 commands. This module provides a quick interface to this index"""
+import json
 import logging
 import os
 import shelve
@@ -34,6 +35,9 @@ class Path(object):
 
     def read_xml(self, label):
         return etree.fromstring(self.read(label))
+
+    def read_json(self, label):
+        return json.loads(self.read(label))
 
     def __len__(self):
         return len(list(self.__iter__()))

--- a/regparser/history/versions.py
+++ b/regparser/history/versions.py
@@ -1,0 +1,9 @@
+from collections import namedtuple
+import json
+
+
+class Version(namedtuple('Version', ['identifier', 'published', 'effective'])):
+    def json(self):
+        return json.dumps({'identifier': self.identifier,
+                           'published': self.published.isoformat(),
+                           'effective': self.effective.isoformat()})

--- a/regparser/history/versions.py
+++ b/regparser/history/versions.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from datetime import datetime
 import json
 
 
@@ -7,3 +8,11 @@ class Version(namedtuple('Version', ['identifier', 'published', 'effective'])):
         return json.dumps({'identifier': self.identifier,
                            'published': self.published.isoformat(),
                            'effective': self.effective.isoformat()})
+
+    @staticmethod
+    def from_json(json_str):
+        json_dict = json.loads(json_str)
+        for key in ('published', 'effective'):
+            json_dict[key] = datetime.strptime(json_dict[key],
+                                               '%Y-%m-%d').date()
+        return Version(**json_dict)

--- a/regparser/notice/xml.py
+++ b/regparser/notice/xml.py
@@ -9,6 +9,7 @@ from urlparse import urlparse
 from lxml import etree
 import requests
 
+from regparser.history.delays import delays_in_sentence
 from regparser.notice import preprocessors
 from regparser.notice.dates import fetch_dates
 import settings
@@ -37,6 +38,13 @@ class NoticeXML(object):
 
     def xml_str(self):
         return etree.tostring(self._xml, pretty_print=True)
+
+    def delays(self):
+        """Pull out FRDelays found in the DATES tag"""
+        dates_str = "".join(p.text for p in self._xml.xpath(
+            "(//DATES/P)|(//EFFDATE/P)"))
+        return [delay for sent in dates_str.split('.')
+                for delay in delays_in_sentence(sent)]
 
     def _set_date_attr(self, date_type, value):
         """Modify the XML tree so that it contains meta data for a date

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 click==5.1
+dagger==1.3.0
 lxml==3.2.0
 pyparsing==1.5.7
 inflection==0.1.2

--- a/tests/commands_annual_editions_tests.py
+++ b/tests/commands_annual_editions_tests.py
@@ -1,0 +1,69 @@
+from datetime import date
+from unittest import TestCase
+
+import click
+from click.testing import CliRunner
+from mock import patch
+
+from regparser import eregs_index
+from regparser.commands import annual_editions
+from regparser.history.versions import Version
+
+
+class CommandsAnnualEditions(TestCase):
+    def setUp(self):
+        self.cli = CliRunner()
+
+    def test_last_versions_raises_exception(self):
+        """If there are no versions available, we should receive an
+        exception"""
+        with self.cli.isolated_filesystem():
+            with self.assertRaises(click.UsageError):
+                list(annual_editions.last_versions('12', '1000'))
+
+    def test_last_versions_multiple_versions(self):
+        """If multiple versions affect the same annual edition, we should only
+        receive the last"""
+        with self.cli.isolated_filesystem():
+            path = eregs_index.VersionPath('12', '1000')
+            path.write(Version('1111', date(2000, 12, 1), date(2000, 12, 1)))
+            path.write(Version('2222', date(2000, 12, 2), date(2000, 12, 2)))
+            path.write(Version('3333', date(2001, 12, 1), date(2001, 12, 1)))
+
+            results = list(annual_editions.last_versions(12, 1000))
+            self.assertEqual(results, [
+                annual_editions.LastVersionInYear('2222', 2001),
+                annual_editions.LastVersionInYear('3333', 2002)])
+
+    def test_process_if_needed_missing_dependency_error(self):
+        """If the annual XML or version isn't present, we should see a
+        dependency error."""
+        with self.cli.isolated_filesystem():
+            last_versions = [annual_editions.LastVersionInYear('1111', 2000)]
+
+            with self.assertRaises(eregs_index.DependencyException):
+                annual_editions.process_if_needed('12', '1000', last_versions)
+
+            eregs_index.VersionPath('12', '1000').write(
+                Version('1111', date(2000, 1, 1), date(2000, 1, 1)))
+
+            with self.assertRaises(eregs_index.DependencyException):
+                annual_editions.process_if_needed('12', '1000', last_versions)
+
+    @patch("regparser.commands.annual_editions.process")
+    def test_process_if_needed_missing_writes(self, process):
+        """If output isn't already present, we should process. If it is
+        present, we don't need to"""
+        with self.cli.isolated_filesystem():
+            last_versions = [annual_editions.LastVersionInYear('1111', 2000)]
+            eregs_index.VersionPath('12', '1000').write(
+                Version('1111', date(2000, 1, 1), date(2000, 1, 1)))
+            eregs_index.Path('annual', '12', '1000').write('2000', 'Annual')
+
+            annual_editions.process_if_needed('12', '1000', last_versions)
+            self.assertTrue(process.called)
+
+            process.reset_mock()
+            eregs_index.Path('tree', '12', '1000').write('1111', 'tree-here')
+            annual_editions.process_if_needed('12', '1000', last_versions)
+            self.assertFalse(process.called)

--- a/tests/commands_versions_tests.py
+++ b/tests/commands_versions_tests.py
@@ -1,0 +1,144 @@
+from datetime import date
+from unittest import TestCase
+
+from click.testing import CliRunner
+from mock import Mock, patch
+
+from regparser import eregs_index
+from regparser.commands import versions
+from regparser.history.delays import FRDelay
+
+
+class CommandsVersionsTests(TestCase):
+    def setUp(self):
+        self.cli = CliRunner()
+
+    @patch("regparser.commands.versions.fetch_notice_json")
+    def test_fetch_version_ids_no_local(self, fetch_notice_json):
+        """If there are no local copies, the document numbers found in the FR
+        notices should be passed through"""
+        fetch_notice_json.return_value = [{'document_number': '1'},
+                                          {'document_number': '22'}]
+        with self.cli.isolated_filesystem():
+            path = eregs_index.Path("path")
+            self.assertEqual(['1', '22'],
+                             versions.fetch_version_ids('title', 'part', path))
+
+    @patch("regparser.commands.versions.fetch_notice_json")
+    def test_fetch_version_ids_local(self, fetch_notice_json):
+        """If a notice is split into multiple entries locally, a single
+        document number might result in multiple version ids"""
+        fetch_notice_json.return_value = [{'document_number': '1'},
+                                          {'document_number': '22'}]
+        with self.cli.isolated_filesystem():
+            path = eregs_index.Path("path")
+            path.write('1_20010101', 'v1')
+            path.write('1_20020202', 'v2')
+            path.write('22', 'second')
+            path.write('22-3344', 'unrelated file')
+            self.assertEqual(['1_20010101', '1_20020202', '22'],
+                             versions.fetch_version_ids('title', 'part', path))
+
+    def test_delays(self):
+        """For NoticeXMLs which cause delays to other NoticeXMLs, we'd like to
+        get a dictionary of delayed -> Delay(delayer, delayed_until)"""
+        not_involved, delayed, delayer = Mock(), Mock(), Mock()
+        not_involved.configure_mock(
+            published=1, fr_volume='vvv', start_page=100, end_page=200,
+            version_id='1', **{'delays.return_value': []})
+        delayed.configure_mock(
+            published=2, fr_volume='vvv', start_page=300, end_page=400,
+            version_id='2', **{'delays.return_value': []})
+        delayer.configure_mock(
+            published=3, fr_volume='vvv', start_page=500, end_page=600,
+            version_id='3',
+            **{'delays.return_value': [FRDelay('other', 1, 'another-date'),
+                                       FRDelay('vvv', 350, 'new-date')]})
+
+        delays = versions.delays([not_involved, delayed, delayer])
+        self.assertEqual(delays, {'2': versions.Delay('3', 'new-date')})
+
+    def test_delays_order(self):
+        """A NoticeXML's effective date can be delayed by multiple NoticeXMLs.
+        Last one wins"""
+        delayed, delayer1, delayer2 = Mock(), Mock(), Mock()
+        delayed.configure_mock(
+            published=1, fr_volume='vvv', start_page=100, end_page=200,
+            version_id='1', **{'delays.return_value': []})
+        delayer1.configure_mock(
+            published=2, fr_volume='vvv', start_page=200, end_page=300,
+            version_id='2',
+            **{'delays.return_value': [FRDelay('vvv', 100, 'zzz-date')]})
+        delayer2.configure_mock(
+            published=3, fr_volume='vvv', start_page=300, end_page=400,
+            version_id='3',
+            **{'delays.return_value': [FRDelay('vvv', 100, 'aaa-date')]})
+
+        delays = versions.delays([delayed, delayer2, delayer1])
+        self.assertEqual(delays, {'1': versions.Delay('3', 'aaa-date')})
+
+        delays = versions.delays([delayed, delayer1, delayer2])
+        self.assertEqual(delays, {'1': versions.Delay('3', 'aaa-date')})
+
+    def test_write_to_disk(self):
+        """If a version has been delayed, its effective date should be part of
+        the serialized json"""
+        xml = Mock()
+        path = eregs_index.Path('path')
+        with self.cli.isolated_filesystem():
+            xml.configure_mock(effective=date(2002, 2, 2), version_id='111',
+                               published=date(2002, 1, 1))
+            versions.write_to_disk(xml, path)
+
+            xml.configure_mock(version_id='222')
+            versions.write_to_disk(
+                xml, path, versions.Delay(by='333', until=date(2004, 4, 4)))
+
+            self.assertEqual(path.read_json('111')['effective'], '2002-02-02')
+            self.assertEqual(path.read_json('222')['effective'], '2004-04-04')
+
+    @patch('regparser.commands.versions.write_to_disk')
+    def test_write_if_needed_raises_exception(self, write_to_disk):
+        """If an input file is missing, this raises an exception"""
+        with self.cli.isolated_filesystem():
+            with self.assertRaises(eregs_index.DependencyException):
+                versions.write_if_needed('title', 'part', ['111'],
+                                         {'111': 'xml111'}, {})
+
+    @patch('regparser.commands.versions.write_to_disk')
+    def test_write_if_needed_output_missing(self, write_to_disk):
+        """If the output file is missing, we'll always write"""
+        with self.cli.isolated_filesystem():
+            eregs_index.Path('notice_xml').write('111', 'content')
+            versions.write_if_needed('title', 'part', ['111'],
+                                     {'111': 'xml111'}, {})
+            self.assertTrue(write_to_disk.called)
+
+    @patch('regparser.commands.versions.write_to_disk')
+    def test_write_if_needed_no_need_to_recompute(self, write_to_disk):
+        """If all dependencies are up to date and the output is present,
+        there's no need to write anything"""
+        with self.cli.isolated_filesystem():
+            eregs_index.Path('notice_xml').write('111', 'content')
+            eregs_index.Path('version', 'title', 'part').write('111', 'out')
+            versions.write_if_needed('title', 'part', ['111'],
+                                     {'111': 'xml111'}, {})
+            self.assertFalse(write_to_disk.called)
+
+    @patch('regparser.commands.versions.write_to_disk')
+    def test_write_if_needed_delays(self, write_to_disk):
+        """Delays introduce dependencies."""
+        with self.cli.isolated_filesystem():
+            eregs_index.Path('notice_xml').write('111', 'content')
+            eregs_index.Path('notice_xml').write('222', 'content')
+            eregs_index.Path('version', 'title', 'part').write('111', 'out')
+            versions.write_if_needed(
+                'title', 'part', ['111'], {'111': 'xml111'},
+                {'111': versions.Delay('222', 'until-date')})
+            self.assertFalse(write_to_disk.called)
+
+            eregs_index.Path('notice_xml').write('222', 'changed')
+            versions.write_if_needed(
+                'title', 'part', ['111'], {'111': 'xml111'},
+                {'111': versions.Delay('222', 'until-date')})
+            self.assertTrue(write_to_disk.called)

--- a/tests/commands_versions_tests.py
+++ b/tests/commands_versions_tests.py
@@ -84,7 +84,7 @@ class CommandsVersionsTests(TestCase):
         """If a version has been delayed, its effective date should be part of
         the serialized json"""
         xml = Mock()
-        path = eregs_index.Path('path')
+        path = eregs_index.VersionPath('12', '1000')
         with self.cli.isolated_filesystem():
             xml.configure_mock(effective=date(2002, 2, 2), version_id='111',
                                published=date(2002, 1, 1))
@@ -94,8 +94,8 @@ class CommandsVersionsTests(TestCase):
             versions.write_to_disk(
                 xml, path, versions.Delay(by='333', until=date(2004, 4, 4)))
 
-            self.assertEqual(path.read_json('111')['effective'], '2002-02-02')
-            self.assertEqual(path.read_json('222')['effective'], '2004-04-04')
+            self.assertEqual(path.read('111').effective, date(2002, 2, 2))
+            self.assertEqual(path.read('222').effective, date(2004, 4, 4))
 
     @patch('regparser.commands.versions.write_to_disk')
     def test_write_if_needed_raises_exception(self, write_to_disk):

--- a/tests/commands_versions_tests.py
+++ b/tests/commands_versions_tests.py
@@ -1,4 +1,6 @@
 from datetime import date
+import os
+from time import time
 from unittest import TestCase
 
 from click.testing import CliRunner
@@ -137,7 +139,10 @@ class CommandsVersionsTests(TestCase):
                 {'111': versions.Delay('222', 'until-date')})
             self.assertFalse(write_to_disk.called)
 
-            eregs_index.Path('notice_xml').write('222', 'changed')
+            # Simulate a change to an input file
+            os.utime(
+                os.path.join(eregs_index.ROOT, 'notice_xml', '222'),
+                (time() + 1000, time() + 1000))
             versions.write_if_needed(
                 'title', 'part', ['111'], {'111': 'xml111'},
                 {'111': versions.Delay('222', 'until-date')})

--- a/tests/eregs_index_tests.py
+++ b/tests/eregs_index_tests.py
@@ -1,0 +1,70 @@
+import os
+import shutil
+import tempfile
+from time import time
+from unittest import TestCase
+
+from regparser import eregs_index
+
+
+class DependencyGraphTests(TestCase):
+    def setUp(self):
+        self._original_root = eregs_index.ROOT
+        eregs_index.ROOT = tempfile.mkdtemp()
+
+        self.dgraph = eregs_index.DependencyGraph()
+        self.path = eregs_index.Path("path")
+
+    def tearDown(self):
+        shutil.rmtree(eregs_index.ROOT)
+        eregs_index.ROOT = self._original_root
+
+    def test_nonexistent_files_are_stale(self):
+        """By definition, if a file is not present, it needs to be rebuilt"""
+        self.path.write("dependency", "value")
+        self.dgraph.add(("path", "depender"), ("path", "dependency"))
+        self.assertFalse(self.dgraph.is_stale("path", "dependency"))
+        self.assertTrue(self.dgraph.is_stale("path", "depender"))
+        # shouldn't raise an exception; all dependencies are up to date
+        self.dgraph.validate_for("path", "depender")
+
+    def test_nonexistant_deps_are_stale(self):
+        """If a dependency is not present, we're stale"""
+        self.path.write("depender", "value")
+        self.dgraph.add(("path", "depender"), ("path", "dependency"))
+        self.assertTrue(self.dgraph.is_stale("path", "dependency"))
+        self.assertTrue(self.dgraph.is_stale("path", "depender"))
+        with self.assertRaises(eregs_index.DependencyException):
+            self.dgraph.validate_for("path", "depender")
+
+    def test_updates_to_dependencies_flow(self):
+        """If a dependency is updated, the graph should be recalculated"""
+        self.path.write("dependency", "value")
+        self.path.write("depender", "value2")
+        self.dgraph.add(("path", "depender"), ("path", "dependency"))
+        self.assertFalse(self.dgraph.is_stale("path", "dependency"))
+        self.assertFalse(self.dgraph.is_stale("path", "depender"))
+
+        # Set the update time of the dependency to the future
+        os.utime(os.path.join(eregs_index.ROOT, "path", "dependency"),
+                 (time()*1000 + 1000, time()*1000 + 1000))
+        self.dgraph.dag.run()
+        self.assertFalse(self.dgraph.is_stale("path", "dependency"))
+        self.assertTrue(self.dgraph.is_stale("path", "depender"))
+
+    def test_dependencies_serialized(self):
+        """Every instance of DependencyGraph shares a serialized copy of the
+        dependencies"""
+        self.dgraph.add(("path", "depender"), ("dependency", "1"))
+        self.dgraph.add(("path", "depender"), ("dependency", "2"))
+        self.assertEqual(
+            self.dgraph.graph[self.dgraph.path_str("path", "depender")],
+            set([self.dgraph.path_str("dependency", "1"),
+                 self.dgraph.path_str("dependency", "2")]))
+
+        del self.dgraph     # implicitly closing the database
+        self.dgraph = eregs_index.DependencyGraph()
+        self.assertEqual(
+            self.dgraph.graph[self.dgraph.path_str("path", "depender")],
+            set([self.dgraph.path_str("dependency", "1"),
+                 self.dgraph.path_str("dependency", "2")]))

--- a/tests/history_delays_tests.py
+++ b/tests/history_delays_tests.py
@@ -1,6 +1,7 @@
+from datetime import date
 from unittest import TestCase
 
-from regparser.history.delays import *
+from regparser.history import delays
 
 
 class HistoryDelaysTests(TestCase):
@@ -42,33 +43,35 @@ class HistoryDelaysTests(TestCase):
                             'dates': 'The effective date of 12 FR 501 has ' +
                                      'been delayed until March 3, 2003'}}
 
-        modify_effective_dates([outdated, unaltered, proposal, changer])
+        delays.modify_effective_dates([outdated, unaltered, proposal, changer])
 
         self.assertEqual('2003-03-03', outdated['effective_on'])
         self.assertEqual('2001-01-01', unaltered['effective_on'])
         self.assertFalse('effective_on' in proposal)
         self.assertEqual('2000-12-31', changer['effective_on'])
 
-    def test_overlaps_with(self):
-        fr = Notice(10, 225)
+    def test_modifies_notice(self):
+        fr = delays.FRDelay(10, 225, None)
         meta = lambda v, s, e: {'fr_volume': v, 'meta': {'start_page': s,
                                                          'end_page': e}}
-        self.assertTrue(overlaps_with(fr, meta(10, 220, 230)))
-        self.assertTrue(overlaps_with(fr, meta(10, 225, 230)))
-        self.assertTrue(overlaps_with(fr, meta(10, 220, 225)))
-        self.assertFalse(overlaps_with(fr, meta(11, 220, 230)))
-        self.assertFalse(overlaps_with(fr, meta(10, 226, 230)))
-        self.assertFalse(overlaps_with(fr, meta(10, 220, 224)))
+        self.assertTrue(fr.modifies_notice(meta(10, 220, 230)))
+        self.assertTrue(fr.modifies_notice(meta(10, 225, 230)))
+        self.assertTrue(fr.modifies_notice(meta(10, 220, 225)))
+        self.assertFalse(fr.modifies_notice(meta(11, 220, 230)))
+        self.assertFalse(fr.modifies_notice(meta(10, 226, 230)))
+        self.assertFalse(fr.modifies_notice(meta(10, 220, 224)))
 
-    def test_altered_frs(self):
+    def test_delays_in_sentence(self):
         sent = "The effective date of 12 FR 501, 13 FR 999, and (13 FR 764) "
         sent += "has been delayed."
-        self.assertEqual(altered_frs(sent),
-                         ([Notice(12, 501), Notice(13, 999), Notice(13, 764)],
-                          None))
+        self.assertEqual(
+            delays.delays_in_sentence(sent),
+            [delays.FRDelay(12, 501, None), delays.FRDelay(13, 999, None),
+             delays.FRDelay(13, 764, None)])
         sent = "In 11 FR 123 we delayed the effective date"
-        self.assertEqual(altered_frs(sent), ([], None))
+        self.assertEqual(delays.delays_in_sentence(sent), [])
         sent = "The effective date of 9 FR 765 has been delayed until "
         sent += "January 7, 2008; rather I mean March 4 2008"
-        self.assertEqual(altered_frs(sent),
-                         ([Notice(9, 765)], date(2008, 3, 4)))
+        self.assertEqual(
+            delays.delays_in_sentence(sent),
+            [delays.FRDelay(9, 765, date(2008, 3, 4))])


### PR DESCRIPTION
Builds on #83 ([diff](https://github.com/cmc333333/regulations-parser/compare/cmc333333:version-command...cmc333333:annual-commands))

1. ~~preprocess notices~~
2. ~~generate versions~~
3. **generate trees from annual XML**
4. generate trees from prev trees + changes found in rules
5. generate layers
6. generate diffs
7. post data to the api

This adds two new commands -- one for fetching an arbitrary annual edition of the regulation from the CFR and another for parsing all of those annual editions into `Node` trees and serializing the results.

Along the way, this refactors a few libraries, increases logging, and adds help text to the `versions` command.