### PR TITLE
"Compare to" + requirements updates

### DIFF
--- a/eregs.py
+++ b/eregs.py
@@ -3,22 +3,16 @@ from importlib import import_module
 import pkgutil
 
 import click
+import requests_cache   # @todo - replace with cache control
 
 from regparser import commands, eregs_index
 from regparser.commands.dependency_resolver import DependencyResolver
-
-try:
-    import requests_cache   # @todo - replace with cache control
-    requests_cache.install_cache('fr_cache')
-except ImportError:
-    # If the cache library isn't present, do nothing -- we'll just make full
-    # HTTP requests rather than looking it up from the cache
-    pass
 
 
 @click.group()
 def cli():
     logging.basicConfig(level=logging.INFO)
+    requests_cache.install_cache('fr_cache')
 
 
 for _, command_name, _ in pkgutil.iter_modules(commands.__path__):

--- a/regparser/commands/compare_to.py
+++ b/regparser/commands/compare_to.py
@@ -1,0 +1,78 @@
+import json
+import os
+import shutil
+import tempfile
+
+import click
+from json_delta import udiff
+import requests
+import requests_cache
+
+from regparser.commands.write_to import write_to
+
+
+def files_to_compare(tmppath, relevant_paths=None):
+    """List of all file names we should care about comparing. Filters out any
+    paths which do not begin with a string in relevant_paths"""
+    relevant_paths = relevant_paths or ['']
+    file_names = [os.path.join(dir_path, file_name)
+                  for dir_path, _, file_names in os.walk(tmppath)
+                  for file_name in file_names]
+    # strip the tempdir info
+    file_names = [file_name[len(tmppath)+1:] for file_name in file_names]
+    matches_a_path = lambda f: any(f.startswith(p) for p in relevant_paths)
+
+    return filter(matches_a_path, file_names)
+
+
+def compare(local_path, remote_url):
+    """Downloads and compares a local JSON file with a remote one. If there is
+    a difference, notifies the user and prompts them if they want to see the
+    diff"""
+    remote_response = requests.get(remote_url)
+    if remote_response.status_code == 404:
+        click.echo("Nonexistent: " + remote_url)
+    else:
+        remote = remote_response.json()
+        with open(local_path) as f:
+            local = json.load(f)
+
+        if remote != local:
+            click.echo("Content differs: {} {}".format(local_path, remote_url))
+            if click.confirm("Show diff?"):
+                map(click.echo, udiff(local, remote))
+
+
+@click.command()
+@click.argument('cfr_title', type=int)
+@click.argument('cfr_part', type=int)
+@click.argument('api_base')
+@click.argument('path', nargs=-1)
+@click.pass_context
+def compare_to(ctx, cfr_title, cfr_part, api_base, path):
+    """Compare local JSON to a remote server. This is useful for verifying
+    changes to the parser.
+
+    API_BASE is the uri of the root of the API. Use what would be the last
+    parameter in the `write_to` command.
+
+    PATH parameters will filter the files we're trying to compare. For
+    example, if we only want to see the difference between trees, one of the
+    PATH parameters should be "regulation".
+    """
+    if not api_base.endswith("/"):
+        api_base += "/"
+
+    tmppath = tempfile.mkdtemp()
+    ctx.invoke(write_to, cfr_title=cfr_title, cfr_part=cfr_part,
+               output=tmppath)
+
+    # @todo: ugly to uninstall the cache after installing it in eregs.py.
+    # Remove the globalness
+    requests_cache.uninstall_cache()
+
+    for file_name in files_to_compare(tmppath, path or ['']):
+        local_name = os.path.join(tmppath, file_name)
+        remote_name = api_base + file_name.replace(os.path.sep, "/")
+        compare(local_name, remote_name)
+    shutil.rmtree(tmppath)

--- a/regparser/commands/compare_to.py
+++ b/regparser/commands/compare_to.py
@@ -40,7 +40,8 @@ def compare(local_path, remote_url):
         if remote != local:
             click.echo("Content differs: {} {}".format(local_path, remote_url))
             if click.confirm("Show diff?"):
