### PR TITLE
Citations for alphanumeric sections

### DIFF
--- a/regparser/grammar/atomic.py
+++ b/regparser/grammar/atomic.py
@@ -58,7 +58,7 @@ digit_a = "." + Word(string.digits).setResultsName('a3').leaveWhitespace()
 
 part = Word(string.digits).setResultsName("part")
 
-section = Word(string.digits).setResultsName("section")
+section = Regex(r"[0-9]+[a-z]*").setResultsName("section")
 
 appendix = Regex(r"[A-Z]+[0-9]*\b").setResultsName("appendix")
 appendix_digit = Word(string.digits).setResultsName("appendix_digit")

--- a/tests/grammar_atomic_tests.py
+++ b/tests/grammar_atomic_tests.py
@@ -19,3 +19,10 @@ class GrammarAtomicTests(TestCase):
         for text in ['(ii)', '(iv)', '(vi)']:
             with self.assertRaises(ParseException):
                 atomic.lower_p.parseString(text)
+
+    def test_section(self):
+        result = atomic.section.parseString('345a')
+        self.assertEqual('345a', result.section)
+
+        result = atomic.section.parseString('9873')
+        self.assertEqual('9873', result.section)


### PR DESCRIPTION
Fixes https://github.com/18F/atf-eregs/issues/59

Expands what an atomic section identifier is to include such cases as 479.32a.