### PR TITLE
Write-to / Output command

### DIFF
--- a/regparser/commands/write_to.py
+++ b/regparser/commands/write_to.py
@@ -1,0 +1,57 @@
+import click
+
+from regparser import eregs_index
+from regparser.api_writer import Client
+
+
+def write_trees(client, cfr_title, cfr_part):
+    tree_dir = eregs_index.TreeEntry(cfr_title, cfr_part)
+    for version_id in eregs_index.VersionEntry(cfr_title, cfr_part):
+        if version_id in tree_dir:
+            click.echo("Writing tree " + version_id)
+            tree = (tree_dir / version_id).read()
+            client.regulation(cfr_part, version_id).write(tree)
+
+
+def write_layers(client, cfr_title, cfr_part):
+    for version_id in eregs_index.VersionEntry(cfr_title, cfr_part):
+        layer_dir = eregs_index.LayerEntry(cfr_title, cfr_part, version_id)
+        for layer_name in layer_dir:
+            click.echo("Writing layer {}@{}".format(layer_name, version_id))
+            layer = (layer_dir / layer_name).read()
+            client.layer(layer_name, cfr_part, version_id).write(layer)
+
+
+def write_notices(client, cfr_title, cfr_part):
+    sxs_dir = eregs_index.SxSEntry()
+    for version_id in eregs_index.VersionEntry(cfr_title, cfr_part):
+        if version_id in sxs_dir:
+            click.echo("Writing notice " + version_id)
+            tree = (sxs_dir / version_id).read()
+            client.notice(version_id).write(tree)
+
+
+def write_diffs(client, cfr_title, cfr_part):
+    diff_dir = eregs_index.DiffEntry(cfr_title, cfr_part)
+    version_ids = list(eregs_index.VersionEntry(cfr_title, cfr_part))
+    for lhs_id in version_ids:
+        container = diff_dir / lhs_id
+        for rhs_id in version_ids:
+            if rhs_id in container:
+                click.echo("Writing diff {} to {}".format(lhs_id, rhs_id))
+                diff = (container / rhs_id).read()
+                client.diff(cfr_part, lhs_id, rhs_id).write(diff)
+
+
+@click.command()
+@click.argument('cfr_title', type=int)
+@click.argument('cfr_part', type=int)
+@click.argument('output')
+def write_to(cfr_title, cfr_part, output):
+    """TODO"""
+    client = Client(output)
+    cfr_part = str(cfr_part)
+    write_trees(client, cfr_title, cfr_part)
+    write_layers(client, cfr_title, cfr_part)
+    write_notices(client, cfr_title, cfr_part)
+    write_diffs(client, cfr_title, cfr_part)

--- a/regparser/commands/write_to.py
+++ b/regparser/commands/write_to.py
@@ -4,6 +4,9 @@ from regparser import eregs_index
 from regparser.api_writer import Client
 
 
+# The write process is split into a set of functions, each responsible for
+# writing a particular type of entity
+
 def write_trees(client, cfr_title, cfr_part):
     tree_dir = eregs_index.TreeEntry(cfr_title, cfr_part)
     for version_id in eregs_index.VersionEntry(cfr_title, cfr_part):
@@ -48,7 +51,13 @@ def write_diffs(client, cfr_title, cfr_part):
 @click.argument('cfr_part', type=int)
 @click.argument('output')
 def write_to(cfr_title, cfr_part, output):
-    """TODO"""
+    """Export data. Sends all data in the index to an external source.
+
+    OUTPUT can be a
+    * directory (if it does not exist, it will be created)
+    * uri (the base url of an instance of regulations-core)
+    * a directory prefixed with "git://". This will export to a git
+      repository"""
     client = Client(output)
     cfr_part = str(cfr_part)
     write_trees(client, cfr_title, cfr_part)