-                map(click.echo, udiff(remote, local))
+                diffs_str = '\n'.join(udiff(remote, local))
+                click.echo_via_pager(diffs_str)
 
 
 @click.command()

--- a/regparser/commands/compare_to.py
+++ b/regparser/commands/compare_to.py
@@ -40,7 +40,7 @@ def compare(local_path, remote_url):
         if remote != local:
             click.echo("Content differs: {} {}".format(local_path, remote_url))
             if click.confirm("Show diff?"):
-                map(click.echo, udiff(local, remote))
+                map(click.echo, udiff(remote, local))
 
 
 @click.command()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
 click==5.1
 dagger==1.3.0
+GitPython==0.3.2.RC1
+inflection==0.1.2
+json-delta==1.1.3
 lxml==3.2.0
 pyparsing==1.5.7
-inflection==0.1.2
-requests==1.2.3
-GitPython==0.3.2.RC1
 python-constraint==1.2
+requests==1.2.3
+requests-cache==0.4.10
 -e .

--- a/tests/commands_compare_to_tests.py
+++ b/tests/commands_compare_to_tests.py
@@ -1,0 +1,112 @@
+import json
+import os
+import shutil
+import tempfile
+from unittest import TestCase
+
+import click
+from click.testing import CliRunner
+
+from regparser.commands import compare_to
+from tests.http_mixin import HttpMixin
+
+
+class CommandsCompareToTests(HttpMixin, TestCase):
+    def setUp(self):
+        super(CommandsCompareToTests, self).setUp()
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+        super(CommandsCompareToTests, self).tearDown()
+
+    def populate(self, files):
+        """Create the requested files in the tempdir. The files param should
+        be a list of tuples, denoting file path components"""
+        for file_parts in files:
+            dir_name = os.path.join(self.tmpdir, *file_parts[:-1])
+            if not os.path.exists(dir_name):
+                os.makedirs(dir_name)
+            with open(os.path.join(dir_name, file_parts[-1]), 'w') as f:
+                f.write('content')
+        return [os.path.join(*parts) for parts in files]
+
+    def test_files_to_compare_lists(self):
+        """Files to compare should find all of the files present in the temp
+        directory"""
+        file_names = self.populate([
+            ('dir1', 'sub1', 'a'), ('dir1', 'sub1', 'b'),
+            ('dir1', 'sub2', 'c'),
+            ('dir2', 'd'), ('dir2', 'e'),
+            ('f',)])
+        os.mkdir(os.path.join(self.tmpdir, 'empty-dir'))
+
+        self.assertItemsEqual(
+            compare_to.files_to_compare(self.tmpdir),
+            # note that file_names do not include the tmpdir
+            file_names)
+
+    def test_file_to_compare_filter(self):
+        """If the `relevant_paths` param is provided, only files which match
+        it should be returned"""
+        self.populate([
+            ('dir1', 'sub1', 'a'), ('dir1', 'sub2', 'b'),
+            ('dir2', 'c'),
+            ('dir3', 'd'),
+            ('dir22', 'e')])
+        results = compare_to.files_to_compare(
+            self.tmpdir, [os.path.join('dir1', 'sub1'), 'dir2'])
+        self.assertItemsEqual(
+            results,
+            [os.path.join('dir1', 'sub1', 'a'),
+             os.path.join('dir2', 'c'),
+             os.path.join('dir22', 'e')])
+
+    def run_compare(self, local_path, remote_url, input=None):
+        """Our CLI library, Click, is easier to test via click.commands. So we
+        create one to wrap compare_to.compare, run it, and return the
+        results"""
+
+        @click.command()
+        def wrapper():
+            compare_to.compare(local_path, remote_url)
+
+        return CliRunner().invoke(wrapper, input=input)
+
+    def test_compare_404(self):
+        """If the remote file doesn't exist, we should be notified"""
+        self.expect_json_http(status=404)
+        result = self.run_compare('local_file', 'http://example.com/remote')
+        self.assertEqual('Nonexistent: http://example.com/remote\n',
+                         result.output)
+
+    def test_compare_no_diff(self):
+        """We shouldn't get any notification if the files are the same"""
+        data = {'key1': 1, 'key2': 'a', 'key3': [1, 2, 3]}
+        local_path = os.path.join(self.tmpdir, 'file.json')
+        with open(local_path, 'w') as f:
+            json.dump(data, f)
+        self.expect_json_http(data)
+        result = self.run_compare(local_path, 'http://example.com/file.json')
+        self.assertEqual('', result.output)
+
+    def test_compare_with_diff(self):
+        """If the files differ, we should get prompted to see the diff. If we
+        say yes, we should see a diff"""
+        local_path = os.path.join(self.tmpdir, 'file.json')
+        with open(local_path, 'w') as f:
+            json.dump({'key1': 1, 'key2': 'a'}, f)
+        self.expect_json_http({'key1': 1, 'key2': 'b'})
+
+        # No, I do not want to see diffs
+        result = self.run_compare(local_path, 'http://example.com/file.json',
+                                  input="n\n")
+        self.assertTrue('Content differs' in result.output)
+        self.assertFalse('key' in result.output)
+
+        # Yes, I do want to see the diffs
+        result = self.run_compare(local_path, 'http://example.com/file.json',
+                                  input="Y\n")
+        self.assertTrue('Content differs' in result.output)
+        self.assertTrue('-  "a"' in result.output)
+        self.assertTrue('+  "b"' in result.output)

