### PR TITLE
First swing at automated dependency resolution

### DIFF
--- a/eregs.py
+++ b/eregs.py
@@ -4,7 +4,8 @@ import pkgutil
 
 import click
 
-from regparser import commands
+from regparser import commands, eregs_index
+from regparser.commands.dependency_resolver import DependencyResolver
 
 try:
     import requests_cache   # @todo - replace with cache control
@@ -22,9 +23,29 @@ def cli():
 
 for _, command_name, _ in pkgutil.iter_modules(commands.__path__):
     module = import_module('regparser.commands.{}'.format(command_name))
-    command = getattr(module, command_name)
-    cli.add_command(command)
+    if hasattr(module, command_name):
+        subcommand = getattr(module, command_name)
+        cli.add_command(subcommand)
 
+
+def main(prev_dependency=None):
+    """Wrapper around cli(), providing exception handling for dependency
+    errors. When a dependency is missing, this will try to resolve that
+    dependency and then retry running cli(). When retrying, the
+    `prev_dependency` parameter indirectly tells us if we've progressed, due
+    to the dependency changing"""
+    try:
+        cli()
+    except eregs_index.DependencyException, e:
+        resolvers = [resolver(e.dependency)
+                     for resolver in DependencyResolver.__subclasses__()]
+        resolvers = [r for r in resolvers if r.has_resolution()]
+        if e.dependency == prev_dependency or len(resolvers) != 1:
+            raise e
+        else:
+            click.echo("Attempting to resolve dependency: " + e.dependency)
+            resolvers[0].resolution()
+            main(e.dependency)
 
 if __name__ == '__main__':
-    cli()
+    main()

--- a/regparser/commands/dependency_resolver.py
+++ b/regparser/commands/dependency_resolver.py
@@ -1,0 +1,24 @@
+import abc
+import os
+import re
+
+
+class DependencyResolver(object):
+    """Base class for objects which know how to "fix" missing dependencies."""
+    __metaclass__ = abc.ABCMeta
+    # The path of dependencies which this can resolve, split into components
+    # which will be combined into a regex
+    PATH_PARTS = tuple()
+
+    def __init__(self, dependency_path):
+        regex = re.compile(re.escape(os.sep).join(self.PATH_PARTS))
+        self.match = regex.match(dependency_path)
+
+    def has_resolution(self):
+        return bool(self.match)
+
+    @abc.abstractmethod
+    def resolution(self):
+        """This will generally call a command in an effort to resolve a
+        dependency"""
+        raise NotImplementedError()

--- a/regparser/commands/fetch_annual_edition.py
+++ b/regparser/commands/fetch_annual_edition.py
@@ -1,6 +1,7 @@
 import click
 
 from regparser import eregs_index
+from regparser.commands.dependency_resolver import DependencyResolver
 from regparser.history import annual
 
 
@@ -13,3 +14,15 @@ def fetch_annual_edition(cfr_title, cfr_part, year):
     volume = annual.find_volume(year, cfr_title, cfr_part)
     xml = volume.find_part_xml(cfr_part)
     eregs_index.AnnualEntry(cfr_title, cfr_part, year).write(xml)
+
+
+class AnnualEditionResolver(DependencyResolver):
+    PATH_PARTS = eregs_index.AnnualEntry.PREFIX + (
+        '(?P<cfr_title>\d+)',
+        '(?P<cfr_part>\d+)',
+        '(?P<year>\d{4})')
+
+    def resolution(self):
+        args = [self.match.group('cfr_title'), self.match.group('cfr_part'),
+                self.match.group('year')]
+        return fetch_annual_edition.main(args, standalone_mode=False)

--- a/regparser/commands/fetch_sxs.py
+++ b/regparser/commands/fetch_sxs.py
@@ -4,6 +4,7 @@
 import click
 
 from regparser import eregs_index
+from regparser.commands.dependency_resolver import DependencyResolver
 from regparser.notice.build import process_xml
 
 
@@ -29,3 +30,12 @@ def fetch_sxs(document_number):
     notice_xml = notice_entry.read()
     notice = process_xml(notice_xml.to_notice_dict(), notice_xml._xml)
     sxs_entry.write(notice)
+
+
+class RuleChangesResolver(DependencyResolver):
+    PATH_PARTS = eregs_index.SxSEntry.PREFIX + (
+        '(?P<doc_number>[a-zA-Z0-9-_]+)',)
+
+    def resolution(self):
+        args = [self.match.group('doc_number')]
+        return fetch_sxs.main(args, standalone_mode=False)

--- a/regparser/commands/parse_rule_changes.py
+++ b/regparser/commands/parse_rule_changes.py
@@ -1,6 +1,7 @@
 import click
 
 from regparser import eregs_index
+from regparser.commands.dependency_resolver import DependencyResolver
 from regparser.notice.build import process_xml
 
 
@@ -26,3 +27,12 @@ def parse_rule_changes(document_number):
     notice_xml = notice_entry.read()
     notice = process_xml(notice_xml.to_notice_dict(), notice_xml._xml)
     rule_entry.write(notice)
+
+
+class RuleChangesResolver(DependencyResolver):
+    PATH_PARTS = eregs_index.RuleChangesEntry.PREFIX + (
+        '(?P<doc_number>[a-zA-Z0-9-_]+)',)
+
+    def resolution(self):
+        args = [self.match.group('doc_number')]
+        return parse_rule_changes.main(args, standalone_mode=False)

--- a/regparser/commands/preprocess_notice.py
+++ b/regparser/commands/preprocess_notice.py
@@ -1,6 +1,7 @@
 import click
 
 from regparser import eregs_index, federalregister
+from regparser.commands.dependency_resolver import DependencyResolver
 from regparser.notice.build import split_doc_num
 from regparser.notice.xml import notice_xmls_for_url
 
@@ -33,3 +34,12 @@ def preprocess_notice(document_number):
 
         notice_xml.version_id = file_name
         eregs_index.NoticeEntry(file_name).write(notice_xml)
+
+
+class NoticeResolver(DependencyResolver):
+    PATH_PARTS = eregs_index.NoticeEntry.PREFIX + (
+        '(?P<doc_number>[a-zA-Z0-9-_]+)',)
+
+    def resolution(self):
+        args = [self.match.group('doc_number')]
+        return preprocess_notice.main(args, standalone_mode=False)

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,5 @@ setup(
         "python-constraint",
         "requests"
     ],
-    entry_points={"console_scripts": ["eregs=eregs:cli"]}
+    entry_points={"console_scripts": ["eregs=eregs:main"]}
 )


### PR DESCRIPTION
We can determine, by looking at the file name of a missing dependency, how to
resolve that dependency. This adds a `DependencyResolver` base class which is
extended by four commands to describe a resolution to a missing annual
edition, SxS file, rule change file, or notice.

Needed to modify `setup.py` to allow for a recursive call when trying to
resolve.