### PR TITLE
Tweaks for 27 CFR 479

### DIFF
--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -94,7 +94,7 @@ class ParagraphProcessor(object):
         nodes = self.parse_nodes(xml)
         intro_node, nodes = self.separate_intro(nodes)
         if intro_node:
-            root.text += " " + intro_node.text
+            root.text = " ".join([root.text, intro_node.text]).strip()
             # @todo - this is ugly. Make tagged_text a legitimate field on Node
             tagged_text_list = []
             if hasattr(root, 'tagged_text'):

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -237,7 +237,7 @@ def build_from_section(reg_part, section_xml):
     section_nodes = []
     for section_number in section_nums:
         section_number = str(section_number)
-        section_text = section_xml.text
+        section_text = section_xml.text.strip()
         tagged_section_text = section_xml.text
 
         section_title = u"§ " + reg_part + "." + section_number

--- a/regparser/tree/xml_parser/tree_utils.py
+++ b/regparser/tree/xml_parser/tree_utils.py
@@ -114,8 +114,8 @@ def _should_add_space(prev_text, next_text):
     prev_text, next_text = prev_text[-1:], next_text[:1]
     return (not prev_text.isspace() and not next_text.isspace()
             and next_text
-            and prev_text not in '([/<'
-            and next_text not in ').;,]>/')
+            and prev_text not in u'([/<—-'
+            and next_text not in u').;,]>/—-')
 
 
 def get_node_text(node, add_spaces=False):

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -205,7 +205,7 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
                          node['a']['p1'].text)
         self.assertEqual("GPOTABLE", node['a']['p1'].source_xml.tag)
 
-    def test_build_form_section_extract(self):
+    def test_build_from_section_extract(self):
         """Account for paragraphs within an EXTRACT tag"""
         with self.section() as root:
             root.P("(a) aaaa")
@@ -221,7 +221,7 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
         content = ["```extract", "1. Some content", "2. Other content", "```"]
         self.assertEqual("\n".join(content), extract.text)
 
-    def test_build_form_section_notes(self):
+    def test_build_from_section_notes(self):
         """Account for paragraphs within a NOTES tag"""
         with self.section() as root:
             root.P("(a) aaaa")
@@ -236,6 +236,19 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
         self.assertEqual(['8675', '309', 'a', 'p1'], extract.label)
         content = ["```note", "1. Some content", "2. Other content", "```"]
         self.assertEqual("\n".join(content), extract.text)
+
+    def test_build_from_section_whitespace(self):
+        """The whitespace in the section text (and intro paragraph) should get
+        removed"""
+        with self.tree.builder("SECTION", node_value="\n\n") as root:
+            root.SECTNO(u"§ 8675.309")
+            root.SUBJECT("subsubsub")
+            root.P("   Some \n content\n")
+            root.P("(a) aaa")
+            root.P("(b) bbb")
+
+        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+        self.assertEqual(node.text, "Some \n content")
 
     def test_get_title(self):
         with self.tree.builder("PART") as root:


### PR DESCRIPTION
The trees generated from annual editions and the trees built from final rules contained a few, minor differences. These tweaks to the parser iron the inconsequential ones out.

* Strip whitespace from section and intro paragraph texts. Turns out these vary a tad from edition to edition despite being inconsequential to the regulation
* When removing tags, don't add a space if the tag was preceded or followed by a hyphen or em-dash. Things like
```xml
<p> Abcdef-<prtpage />ghi</p>
```
were being processed as
```
Abcdef- ghi
```