### PR TITLE
A few code tweaks for parsing 27 CFR 478

### DIFF
--- a/regparser/commands/preprocess_notice.py
+++ b/regparser/commands/preprocess_notice.py
@@ -27,7 +27,7 @@ def preprocess_notice(document_number):
             effective_date = notice_xml.derive_effective_date()
             file_name = split_doc_num(document_number,
                                       effective_date.isoformat())
-        elif 'effective_on' in meta:
+        elif meta.get('effective_on'):
             notice_xml.effective = meta['effective_on']
         else:
             notice_xml.derive_effective_date()

--- a/regparser/tree/depth/derive.py
+++ b/regparser/tree/depth/derive.py
@@ -35,9 +35,12 @@ class Solution(object):
     def __iter__(self):
         return iter(self.assignment)
 
+    def pretty_str(self):
+        return "\n".join(" "*4*par.depth + par.typ[par.idx]
+                         for par in self.assignment)
+
     def pretty_print(self):
-        for par in self.assignment:
-            print " "*4*par.depth + par.typ[par.idx]
+        print self.pretty_str()
 
 
 def _compress_markerless(marker_list):
@@ -140,3 +143,19 @@ def derive_depths(original_markers, additional_constraints=[]):
         assignment = _decompress_markerless(assignment, original_markers)
         solutions.append(Solution(assignment))
     return solutions
+
+
+def debug_idx(markers, constraints=[]):
+    """Binary search through the markers to find the point at which
+    derive_depths no longer works"""
+    working, not_working = -1, len(markers)
+
+    while working != not_working - 1:
+        midpoint = (working + not_working) / 2
+        solutions = derive_depths(markers[:midpoint + 1], constraints)
+        if solutions:
+            working = midpoint
+        else:
+            not_working = midpoint
+
+    return not_working

--- a/regparser/tree/depth/rules.py
+++ b/regparser/tree/depth/rules.py
@@ -196,11 +196,12 @@ def depth_type_inverses(constrain, all_variables):
     """If paragraphs are at the same depth, they must share the same type. If
     paragraphs are the same type, they must share the same depth"""
     def inner(typ, idx, depth, *all_prev):
-        if typ == markers.stars:
+        if typ == markers.stars or typ == markers.markerless:
             return True
         for i in range(0, len(all_prev), 3):
             prev_typ, prev_idx, prev_depth = all_prev[i:i+3]
-            if prev_depth == depth and prev_typ not in (markers.stars, typ):
+            if prev_depth == depth and prev_typ not in (markers.stars, typ,
+                                                        markers.markerless):
                 return False
             if prev_typ == typ and prev_depth != depth:
                 return False

--- a/regparser/tree/xml_parser/extract_processor.py
+++ b/regparser/tree/xml_parser/extract_processor.py
@@ -12,7 +12,7 @@ class ExtractParagraphProcessor(paragraph_processor.ParagraphProcessor):
                 paragraph_processor.SimpleTagMatcher('P', 'FP')]
 
 
-class ExtractMatcher(object):
+class ExtractMatcher(paragraph_processor.BaseMatcher):
     def matches(self, xml):
         return xml.tag in ('EXTRACT',)
 

--- a/regparser/tree/xml_parser/extract_processor.py
+++ b/regparser/tree/xml_parser/extract_processor.py
@@ -1,0 +1,22 @@
+from regparser.tree.depth import markers as mtypes
+from regparser.tree.struct import Node
+from regparser.tree.xml_parser import paragraph_processor
+
+
+class ExtractParagraphProcessor(paragraph_processor.ParagraphProcessor):
+    """Paragraph Processor which does not try to derive paragraph markers"""
+    MATCHERS = [paragraph_processor.StarsMatcher(),
+                paragraph_processor.TableMatcher(),
+                paragraph_processor.FencedMatcher(),
+                paragraph_processor.HeaderMatcher(),
+                paragraph_processor.SimpleTagMatcher('P', 'FP')]
+
+
+class ExtractMatcher(object):
+    def matches(self, xml):
+        return xml.tag in ('EXTRACT',)
+
+    def derive_nodes(self, xml, processor=None):
+        extract_node = Node(text=(xml.text or '').strip(),
+                            node_type=u"extract", label=[mtypes.MARKERLESS])
+        return [ExtractParagraphProcessor().process(xml, extract_node)]

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -7,7 +7,7 @@ from regparser import content
 from regparser.tree.depth import markers as mtypes, rules
 from regparser.tree.struct import Node
 from regparser.tree.paragraph import p_level_of, p_levels
-from regparser.tree.xml_parser import paragraph_processor
+from regparser.tree.xml_parser import extract_processor, paragraph_processor
 from regparser.tree.xml_parser.appendices import build_non_reg_text
 from regparser.tree import reg_text
 from regparser.tree.xml_parser import tree_utils
@@ -289,11 +289,10 @@ class ParagraphMatcher(object):
 
 
 class RegtextParagraphProcessor(paragraph_processor.ParagraphProcessor):
