### PR TITLE
Pipeline command and tweaks to `clear`

### DIFF
--- a/regparser/commands/clear.py
+++ b/regparser/commands/clear.py
@@ -6,11 +6,30 @@ import click
 from regparser import eregs_index
 
 
+SQLITE_CACHE = 'fr_cache.sqlite'
+
+
 @click.command()
-def clear():
-    """Delete all intermediate data. Generally not needed, but this is a
-    simple method to start fresh regarding intermediate and cached data"""
-    if os.path.exists(eregs_index.ROOT):
-        shutil.rmtree(eregs_index.ROOT)
-    if os.path.exists("fr_cache.sqlite"):
-        os.remove("fr_cache.sqlite")
+@click.argument('path', nargs=-1)
+@click.option('--http-cache/--no-http-cache', default=False,
+              help="Clear HTTP request (FR, GPO, etc.). Defaults false")
+def clear(path, http_cache):
+    """Delete intermediate data. Only PATH arguments are cleared unless no
+    arguments are present, then everything is wiped.
+
+    \b
+    $ eregs clear                   # clears everything
+    $ eregs clear diff/27 trees     # deletes all cached trees and all CFR
+                                    # title 27 diffs
+    """
+    if not path:
+        path = ['']
+    paths = [os.path.join(eregs_index.ROOT, p) for p in path]
+    for path in paths:
+        if os.path.exists(path):
+            shutil.rmtree(path)
+        else:
+            click.echo("Warning: path does not exist: " + path)
+
+    if http_cache and os.path.exists(SQLITE_CACHE):
+        os.remove(SQLITE_CACHE)

--- a/regparser/commands/pipeline.py
+++ b/regparser/commands/pipeline.py
@@ -1,0 +1,33 @@
+import click
+
+from regparser.commands.versions import versions
+from regparser.commands.annual_editions import annual_editions
+from regparser.commands.fill_with_rules import fill_with_rules
+from regparser.commands.layers import layers
+from regparser.commands.diffs import diffs
+from regparser.commands.write_to import write_to
+
+
+@click.command()
+@click.argument('cfr_title', type=int)
+@click.argument('cfr_part', type=int)
+@click.argument('output')
+@click.pass_context
+def pipeline(ctx, cfr_title, cfr_part, output):
+    """Full regulation parsing pipeline. Consists of retrieving and parsing
+    annual edition, attempting to parse final rules in between, deriving
+    layers and diffs, and writing them to disk or an API
+
+    \b
+    OUTPUT can be a
+    * directory (if it does not exist, it will be created)
+    * uri (the base url of an instance of regulations-core)
+    * a directory prefixed with "git://". This will export to a git
+      repository"""
+    params = {'cfr_title': cfr_title, 'cfr_part': cfr_part}
+    ctx.invoke(versions, **params)
+    ctx.invoke(annual_editions, **params)
+    ctx.invoke(fill_with_rules, **params)
+    ctx.invoke(layers, **params)
+    ctx.invoke(diffs, **params)
+    ctx.forward(write_to)


### PR DESCRIPTION
Builds on #88 and #91 -- without them, the `pipeline` command wouldn't be very useful.

The `pipeline` command runs through all of the steps needed to parse a regulation -- it's like `build_from`, but using the split-out commands. The benefit here is that each of these steps is incremental.

Say we've already ran the pipeline and have all of our trees, layers, diffs, etc. I realize that the parser messed up when deriving amendments, so I modify the appropriate notice xml. I then run `preprocess_notice` to get the updated version into the index. Running `pipeline` again will _only_ rebuild the dependencies for that notice (trees, layers, diffs). Similarly, if a new final rule is made, running `pipeline` (after clearing the HTTP cache) will only build trees, layers, etc. associated with that new rule.

This also modifies the clear command to allow specific paths to be removed (if you know them) and makes deleting the HTTP cache an optional flag (defaulting off)