### PR TITLE
Add XML preprocessor to merge EXTRACTs.

### DIFF
--- a/regparser/builder.py
+++ b/regparser/builder.py
@@ -13,7 +13,7 @@ from regparser.history.notices import (
     applicable as applicable_notices, group_by_eff_date)
 from regparser.history.delays import modify_effective_dates
 from regparser.layer import ALL_LAYERS
-from regparser.notice import fake as notice_fake
+from regparser.notice import fake as notice_fake, preprocessors
 from regparser.notice.compiler import compile_regulation
 from regparser.tree import struct, xml_parser
 
@@ -332,6 +332,9 @@ def tree_and_builder(filename, title, checkpoint_path=None, doc_number=None):
         reg_xml = etree.fromstring(reg_text)
     else:
         raise ValueError("Building from text input is no longer supported")
+
+    for preprocessor in preprocessors.ALL:
+        preprocessor().transform(reg_xml)
 
     reg_tree = checkpointer.checkpoint(
         "init-tree-" + file_digest,

--- a/regparser/commands/fetch_annual_edition.py
+++ b/regparser/commands/fetch_annual_edition.py
@@ -2,6 +2,7 @@ import click
 
 from regparser import eregs_index
 from regparser.history import annual
+from regparser.notice import preprocessors
 
 
 @click.command()
@@ -12,4 +13,6 @@ def fetch_annual_edition(cfr_title, cfr_part, year):
     """Download an annual edition of a regulation"""
     volume = annual.find_volume(year, cfr_title, cfr_part)
     xml = volume.find_part_xml(cfr_part)
+    for preprocessor in preprocessors.ALL:
+        preprocessor().transform(xml)
     eregs_index.AnnualEntry(cfr_title, cfr_part, year).write(xml)

--- a/regparser/notice/preprocessors.py
+++ b/regparser/notice/preprocessors.py
@@ -115,6 +115,8 @@ class ApprovalsFP(PreProcessorBase):
 class ExtractTags(PreProcessorBase):
     """Often, what should be a single EXTRACT tag is broken up by incorrectly
     positioned subtags. Try to find any such EXTRACT sandwiches and merge."""
+    FILLING = ('FTNT', 'GPOTABLE')  # tags which shouldn't be between EXTRACTs
+
     def extract_pair(self, extract):
         """Checks for and merges two EXTRACT tags in sequence"""
         next_el = extract.getnext()
@@ -124,13 +126,13 @@ class ExtractTags(PreProcessorBase):
         return False
 
     def sandwich(self, extract):
-        """Checks for this pattern: EXTRACT (FTNT|GPOTABLE) EXTRACT, and, if
-        present, combines the first two tags. The two EXTRACTs would get
-        merged in a later pass"""
+        """Checks for this pattern: EXTRACT FILLING EXTRACT, and, if present,
+        combines the first two tags. The two EXTRACTs would get merged in a
+        later pass"""
         next_el = extract.getnext()
         next_next_el = next_el is not None and next_el.getnext()
         if next_el is not None and next_next_el is not None:
-            has_filling = next_el.tag in ('FTNT', 'GPOTABLE')
+            has_filling = next_el.tag in self.FILLING
             has_bread = next_next_el.tag == 'EXTRACT'
             if has_filling and has_bread:   # -> is sandwich
                 self.combine_with_following(extract, include_tag=True)

--- a/tests/xml_builder.py
+++ b/tests/xml_builder.py
@@ -82,3 +82,21 @@ class XMLBuilderMixin(object):
         with builder.builder('ROOT'):
             pass
         return builder.render_xml()
+
+    @contextmanager
+    def assert_xml_transformed(self):
+        """This verifies that XML has been transformed the way we expect.
+        Usage:
+
+        with self.assert_xml_transformed() as original_xml:
+            some_transform(xml)
+            with self.tree.builder("TAG1") as tag1:
+                ...
+
+        in which case, the mutated xml is tested against the final value of
+        self.tree
+        """
+        xml = self.tree.render_xml()
+        yield xml
+        new_xml = self.tree.render_xml()
+        self.assertEqual(etree.tostring(xml), etree.tostring(new_xml))


### PR DESCRIPTION
Closes 18f/atf-eregs#54

In one year, the XML might look like:
```
  <EXTRACT>
    <TAG1>....</TAG1>
    <GPOTABLE>...</GPOTABLE>
    <TAG2>...</TAG1>
  </EXTRACT>
```

and in the next:
```
  <EXTRACT>
    <TAG1>....</TAG1>
  </EXTRACT>
  <GPOTABLE>...</GPOTABLE>
  <EXTRACT>
    <TAG2>...</TAG1>
  </EXTRACT>
```

It's safe to say that the table is supposed to be inside the extract; this
preprocessor performs that change. It also applies these preprocessing steps
to annual editions (previously, they had only been applied to notices), and
adds a shortcut for comparing XML trees.