-    NODE_TYPE = Node.REGTEXT
     MATCHERS = [paragraph_processor.StarsMatcher(),
                 paragraph_processor.TableMatcher(),
                 paragraph_processor.FencedMatcher(),
-                paragraph_processor.ExtractMatcher(),
+                extract_processor.ExtractMatcher(),
                 paragraph_processor.HeaderMatcher(),
                 ParagraphMatcher()]
 

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -255,7 +255,7 @@ def build_from_section(reg_part, section_xml):
     return section_nodes
 
 
-class ParagraphMatcher(object):
+class ParagraphMatcher(paragraph_processor.BaseMatcher):
     """<P>/<FP> with or without initial paragraph markers -- (a)(1)(i) etc."""
     def matches(self, xml):
         return xml.tag in ('P', 'FP')

--- a/tests/tree_depth_derive_tests.py
+++ b/tests/tree_depth_derive_tests.py
@@ -163,3 +163,10 @@ class DeriveTests(TestCase):
             ['1', STARS_TAG, 'c', '2', INLINE_STARS, 'i', STARS_TAG, 'iii'],
             [rules.depth_type_inverses],
             [0, 1, 1, 0, 1, 1, 2, 2])
+
+    def test_depth_type_inverses_markerless(self):
+        """Markerless paragraphs should not trigger an incompatibility"""
+        self.assert_depth_match_extra(
+            ['1', MARKERLESS, '2', 'a'],
+            [rules.depth_type_inverses],
+            [0, 1, 0, 1])

--- a/tests/tree_depth_derive_tests.py
+++ b/tests/tree_depth_derive_tests.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from regparser.tree.depth import markers, rules
-from regparser.tree.depth.derive import derive_depths
+from regparser.tree.depth.derive import debug_idx, derive_depths
 from regparser.tree.depth.markers import INLINE_STARS, MARKERLESS, STARS_TAG
 
 
@@ -170,3 +170,12 @@ class DeriveTests(TestCase):
             ['1', MARKERLESS, '2', 'a'],
             [rules.depth_type_inverses],
             [0, 1, 0, 1])
+
+    def test_debug_idx(self):
+        """Find the index of the first error when attempting to derive
+        depths"""
+        self.assertEqual(debug_idx(['1', '2', '3']), 3)
+        self.assertEqual(debug_idx(['1', '4']), 1)
+        self.assertEqual(debug_idx(['1', '2', '4']), 2)
+        self.assertEqual(
+            debug_idx(['1', 'a', '2', 'A'], [rules.depth_type_inverses]), 3)

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -341,6 +341,7 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
             with root.EXTRACT() as extract:
                 extract.P("1. Some content")
                 extract.P("2. Other content")
+                extract.P("(3) This paragraph has parens for some reason")
         nodes = reg_text.build_from_section('8675', self.tree.render_xml())
 
         root_node = nodes[0]
@@ -357,17 +358,20 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
 
         extract_node = outer_p_node.children[0]
         self.assertEqual(['8675', '309', 'a', 'p1'], extract_node.label)
-        self.assertEqual(2, len(extract_node.children))
+        self.assertEqual(3, len(extract_node.children))
         self.assertEqual('', extract_node.text)
         self.assertEqual("extract", extract_node.node_type)
 
-        first_p_node, second_p_node = extract_node.children
+        first_p_node, second_p_node, third_p_node = extract_node.children
         self.assertEqual(['8675', '309', 'a', 'p1', 'p1'], first_p_node.label)
         self.assertEqual(['8675', '309', 'a', 'p1', 'p2'], second_p_node.label)
+        self.assertEqual(['8675', '309', 'a', 'p1', 'p3'], third_p_node.label)
         self.assertEqual("regtext", first_p_node.node_type,
                          second_p_node.node_type)
         self.assertEqual('1. Some content', first_p_node.text)
         self.assertEqual('2. Other content', second_p_node.text)
+        self.assertEqual('(3) This paragraph has parens for some reason',
+                         third_p_node.text)
 
     def test_build_from_section_notes(self):
         """Account for paragraphs within a NOTES tag"""


### PR DESCRIPTION
For 18f/atf-eregs#78

Problems this fixes:
* The FR API would return an effective date of `None`; we were assuming that the presence of the key indicated the presence of a date
* We didn't have an exception for `MARKERLESS` paragraphs when asserting that paragraphs at the same depth should have the same marker type
* We were reusing the `RegtextParagraphProcessor` inside `EXTRACT`s, which caused problems as the contents of `EXTRACT`s do not have the structure assumed in Regtext. Resolved by creating a more generic `ExtractParagraphProcessor`

Other improvements/refactors:
* Add more direct debugging info when deriving depth fails. This will actually point out "here's your problem marker"
* Make sure all xml matchers derive from an abstract base class which defines their interface
* Modifies `SimpleTagMatcher` to allow multiple xml tags to be matched