--- a/tests/commands_compare_to_tests.py
+++ b/tests/commands_compare_to_tests.py
@@ -95,8 +95,8 @@ class CommandsCompareToTests(HttpMixin, TestCase):
         say yes, we should see a diff"""
         local_path = os.path.join(self.tmpdir, 'file.json')
         with open(local_path, 'w') as f:
-            json.dump({'key1': 1, 'key2': 'a'}, f)
-        self.expect_json_http({'key1': 1, 'key2': 'b'})
+            json.dump({'key1': 1, 'key2': 'b'}, f)
+        self.expect_json_http({'key1': 1, 'key2': 'a'})
 
         # No, I do not want to see diffs
         result = self.run_compare(local_path, 'http://example.com/file.json',


### PR DESCRIPTION
The goal of this command is to compare your local tree with a remote API. This
is particularly useful for regression tests, to make sure that tweaks to the
parser didn't change the tree/etc. in unexpected ways.

The command calls `write_to` with a temporary directory, then runs through
the files in that directory, comparing each to the same file on the API. If
the file is not present remotely, the user is notified. If the file has a
difference, the user is asked whether or not they want to see the diff.


Interaction looks like:
```
(parser)vagrant@debian8:~/regulations-parser$ eregs compare_to 27 479 https://example.com/api regulation
Writing tree 03-1657
[ .. Snip .. ]
Writing diff 2014-18842 to 2014-18842
INFO:requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): atf-eregs.18f.gov
Content differs: /tmp/tmpIsalss/regulation/479/2014-02580 https://atf-eregs.18f.gov/api/regulation/479/2014-02580
Show diff? [y/N]: n
INFO:requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): atf-eregs.18f.gov
Content differs: /tmp/tmpIsalss/regulation/479/2014-18842 https://atf-eregs.18f.gov/api/regulation/479/2014-18842
Show diff? [y/N]: n
INFO:requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): atf-eregs.18f.gov
Content differs: /tmp/tmpIsalss/regulation/479/E8-23178 https://atf-eregs.18f.gov/api/regulation/479/E8-23178
Show diff? [y/N]: y
 {
 "text": "",
 ...,
 "children":
   [
    {...},
    ...(1),
    {...},
    {
    "text": "",
    ...,
    "children":
      [
       {...},
       ...(2),
       {...},
       {
       "text": "\n        ",
       ...,
       "children":
         [
          {...},
          ...(1),
          {...},
          {
          "node_type": "regtext",
          ...,
          "text":
-           "(d) Signing of ATF Forms 5630.7 \u2014"
+           "(d) Signing of ATF Forms 5630.7\u2014"
          },
          {...}
         ]
       },
       {...},
       ...(4),
       {...},
       {...}
      ]
    },
    {...},
    ...(4),
    {...},
    {
    "node_type": "subpart",
    ...,
    "title":
-     "Application To Make a Firearm",
+     "Application to Make a Firearm",

    "label":
      [
       "479",
       "Subjgrp",
-      "ATMaF"
+      "AtMaF"
      ]
    },
    {...},
    ...(2),
    {...},
    {
    "text": "",
    ...,
    "children":
      [
       {...},
       {...},
       {
       "text": "\n          ",
       ...,
       "children":
         [
          {...},
          {
          "node_type": "regtext",
          ...,
          "text":
-           "(b) The exemption provided in paragraph (a) of this section shall be obtained by the transferor of the firearm filing with the Director an application, Form 5 (Firearms), Application for Tax-exempt Transfer and Registration of Firearm, in duplicate, executed under the penalties of perjury. The application shall (1) show the name and address of the transferor and of the transferee, (2) identify the Federal firearms license and special (occupational) tax stamp, if any, of the transferor and of the transferee, (3) show the name and address of the manufacturer and the importer of the firearm, if known, (4) show the type, model, overall length (if applicable), length of barrel, caliber, gauge or size, serial number, and other marks of identification of the firearm, and (5) contain a statement by the transferor that the transferor is entitled to the exemption because either the transferor or the transferee is a governmental entity coming within the purview of paragraph (a) of this section. In the case of a transfer of a firearm by a governmental entity to a transferee who is a natural person not qualified as a manufacturer, importer, or dealer under this part, the transferee shall be further identified in the manner prescribed in \u00a7 479.85. If the Director approves an application, Form 5 (Firearms), the original Form 5 (Firearms) shall be returned to the transferor with the approval noted thereon. Approval of an application, Form 5 (Firearms), by the Director shall effectuate the registration of that firearm to the transferee. Upon receipt of the approved Form 5 (Firearms), the transferor shall deliver same with the firearm to the transferee. The transferor shall not transfer the firearm to the transferee until the application, Form 5 (Firearms), has been approved by the Director and the original thereof has been returned to the transferor. If the Director disapproves the application, Form 5 (Firearms), the original Form 5 (Firearms) shall be returned to the transferor with the reasons for the disapproval stated thereon. An application by a governmental entity to transfer a firearm shall be denied if the transfer, receipt, or possession of a firearm would place the transferee in violation of law."
+           "(b) The exemption provided in paragraph (a) of this section shall be obtained by the transferor of the firearm filing with the Director an application, Form 5 (Firearms), Application for Tax-exempt Transfer and Registration of Firearm, in duplicate, executed under the penalties of perjury. The application shall (1) show the name and address of the transferor and of the transferee, (2) identify the Federal firearms license and special (occupational) tax stamp, if any, of the transferor and of the transferee, (3) show the name and address of the manufacturer and the importer of the firearm, if known, (4) show the type, model, overall length (if applicable), length of barrel, caliber, gauge or size, serial number, and other marks of identification of the firearm, and (5) contain a statement by the transferor that the transferor is entitled to the exemption because either the transferor or the transferee is a governmental entity coming within the purview of paragraph (a) of this section. In the case of a transfer of a firearm by a governmental entity to a transferee who is a natural person not qualified as a manufacturer, importer, or dealer under this part, the transferee shall be further identified in the manner prescribed in \u00a7 479.85. If the Director approves an application, Form 5 (Firearms), the original Form 5 (Firearms) shall be returned to the transferor with the approval noted thereon. Approval of an application, Form 5 (Firearms), by the Director shall effectuate the registration of that firearm to the transferee. Upon receipt of the approved Form 5 (Firearms), the transferor shall deliver same with the firearm to the transferee. The transferor shall not transfer the firearm to the transferee until the application, Form 5 (Firearms), has been approved by the Director and the original thereof has been returned to the transferor. If the Director disapproves the application, Form 5 (Firearms), the original Form 5 (Firearms) shall be returned to the transferor with the reasons for the disapproval stated thereon. An application by a governmental entity to transfer a firearm shall be denied if the tranfer, receipt, or possession of a firearm would place the transferee in violation of law."
          },
          {...}
         ]
       },
       {...},
       {...}
      ]
    },
    {...},
    ...(11),
    {...},
    {...}
   ]
 }
INFO:requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): atf-eregs.18f.gov
```

I'd like to remove the logging messages, but meh for now