--- a/regparser/commands/write_to.py
+++ b/regparser/commands/write_to.py
@@ -53,6 +53,7 @@ def write_diffs(client, cfr_title, cfr_part):
 def write_to(cfr_title, cfr_part, output):
     """Export data. Sends all data in the index to an external source.
 
+    \b
     OUTPUT can be a
     * directory (if it does not exist, it will be created)
     * uri (the base url of an instance of regulations-core)

--- a/tests/commands_write_to_tests.py
+++ b/tests/commands_write_to_tests.py
@@ -1,0 +1,95 @@
+from datetime import date
+import os
+import tempfile
+import shutil
+from unittest import TestCase
+
+from click.testing import CliRunner
+
+from regparser import eregs_index
+from regparser.commands.write_to import write_to
+from regparser.history.versions import Version
+from regparser.tree.struct import Node
+
+
+class CommandsWriteToTests(TestCase):
+    def setUp(self):
+        self.cli = CliRunner()
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def add_versions(self):
+        """Add some versions to the index"""
+        eregs_index.VersionEntry('12', '1000', 'v1').write(
+            Version('v1', date(2001, 1, 1), date(2001, 1, 1)))
+        eregs_index.VersionEntry('12', '1000', 'v2').write(
+            Version('v2', date(2002, 2, 2), date(2002, 2, 2)))
+        eregs_index.VersionEntry('12', '1000', 'v3').write(
+            Version('v3', date(2003, 3, 3), date(2003, 3, 3)))
+        eregs_index.VersionEntry('12', '1001', 'other').write(
+            Version('other', date(2003, 3, 3), date(2003, 3, 3)))
+
+    def add_trees(self):
+        """Add some versions to the index"""
+        eregs_index.TreeEntry('12', '1000', 'v2').write(Node('v2'))
+        eregs_index.TreeEntry('12', '1000', 'v3').write(Node('v3'))
+        eregs_index.TreeEntry('12', '1000', 'v4').write(Node('v4'))
+
+    def add_layers(self):
+        """Add an assortment of layers to the index"""
+        eregs_index.LayerEntry('12', '1000', 'v2', 'layer1').write({'1': 1})
+        eregs_index.LayerEntry('12', '1000', 'v2', 'layer2').write({'2': 2})
+        eregs_index.LayerEntry('12', '1000', 'v3', 'layer2').write({'2': 2})
+        eregs_index.LayerEntry('12', '1000', 'v3', 'layer3').write({'3': 3})
+        eregs_index.LayerEntry('12', '1000', 'v0', 'layer1').write({'1': 1})
+
+    def add_diffs(self):
+        """Adds an uneven assortment of diffs between trees"""
+        eregs_index.DiffEntry('12', '1000', 'v1', 'v2').write({'1': 2})
+        eregs_index.DiffEntry('12', '1000', 'v2', 'v2').write({'2': 2})
+        eregs_index.DiffEntry('12', '1000', 'v2', 'v1').write({'2': 1})
+        eregs_index.DiffEntry('12', '1000', 'v0', 'v1').write({'0': 1})
+
+    def add_notices(self):
+        """Adds an uneven assortment of notices"""
+        eregs_index.SxSEntry('v0').write({'0': 0})
+        eregs_index.SxSEntry('v1').write({'1': 1})
+        eregs_index.SxSEntry('v2').write({'2': 2})
+
+    def assert_file_exists(self, *parts):
+        """Helper method to verify that a file was created"""
+        path = os.path.join(self.tmpdir, *parts)
+        self.assertTrue(os.path.exists(path))
+
+    def test_integration(self):
+        """Create a (small) set of files in the index. These files have
+        various mismatches between version information -- we should only write
+        the files which have an associated version"""
+        with self.cli.isolated_filesystem():
+            self.add_versions()
+            self.add_trees()
+            self.add_layers()
+            self.add_diffs()
+            self.add_notices()
+            self.cli.invoke(write_to, ['12', '1000', self.tmpdir])
+
+            self.assert_file_exists('regulation', '1000', 'v2')
+            self.assert_file_exists('regulation', '1000', 'v3')
+            # v4 is skipped as there is no corresponding version
+
+            self.assert_file_exists('layer', 'layer1', '1000', 'v2')
+            self.assert_file_exists('layer', 'layer2', '1000', 'v2')
+            self.assert_file_exists('layer', 'layer2', '1000', 'v3')
+            self.assert_file_exists('layer', 'layer3', '1000', 'v3')
+            # v0, layer1 is skipped as there is no corresponding version
+
+            self.assert_file_exists('diff', '1000', 'v1', 'v2')
+            self.assert_file_exists('diff', '1000', 'v2', 'v2')
+            self.assert_file_exists('diff', '1000', 'v2', 'v1')
+            # v0, v1 is skipped as there is no corresponding version
+
+            # v0 is skipped as there is no corresponding version
+            self.assert_file_exists('notice', 'v1')
+            self.assert_file_exists('notice', 'v2')

--- a/tests/http_mixin.py
+++ b/tests/http_mixin.py
@@ -28,3 +28,9 @@ class HttpMixin(object):
 
     def last_http_params(self):
         return httpretty.last_request().querystring
+
+    def last_http_headers(self):
+        return httpretty.last_request().headers.dict
+
+    def last_http_body(self):
+        return httpretty.last_request().parsed_body


### PR DESCRIPTION
1. ~~preprocess notices~~
2. ~~generate versions~~
3. ~~generate trees from annual XML~~
4. ~~generate trees from prev trees + changes found in rules~~
5. ~~generate layers~~
6. ~~generate diffs~~
7. **post data to the api**

Once everything is built, send the results to a location on the file system, an API, or a git repository. No dependencies are checked, though that might make sense in a future iteration. Along the way, modifies the api_writer classes so that they can be configured at instance creation time rather than requiring they use the `settings`