### PR TITLE
Fix obscure file locking problem

### DIFF
--- a/regparser/eregs_index.py
+++ b/regparser/eregs_index.py
@@ -210,4 +210,3 @@ class DependencyGraph(object):
         """Determine if a file needs to be rebuilt"""
         self._run_if_needed()
         return bool(self.dag.get(str(entry)).stale)
-

--- a/regparser/eregs_index.py
+++ b/regparser/eregs_index.py
@@ -203,9 +203,11 @@ class DependencyGraph(object):
         key = str(entry)
         for dependency in self.graph[key]:
             if self.dag.get(dependency).stale:
+                self.graph.close()
                 raise DependencyException(key, dependency)
 
     def is_stale(self, entry):
         """Determine if a file needs to be rebuilt"""
         self._run_if_needed()
         return bool(self.dag.get(str(entry)).stale)
+


### PR DESCRIPTION
The problem arose with the shelf module if an object containing a shelf wasn't torn down correctly due to an exception being raised. This seemed to be a bug occurring only on OS X.