### PR TITLE
Commands to parse final rules and build trees with their results

### DIFF
--- a/regparser/builder.py
+++ b/regparser/builder.py
@@ -109,18 +109,7 @@ class Builder(object):
                     seen_start = True
         for notice in relevant_notices:
             version = notice['document_number']
-            yield version, self.merge_changes(version, notice['changes'])
-
-    def merge_changes(self, document_number, changes):
-        patches = content.RegPatches().get(document_number)
-        if patches:
-            changes = copy.copy(changes)
-            for key in patches:
-                if key in changes:
-                    changes[key].extend(patches[key])
-                else:
-                    changes[key] = patches[key]
-        return changes
+            yield version, merge_changes(version, notice['changes'])
 
     @staticmethod
     def determine_doc_number(reg_xml, title, title_part):
@@ -130,6 +119,21 @@ class Builder(object):
         if not doc_number:
             doc_number = _fdsys_to_doc_number(reg_xml, title, title_part)
         return doc_number
+
+
+def merge_changes(document_number, changes):
+    """Changes can be present in the notice or in an external set inside the
+    `content` module. If any are present in the latter, they extend the
+    former"""
+    patches = content.RegPatches().get(document_number)
+    if patches:
+        changes = copy.copy(changes)
+        for key in patches:
+            if key in changes:
+                changes[key].extend(patches[key])
+            else:
+                changes[key] = patches[key]
+    return changes
 
 
 class LayerCacheAggregator(object):

--- a/regparser/commands/annual_editions.py
+++ b/regparser/commands/annual_editions.py
@@ -4,14 +4,8 @@ from datetime import date
 import click
 
 from regparser import eregs_index
-from regparser.api_writer import AmendmentNodeEncoder
 from regparser.history import annual
 from regparser.tree import xml_parser
-
-# @todo - review this encoder -- we're using it now as it is what was used by
-# build_from
-json_encoder = AmendmentNodeEncoder(sort_keys=True, indent=4,
-                                    separators=(', ', ': '))
 
 
 LastVersionInYear = namedtuple('LastVersionInYear', ['version_id', 'year'])
@@ -32,18 +26,18 @@ def last_versions(cfr_title, cfr_part):
         yield LastVersionInYear(have_annual_edition[year], year)
 
 
-def process(last_version, input_path, output_path):
+def process(last_version, input_path, tree_path):
     """Parse the XML into a JSON tree; write it to disk"""
     xml = input_path.read_xml(last_version.year)
     tree = xml_parser.reg_text.build_tree(xml)
-    output_path.write(last_version.version_id, json_encoder.encode(tree))
+    tree_path.write(last_version.version_id, tree)
 
 
 def process_if_needed(cfr_title, cfr_part, last_versions):
     """Calculate dependencies between input and output files for these annual
     editions. If an output is missing or out of date, process it"""
     annual_path = eregs_index.Path("annual", cfr_title, cfr_part)
-    tree_path = eregs_index.Path("tree", cfr_title, cfr_part)
+    tree_path = eregs_index.TreePath(cfr_title, cfr_part)
     deps = eregs_index.DependencyGraph()
 
     for last_version in last_versions:

--- a/regparser/commands/fill_with_rules.py
+++ b/regparser/commands/fill_with_rules.py
@@ -1,0 +1,67 @@
+import click
+
+from regparser import eregs_index
+from regparser.builder import merge_changes
+from regparser.notice.compiler import compile_regulation
+
+
+def dependencies(tree_path, version_ids, cfr_title, cfr_part):
+    """Set up the dependency graph for this regulation. First calculates
+    "gaps" -- versions for which there is no existing tree. In this
+    calculation, we ignore the first version, as we won't be able to build
+    anything for it. Add dependencies for any gaps, tying the output tree to
+    the preceding tree, the version info and the parsed rule"""
+    existing_ids = set(tree_path)
+    gaps = [(prev, curr) for prev, curr in zip(version_ids, version_ids[1:])
+            if curr not in existing_ids]
+
+    deps = eregs_index.DependencyGraph()
+    for prev, curr in gaps:
+        curr_tuple = ('tree', cfr_title, cfr_part, curr)
+        deps.add(curr_tuple, ('tree', cfr_title, cfr_part, prev))
+        deps.add(curr_tuple, ('rule_changes', curr))
+        deps.add(curr_tuple, ('version', cfr_title, cfr_part, curr))
+    return deps
+
+
+def derived_from_rules(version_ids, deps, cfr_title, cfr_part):
+    """We only want to process trees which are created by parsing rules. To do
+    that, we'll filter by those trees which have a dependency on a parsed
+    rule"""
+    rule_versions = []
+    for version_id in version_ids:
+        path = deps.path_str('tree', cfr_title, cfr_part, version_id)
+        rule_change = deps.path_str('rule_changes', version_id)
+        if rule_change in deps.graph.get(path, []):
+            rule_versions.append(version_id)
+    return rule_versions
+
+
+def process(tree_path, previous, version_id):
+    """Build and write a tree by combining the preceding tree with changes
+    present in the associated rule"""
+    prev_tree = tree_path.read(previous)
+    notice = eregs_index.Path('rule_changes').read_json(version_id)
+    changes = merge_changes(version_id, notice.get('changes', {}))
+    new_tree = compile_regulation(prev_tree, changes)
+    tree_path.write(version_id, new_tree)
+
+
+@click.command()
+@click.argument('cfr_title', type=int)
+@click.argument('cfr_part', type=int)
+def fill_with_rules(cfr_title, cfr_part):
+    """Fill in missing trees using data from rules. When a regulation tree
+    cannot be derived through annual editions, it must be built by parsing the
+    changes in final rules. This command builds those missing trees"""
+    tree_path = eregs_index.TreePath(cfr_title, cfr_part)
+    version_ids = [v.identifier
+                   for v in eregs_index.VersionPath(cfr_title, cfr_part)]
+    deps = dependencies(tree_path, version_ids, cfr_title, cfr_part)
+
+    preceeded_by = dict(zip(version_ids[1:], version_ids))
+    derived = derived_from_rules(version_ids, deps, cfr_title, cfr_part)
+    for version_id in derived:
+        deps.validate_for('tree', cfr_title, cfr_part, version_id)
+        if deps.is_stale('tree', cfr_title, cfr_part, version_id):
+            process(tree_path, preceeded_by[version_id], version_id)

