### PR TITLE
Handle EXTRACT elements containing more complex child elements.

### DIFF
--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -11,6 +11,7 @@ class Node(object):
     REGTEXT = u'regtext'
     SUBPART = u'subpart'
     EMPTYPART = u'emptypart'
+    EXTRACT = u'extract'
 
     INTERP_MARK = 'Interp'
 

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -85,7 +85,6 @@ class ParagraphProcessor(object):
     def separate_intro(self, nodes):
         """In many situations the first unlabeled paragraph is the "intro"
         text for a section. We separate that out here"""
-
         labels = [n.label[0] for n in nodes]    # label is only one part long
 
         only_one = labels == [mtypes.MARKERLESS]

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -181,22 +181,9 @@ class ExtractMatcher(object):
         return xml.tag in ('EXTRACT')
 
     def derive_nodes(self, xml, processor=None):
-        extract_node = Node(text=xml.text, node_type=u"extract",
-                            label=[mtypes.MARKERLESS])
-        child_nodes = processor.parse_nodes(xml)
-
-        if child_nodes:
-            markers = [node.label[0] for node in child_nodes]
-            depths = derive_depths(markers, processor.additional_constraints())
-            if not depths:
-                logging.error(
-                    "Could not determine paragraph depths:\n%s", markers)
-            depths = processor.select_depth(depths)
-            hierarchy = processor.build_hierarchy(extract_node,
-                                                  child_nodes, depths)
-            extract_node = hierarchy
-
-        return [extract_node]
+        extract_node = Node(text=(xml.text or '').strip(),
+                            node_type=u"extract", label=[mtypes.MARKERLESS])
+        return [processor.process(xml, extract_node)]
 
 
 class FencedMatcher(object):

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -218,7 +218,7 @@ def build_from_section(reg_part, section_xml):
     subject_xml = section_xml.xpath('SUBJECT')
     if not subject_xml:
         subject_xml = section_xml.xpath('RESERVED')
-    subject_text = subject_xml[0].text
+    subject_text = (subject_xml[0].text or '').strip()
 
     section_nums = []
     for match in re.finditer(r'%s\.(\d+[a-z]*)' % reg_part, section_no):
@@ -294,6 +294,7 @@ class RegtextParagraphProcessor(paragraph_processor.ParagraphProcessor):
                 paragraph_processor.TableMatcher(),
                 paragraph_processor.FencedMatcher(),
                 paragraph_processor.ExtractMatcher(),
+                paragraph_processor.HeaderMatcher(),
                 ParagraphMatcher()]
 
     def additional_constraints(self):

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -260,7 +260,7 @@ class ParagraphMatcher(object):
     def matches(self, xml):
         return xml.tag in ('P', 'FP')
 
-    def derive_nodes(self, xml):
+    def derive_nodes(self, xml, processor=None):
         text = ''
         tagged_text = tree_utils.get_node_text_tags_preserved(xml).strip()
         markers_list = get_markers(tagged_text, self.next_marker(xml))
@@ -293,6 +293,7 @@ class RegtextParagraphProcessor(paragraph_processor.ParagraphProcessor):
     MATCHERS = [paragraph_processor.StarsMatcher(),
                 paragraph_processor.TableMatcher(),
                 paragraph_processor.FencedMatcher(),
+                paragraph_processor.ExtractMatcher(),
                 ParagraphMatcher()]
 
     def additional_constraints(self):

--- a/tests/tree_xml_parser_paragraph_processor_tests.py
+++ b/tests/tree_xml_parser_paragraph_processor_tests.py
@@ -8,6 +8,7 @@ from regparser.tree.depth.derive import ParAssignment
 from regparser.tree.struct import Node
 from regparser.tree.xml_parser import paragraph_processor
 
+
 class _ExampleProcessor(paragraph_processor.ParagraphProcessor):
     MATCHERS = [paragraph_processor.SimpleTagMatcher('TAGA'),
                 paragraph_processor.SimpleTagMatcher('TAGB'),

--- a/tests/tree_xml_parser_paragraph_processor_tests.py
+++ b/tests/tree_xml_parser_paragraph_processor_tests.py
@@ -8,9 +8,7 @@ from regparser.tree.depth.derive import ParAssignment
 from regparser.tree.struct import Node
 from regparser.tree.xml_parser import paragraph_processor
 
-
 class _ExampleProcessor(paragraph_processor.ParagraphProcessor):
-    NODE_TYPE = 'EXAMPLE'
     MATCHERS = [paragraph_processor.SimpleTagMatcher('TAGA'),
                 paragraph_processor.SimpleTagMatcher('TAGB'),
                 paragraph_processor.StarsMatcher()]
@@ -47,7 +45,9 @@ class ParagraphProcessorTest(TestCase):
         self.assertEqual(result[1].text, 'Some other text')
 
     def test_parse_nodes_node_type(self):
-        """All created nodes should have the specified type"""
+        """ All created nodes should have the default type, regtext, except for
+        specific elements. The NODE_TYPE of the processor object is no longer
+        used. """
         xml = u"""
             <ROOT>
                 <TAGA>Some content</TAGA>
@@ -55,7 +55,7 @@ class ParagraphProcessorTest(TestCase):
             </ROOT>
         """
         result = _ExampleProcessor().parse_nodes(etree.fromstring(xml))
-        self.assertEqual([n.node_type for n in result], ['EXAMPLE', 'EXAMPLE'])
+        self.assertEqual([n.node_type for n in result], ['regtext', 'regtext'])
 
     def test_build_hierarchy(self):
         """Nodes should be returned at the provided depths"""


### PR DESCRIPTION
Addresses #103.

`ParagraphProcessor` instances no longer override the `node_type` of nodes they return with their own `node_type`; instead, the various Matcher objects should set `node_type` in cases where the default of `regtext` needs to be overridden.

This approach overloads `node_type`; previously it only applied at an outer level, expressing that the node was regulation text, or an appendix, etc. It is now also used to express the types of child nodes, in this case that some elements are extracts.

Because the children of the EXTRACT element need to be processed as if they were outside that element, the various Matcher objects’ `derive_nodes` methods need to accept a `processor` argument to give those objects access to the processor's `parse_nodes` method.