### PR TITLE
Account for missing notice attrs

### DIFF
--- a/regparser/commands/fetch_sxs.py
+++ b/regparser/commands/fetch_sxs.py
@@ -5,7 +5,8 @@ import click
 
 from regparser import eregs_index
 from regparser.commands.dependency_resolver import DependencyResolver
-from regparser.notice.build import process_xml
+from regparser.federalregister import meta_data, FULL_NOTICE_FIELDS
+from regparser.notice.build import build_notice
 
 
 @click.command()
@@ -28,7 +29,9 @@ def fetch_sxs(document_number):
     # @todo - break apart processing of SxS. We don't need all of the other
     # fields
     notice_xml = notice_entry.read()
-    notice = process_xml(notice_xml.to_notice_dict(), notice_xml._xml)
+    notice_meta = meta_data(document_number, FULL_NOTICE_FIELDS)
+    notice = build_notice(notice_xml.cfr_titles[0], None, notice_meta,
+                          xml_to_process=notice_xml._xml)[0]
     sxs_entry.write(notice)
 
 

--- a/regparser/commands/parse_rule_changes.py
+++ b/regparser/commands/parse_rule_changes.py
@@ -2,7 +2,7 @@ import click
 
 from regparser import eregs_index
 from regparser.commands.dependency_resolver import DependencyResolver
-from regparser.notice.build import process_xml
+from regparser.notice.build import process_amendments
 
 
 @click.command()
@@ -22,10 +22,9 @@ def parse_rule_changes(document_number):
     # We don't check for staleness as we want to always execute when given a
     # specific file to process
 
-    # @todo - break apart processing of amendments/changes. We don't need
-    # all of the other fields
     notice_xml = notice_entry.read()
-    notice = process_xml(notice_xml.to_notice_dict(), notice_xml._xml)
+    notice = process_amendments({'cfr_parts': notice_xml.cfr_parts},
+                                notice_xml._xml)
     rule_entry.write(notice)
 
 

--- a/regparser/federalregister.py
+++ b/regparser/federalregister.py
@@ -4,6 +4,11 @@ from regparser.notice.build import build_notice
 
 FR_BASE = "https://www.federalregister.gov"
 API_BASE = FR_BASE + "/api/v1/"
+FULL_NOTICE_FIELDS = [
+    "abstract", "action", "agency_names", "cfr_references", "citation",
+    "comments_close_on", "dates", "document_number", "effective_on",
+    "end_page", "full_text_xml_url", "html_url", "publication_date",
+    "regulation_id_numbers", "start_page", "type", "volume"]
 
 
 def fetch_notice_json(cfr_title, cfr_part, only_final=False,
@@ -15,11 +20,7 @@ def fetch_notice_json(cfr_title, cfr_part, only_final=False,
         "conditions[cfr][part]": cfr_part,
         "per_page": 1000,
         "order": "oldest",
-        "fields[]": [
-            "abstract", "action", "agency_names", "cfr_references", "citation",
-            "comments_close_on", "dates", "document_number", "effective_on",
-            "end_page", "full_text_xml_url", "html_url", "publication_date",
-            "regulation_id_numbers", "start_page", "type", "volume"]}
+        "fields[]": FULL_NOTICE_FIELDS}
     if only_final:
         params["conditions[type][]"] = 'RULE'
     if max_effective_date:

