### PR TITLE
Footnote data 

### DIFF
--- a/regparser/layer/formatting.py
+++ b/regparser/layer/formatting.py
@@ -223,7 +223,7 @@ class Footnotes(PlaintextFormatData):
     def match_data(self, match):
         # Un-escape parens
         note = match.group('note').replace(r'\(', '(').replace(r'\)', ')')
-        return {'footnote': {'ref': match.group('ref'), 'note': note}}
+        return {'footnote_data': {'ref': match.group('ref'), 'note': note}}
 
 
 class Formatting(Layer):

--- a/tests/layer_formatting_tests.py
+++ b/tests/layer_formatting_tests.py
@@ -285,8 +285,8 @@ class FootnotesTests(TestCase):
         self.assertEqual(result, [{
             'text': text[len("Something like"):-len(" this")],
             'locations': [0],
-            'footnote': {'ref': '1',
-                         'note': "where 'like' is not defined"}}])
+            'footnote_data': {'ref': '1',
+                              'note': "where 'like' is not defined"}}])
 
     def test_process_has_escape(self):
         text = r"Parens[^parens](they look like \(\))"
@@ -294,5 +294,5 @@ class FootnotesTests(TestCase):
         self.assertEqual(result, [{
             'text': text[len("Parens"):],
             'locations': [0],
-            'footnote': {'ref': 'parens',
-                         'note': "they look like ()"}}])
+            'footnote_data': {'ref': 'parens',
+                              'note': "they look like ()"}}])

--- a/tests/layer_formatting_tests.py
+++ b/tests/layer_formatting_tests.py
@@ -276,3 +276,23 @@ class DashesTests(TestCase):
         self.assertEqual(result['locations'], [0])
         self.assertEqual(result['dash_data'],
                          {'text': 'This is an fp-dash'})
+
+
+class FootnotesTests(TestCase):
+    def test_process_simple(self):
+        text = "Something like[^1](where 'like' is not defined) this"
+        result = list(formatting.Footnotes().process(text))
+        self.assertEqual(result, [{
+            'text': text[len("Something like"):-len(" this")],
+            'locations': [0],
+            'footnote': {'ref': '1',
+                         'note': "where 'like' is not defined"}}])
+
+    def test_process_has_escape(self):
+        text = r"Parens[^parens](they look like \(\))"
+        result = list(formatting.Footnotes().process(text))
+        self.assertEqual(result, [{
+            'text': text[len("Parens"):],
+            'locations': [0],
+            'footnote': {'ref': 'parens',
+                         'note': "they look like ()"}}])

--- a/tests/layer_formatting_tests.py
+++ b/tests/layer_formatting_tests.py
@@ -241,18 +241,22 @@ class LayerFormattingTests(XMLBuilderMixin, TestCase):
                  barr_header, unbr_header, barr_header, unbr_header]
             ])
 
-    def test_process_fenced(self):
-        node = Node("Content content\n```abc def\nLine 1\nLine 2\n```")
-        result = formatting.Formatting(None).process(node)
+
+class FencedTests(TestCase):
+    def test_process(self):
+        text = "Content content\n```abc def\nLine 1\nLine 2\n```"
+        result = list(formatting.FencedData().process(text))
         self.assertEqual(1, len(result))
         result = result[0]
-        self.assertEqual(result['text'], node.text[16:])
+        self.assertEqual(result['text'], text[16:])
         self.assertEqual(result['fence_data'],
                          {'type': 'abc def', 'lines': ['Line 1', 'Line 2']})
 
-    def test_process_subscript(self):
-        node = Node("This is a_{subscript}. And then a_{subscript} again")
-        result = formatting.Formatting(None).process(node)
+
+class SubscriptTests(TestCase):
+    def test_process(self):
+        text = "This is a_{subscript}. And then a_{subscript} again"
+        result = list(formatting.Subscript().process(text))
         self.assertEqual(1, len(result))
         result = result[0]
         self.assertEqual(result['text'], "a_{subscript}")
@@ -260,9 +264,11 @@ class LayerFormattingTests(XMLBuilderMixin, TestCase):
         self.assertEqual(result['subscript_data'],
                          {'variable': 'a', 'subscript': 'subscript'})
 
-    def test_process_dashes(self):
-        node = Node("This is an fp-dash_____")
-        result = formatting.Formatting(None).process(node)
+
+class DashesTests(TestCase):
+    def test_process(self):
+        text = "This is an fp-dash_____"
+        result = list(formatting.Dashes().process(text))
         self.assertEqual(1, len(result))
         result = result[0]
 

--- a/tests/tree_utils_tests.py
+++ b/tests/tree_utils_tests.py
@@ -98,6 +98,16 @@ class TreeUtilsTest(unittest.TestCase):
         self.assert_transform_equality(
             u'<P>(d) <E T="03">Text text</E>—more stuffs</P>',
             u'(d) Text text—more stuffs', *with_space)
+        self.assert_transform_equality(
+            '<P>F<E T="52">n</E> = F<E T="52">n-1</E> + '
+            'F<E T="52">n-2</E></P>',
+            'F_{n} = F_{n-1} + F_{n-2}', *no_space)
+        self.assert_transform_equality(
+            '<P>There was an error<SU footnote="but not mine!">5</SU></P>',
+            'There was an error[^5](but not mine!)', *no_space)
+        self.assert_transform_equality(
+            '<P>Note<SU footnote="(parens), see">note</SU> that</P>',
+            r'Note[^note](\(parens\), see) that', *no_space)
 
     def test_unwind_stack(self):
         level_one_n = Node(label=['272'])


### PR DESCRIPTION
Builds on #106 ([diff](https://github.com/cmc333333/regulations-parser/compare/cmc333333:55-footnote-preprocess...cmc333333:55-footnote-data)) for 18f/atf-eregs#55.

Now that the XML includes the exact footnote information we need in line, use that to generate markdown-style inline footnotes (e.g. `text[^1](some footnote)`). Modify the formatting layer to parse these.

Related cleanups/refactors:
* Move fenced, subscripts, dashes, and now footnote -processing into separate classes (rather than a single, ever expanding function)
* Made `get_node_text` more consistent with its space insertion. Previously, subscripts always had a following space. Similarly, pull out the logic to replace an XML tag into a single function to be reused by subscript and footnotes