--- a/regparser/commands/parse_rule_changes.py
+++ b/regparser/commands/parse_rule_changes.py
@@ -1,0 +1,32 @@
+import click
+
+from regparser import eregs_index
+from regparser.notice.build import process_xml
+from regparser.notice.encoder import AmendmentEncoder
+from regparser.notice.xml import NoticeXML
+
+
+@click.command()
+@click.argument('document_number')
+def parse_rule_changes(document_number):
+    """Parse changes present in a single rule.
+
+    DOCUMENT_NUMBER is the identifier associated with a final rule. If a rule
+    has been split, use the split identifiers, a.k.a. version ids."""
+    deps = eregs_index.DependencyGraph()
+    deps.add(('rule_changes', document_number),
+             ('notice_xml', document_number))
+    encoder = AmendmentEncoder(sort_keys=True, indent=4,
+                               separators=(', ', ': '))
+
+    deps.validate_for('rule_changes', document_number)
+    # We don't check for staleness as we want to always execute when given a
+    # specific file to process
+
+    # @todo - break apart processing of amendments/changes. We don't need
+    # all of the other fields
+    notice_xml = eregs_index.Path('notice_xml').read_xml(document_number)
+    notice = process_xml(NoticeXML(notice_xml).to_notice_dict(),
+                         notice_xml)
+    eregs_index.Path('rule_changes').write(
+        document_number, encoder.encode(notice))

--- a/regparser/notice/xml.py
+++ b/regparser/notice/xml.py
@@ -78,6 +78,16 @@ class NoticeXML(object):
             date_type))
         return datetime.strptime(value, "%Y-%m-%d").date()
 
+    def to_notice_dict(self):
+        """@todo Stop gap method -- converts NoticeXML into a dict which is
+        the assumed standard for other parts of the application. Try to only
+        add fields as needed"""
+        return {
+            'meta': {
+                'start_page': self.start_page
+            }
+        }
+
     # --- Setters/Getters for specific fields. ---
     # We encode relevant information within the XML, but wish to provide easy
     # access

--- a/tests/builder_tests.py
+++ b/tests/builder_tests.py
@@ -11,7 +11,7 @@ from regparser.tree.struct import Node
 
 
 class BuilderTests(TestCase):
-    @patch.object(Builder, 'merge_changes')
+    @patch('regparser.builder.merge_changes')
     @patch.object(Builder, '__init__')
     def test_revision_generator_notices(self, init, merge_changes):
         init.return_value = None
@@ -138,7 +138,7 @@ class BuilderTests(TestCase):
         self.assertEqual({'max_effective_date': '2012-01-01',
                           'only_final': True}, args[1])   # kw args
 
-    @patch.object(Builder, 'merge_changes')
+    @patch('regparser.builder.merge_changes')
     @patch.object(Builder, '__init__')
     def test_changes_in_sequence_skips(self, init, merge_changes):
         """Skips over notices which occurred _before_ our starting point"""