--- a/regparser/grammar/unified.py
+++ b/regparser/grammar/unified.py
@@ -194,11 +194,11 @@ multiple_cfr_p = (
                "tail", listAllMatches=True)))
 
 notice_cfr_p = (
-    Suppress(atomic.title)
+    atomic.title
     + Suppress("CFR")
     + Optional(Suppress(atomic.part_marker | atomic.parts_marker))
     + OneOrMore(
-        atomic.part
+        atomic.part.copy().setResultsName('cfr_parts', listAllMatches=True)
         + Optional(Suppress(','))
         + Optional(Suppress('and'))
     )

--- a/regparser/history/annual.py
+++ b/regparser/history/annual.py
@@ -98,7 +98,7 @@ def find_volume(year, title, part):
 
 def first_notice_and_xml(title, part):
     """Find the first annual xml and its associated notice"""
-    notices = [build_notice(title, part, n, do_process_xml=False)
+    notices = [build_notice(title, part, n, fetch_xml=False)
                for n in fetch_notice_json(title, part, only_final=True)
                if n['full_text_xml_url'] and n['effective_on']]
     modify_effective_dates(notices)

--- a/tests/commands_parse_rule_changes_tests.py
+++ b/tests/commands_parse_rule_changes_tests.py
@@ -26,19 +26,20 @@ class CommandsParseRuleChangesTests(XMLBuilderMixin, TestCase):
             self.assertTrue(isinstance(result.exception,
                                        eregs_index.DependencyException))
 
-    @patch('regparser.commands.parse_rule_changes.process_xml')
-    def test_writes(self, process_xml):
+    @patch('regparser.commands.parse_rule_changes.process_amendments')
+    def test_writes(self, process_amendments):
         """If the notice XML is present, we write the parsed version to disk,
         even if that version's already present"""
+        process_amendments.return_value = {'filled': 'values'}
         with self.cli.isolated_filesystem():
             eregs_index.NoticeEntry('1111').write(self.notice_xml)
             self.cli.invoke(parse_rule_changes, ['1111'])
-            self.assertTrue(process_xml.called)
-            args = process_xml.call_args[0]
+            self.assertTrue(process_amendments.called)
+            args = process_amendments.call_args[0]
             self.assertTrue(isinstance(args[0], dict))
             self.assertTrue(isinstance(args[1], etree._Element))
 
-            process_xml.reset_mock()
+            process_amendments.reset_mock()
             eregs_index.Entry('rule_changes', '1111').write('content')
             self.cli.invoke(parse_rule_changes, ['1111'])
-            self.assertTrue(process_xml.called)
+            self.assertTrue(process_amendments.called)

--- a/tests/grammar_unified_tests.py
+++ b/tests/grammar_unified_tests.py
@@ -37,19 +37,19 @@ class GrammarCommonTests(TestCase):
             self.assertEqual("3", result.section)
             self.assertEqual("4", result.c1)
 
+    def assert_notice_cfr_p_match(self, text, title, parts):
+        result = unified.notice_cfr_p.parseString(text)
+        self.assertEqual(str(title), result.cfr_title)
+        self.assertEqual([str(part) for part in parts], list(result.cfr_parts))
+
     def test_notice_cfr_p(self):
-        text = '12 CFR Parts 1002, 1024, and 1026'
-        result = unified.notice_cfr_p.parseString(text)
-        self.assertEqual(['1002', '1024', '1026'], list(result))
-        text = '12 CFR Parts 1024, and 1026'
-        result = unified.notice_cfr_p.parseString(text)
-        self.assertEqual(['1024', '1026'], list(result))
-        text = '12 CFR Parts 1024'
-        result = unified.notice_cfr_p.parseString(text)
-        self.assertEqual(['1024'], list(result))
-        text = '12 CFR 1024'
-        result = unified.notice_cfr_p.parseString(text)
-        self.assertEqual(['1024'], list(result))
+        self.assert_notice_cfr_p_match('12 CFR Parts 1002, 1024, and 1026',
+                                       title=12, parts=[1002, 1024, 1026])
+        self.assert_notice_cfr_p_match('12 CFR Parts 1024, and 1026',
+                                       title=12, parts=[1024, 1026])
+        self.assert_notice_cfr_p_match('12 CFR Parts 1024',
+                                       title=12, parts=[1024])
+        self.assert_notice_cfr_p_match('12 CFR 1024', title=12, parts=[1024])
 
     def test_marker_comment2(self):
         texts = [u'comment § 1004.3-4-i',


### PR DESCRIPTION
Resolves 18f/atf-eregs#62

The `write_to`/`pipeline` commands took a shortcut by re-using the section-by-section analysis JSON. Unfortunately, we were not building all of the fields in that JSON, so writes to the API would be rejected (and any SxS would have been incomplete). This patch hooks into the existing functions to build a full JSON structure to represent the notice.