--- a/tests/commands_fill_with_rules_tests.py
+++ b/tests/commands_fill_with_rules_tests.py
@@ -1,0 +1,60 @@
+from unittest import TestCase
+
+from click.testing import CliRunner
+
+from regparser import eregs_index
+from regparser.commands import fill_with_rules
+
+
+class CommandsFillWithRulesTests(TestCase):
+    def setUp(self):
+        self.cli = CliRunner()
+
+    def test_dependencies(self):
+        """Expect nonexistent trees to depend on their predecessor, associated
+        rule changes and version files. Shouldn't add dependencies for the
+        first version, if missing"""
+        with self.cli.isolated_filesystem():
+            existing_trees = ['222', '555']
+            version_ids = ['111', '222', '333', '444', '555', '666']
+            deps = fill_with_rules.dependencies(
+                existing_trees, version_ids, '12', '1000')
+            paths = {
+                version_id: deps.path_str('tree', '12', '1000', version_id)
+                for version_id in version_ids}
+            # First is skipped, as we can't build it from a rule
+            self.assertNotIn(paths['111'], deps.graph)
+            # Second can also be skipped as a tree already exists
+            self.assertNotIn(paths['222'], deps.graph)
+            # Third relies on the associated versions and the second tree
+            self.assertEqual(
+                deps.graph[paths['333']],
+                set([paths['222'], deps.path_str('rule_changes', '333'),
+                     deps.path_str('version', '12', '1000', '333')]))
+            # Fourth relies on the third, even though it's not been built
+            self.assertEqual(
+                deps.graph[paths['444']],
+                set([paths['333'], deps.path_str('rule_changes', '444'),
+                     deps.path_str('version', '12', '1000', '444')]))
+            # Fifth can be skipped as the tree already exists
+            self.assertNotIn(paths['555'], deps.graph)
+            # Six relies on the fifth
+            self.assertEqual(
+                deps.graph[paths['666']],
+                set([paths['555'], deps.path_str('rule_changes', '666'),
+                     deps.path_str('version', '12', '1000', '666')]))
+
+    def test_derived_from_rules(self):
+        """Should filter a set of version ids to only those with a dependency
+        on changes derived from a rule"""
+        with self.cli.isolated_filesystem():
+            deps = eregs_index.DependencyGraph()
+            deps.add(('tree', '12', '1000', '111'),
+                     ('annual', '12', '1000', '2001'))
+            deps.add(('tree', '12', '1000', '222'), ('rule_changes', '222'))
+            deps.add(('tree', '12', '1000', '333'), ('rule_changes', '333'))
+            deps.add(('tree', '12', '1000', '333'),
+                     ('version', '12', '1000', '333'))
+            derived = fill_with_rules.derived_from_rules(
+                ['111', '222', '333', '444'], deps, '12', '1000')
+            self.assertEqual(derived, ['222', '333'])

--- a/tests/commands_parse_rule_changes_tests.py
+++ b/tests/commands_parse_rule_changes_tests.py
@@ -1,0 +1,43 @@
+from unittest import TestCase
+
+from click.testing import CliRunner
+from lxml import etree
+from mock import patch
+
+from regparser import eregs_index
+from regparser.commands.parse_rule_changes import parse_rule_changes
+from tests.xml_builder import XMLBuilderMixin
+
+
+class CommandsParseRuleChangesTests(XMLBuilderMixin, TestCase):
+    def setUp(self):
+        super(CommandsParseRuleChangesTests, self).setUp()
+        self.cli = CliRunner()
+        with self.tree.builder("ROOT") as root:
+            root.PRTPAGE(P="1234")
+        self.xml_str = self.tree.render_string()
+
+    def test_missing_notice(self):
+        """If the necessary notice XML is not present, we should expect a
+        dependency error"""
+        with self.cli.isolated_filesystem():
+            result = self.cli.invoke(parse_rule_changes, ['1111'])
+            self.assertTrue(isinstance(result.exception,
+                                       eregs_index.DependencyException))
+
+    @patch('regparser.commands.parse_rule_changes.process_xml')
+    def test_writes(self, process_xml):
+        """If the notice XML is present, we write the parsed version to disk,
+        even if that version's already present"""
+        with self.cli.isolated_filesystem():
+            eregs_index.Path('notice_xml').write('1111', self.xml_str)
+            self.cli.invoke(parse_rule_changes, ['1111'])
+            self.assertTrue(process_xml.called)
+            args = process_xml.call_args[0]
+            self.assertTrue(isinstance(args[0], dict))
+            self.assertTrue(isinstance(args[1], etree._Element))
+
+            process_xml.reset_mock()
+            eregs_index.Path('rule_changes').write('1111', 'content')
+            self.cli.invoke(parse_rule_changes, ['1111'])
+            self.assertTrue(process_xml.called)


### PR DESCRIPTION
1. ~~preprocess notices~~
2. ~~generate versions~~
3. ~~generate trees from annual XML~~
4. **generate trees from prev trees + changes found in rules**
5. generate layers
6. generate diffs
7. post data to the api

This adds two new commands -- one for parsing an arbitrary notice (pulling out the relevant changes) and one for using that data to generate new trees. Effectively, this command looks through the generated trees, finds any gaps (where a `Version` exists without a corresponding tree) and attempts to fill those gaps with the data parsed from notices.

A few tweaks to the surrounding code, but nothing major.