### PR TITLE
Synchronization of modified XML

### DIFF
--- a/eregs.py
+++ b/eregs.py
@@ -5,8 +5,9 @@ import pkgutil
 import click
 import requests_cache   # @todo - replace with cache control
 
-from regparser import commands, eregs_index
+from regparser import commands
 from regparser.commands.dependency_resolver import DependencyResolver
+from regparser.index import dependency
 
 
 @click.group()
@@ -30,7 +31,7 @@ def main(prev_dependency=None):
     to the dependency changing"""
     try:
         cli()
-    except eregs_index.DependencyException, e:
+    except dependency.Missing, e:
         resolvers = [resolver(e.dependency)
                      for resolver in DependencyResolver.__subclasses__()]
         resolvers = [r for r in resolvers if r.has_resolution()]

--- a/regparser/commands/annual_editions.py
+++ b/regparser/commands/annual_editions.py
@@ -3,8 +3,8 @@ from datetime import date
 
 import click
 
-from regparser import eregs_index
 from regparser.history import annual
+from regparser.index import dependency, entry
 from regparser.tree import xml_parser
 
 
@@ -15,7 +15,7 @@ def last_versions(cfr_title, cfr_part):
     """Run through all known versions of this regulation and pull out versions
     which are the last to be included before an annual edition"""
     have_annual_edition = {}
-    path = eregs_index.VersionEntry(cfr_title, cfr_part)
+    path = entry.Version(cfr_title, cfr_part)
     if len(path) == 0:
         raise click.UsageError("No versions found. Run `versions`?")
     for version_id in path:
@@ -30,10 +30,10 @@ def last_versions(cfr_title, cfr_part):
 def process_if_needed(cfr_title, cfr_part, last_versions):
     """Calculate dependencies between input and output files for these annual
     editions. If an output is missing or out of date, process it"""
-    annual_path = eregs_index.AnnualEntry(cfr_title, cfr_part)
-    tree_path = eregs_index.TreeEntry(cfr_title, cfr_part)
-    version_path = eregs_index.VersionEntry(cfr_title, cfr_part)
-    deps = eregs_index.DependencyGraph()
+    annual_path = entry.Annual(cfr_title, cfr_part)
+    tree_path = entry.Tree(cfr_title, cfr_part)
+    version_path = entry.Version(cfr_title, cfr_part)
+    deps = dependency.Graph()
 
     for last_version in last_versions:
         deps.add(tree_path / last_version.version_id,

--- a/regparser/commands/clear.py
+++ b/regparser/commands/clear.py
@@ -3,7 +3,7 @@ import shutil
 
 import click
 
-from regparser import eregs_index
+from regparser.index import entry
 
 
 SQLITE_CACHE = 'fr_cache.sqlite'
@@ -24,7 +24,7 @@ def clear(path, http_cache):
     """
     if not path:
         path = ['']
-    paths = [os.path.join(eregs_index.ROOT, p) for p in path]
+    paths = [os.path.join(entry.ROOT, p) for p in path]
     for path in paths:
         if os.path.exists(path):
             shutil.rmtree(path)

--- a/regparser/commands/diffs.py
+++ b/regparser/commands/diffs.py
@@ -1,7 +1,7 @@
 import click
 
-from regparser import eregs_index
 from regparser.diff.tree import changes_between
+from regparser.index import dependency, entry
 
 
 @click.command()
@@ -9,22 +9,22 @@ from regparser.diff.tree import changes_between
 @click.argument('cfr_part', type=int)
 def diffs(cfr_title, cfr_part):
     """Construct diffs between known trees."""
-    tree_dir = eregs_index.FrozenTreeEntry(cfr_title, cfr_part)
-    diff_dir = eregs_index.DiffEntry(cfr_title, cfr_part)
+    tree_dir = entry.FrozenTree(cfr_title, cfr_part)
+    diff_dir = entry.Diff(cfr_title, cfr_part)
     pairs = [(lhs, rhs) for lhs in tree_dir for rhs in tree_dir]
-    deps = eregs_index.DependencyGraph()
+    deps = dependency.Graph()
     for lhs_id, rhs_id in pairs:
         deps.add(diff_dir / lhs_id / rhs_id, tree_dir / lhs_id)
         deps.add(diff_dir / lhs_id / rhs_id, tree_dir / rhs_id)
 
     trees = {}
     for lhs_id, rhs_id in pairs:
-        entry = diff_dir / lhs_id / rhs_id
-        deps.validate_for(entry)
-        if deps.is_stale(entry):
+        path = diff_dir / lhs_id / rhs_id
+        deps.validate_for(path)
+        if deps.is_stale(path):
             if lhs_id not in trees:
                 trees[lhs_id] = (tree_dir / lhs_id).read()
             if rhs_id not in trees:
                 trees[rhs_id] = (tree_dir / rhs_id).read()
 
-            entry.write(dict(changes_between(trees[lhs_id], trees[rhs_id])))
+            path.write(dict(changes_between(trees[lhs_id], trees[rhs_id])))

--- a/regparser/commands/fetch_annual_edition.py
+++ b/regparser/commands/fetch_annual_edition.py
@@ -1,8 +1,8 @@
 import click
 
-from regparser import eregs_index
 from regparser.commands.dependency_resolver import DependencyResolver
 from regparser.history import annual
+from regparser.index import entry
 from regparser.notice import preprocessors
 
 
@@ -16,11 +16,11 @@ def fetch_annual_edition(cfr_title, cfr_part, year):
     xml = volume.find_part_xml(cfr_part)
     for preprocessor in preprocessors.ALL:
         preprocessor().transform(xml)
-    eregs_index.AnnualEntry(cfr_title, cfr_part, year).write(xml)
+    entry.Annual(cfr_title, cfr_part, year).write(xml)
 
 
 class AnnualEditionResolver(DependencyResolver):
-    PATH_PARTS = eregs_index.AnnualEntry.PREFIX + (
+    PATH_PARTS = entry.Annual.PREFIX + (
         '(?P<cfr_title>\d+)',
         '(?P<cfr_part>\d+)',
         '(?P<year>\d{4})')

--- a/regparser/commands/fetch_sxs.py
+++ b/regparser/commands/fetch_sxs.py
@@ -3,9 +3,9 @@
 # SxS are split, the two programs will diverge
 import click
 
-from regparser import eregs_index
 from regparser.commands.dependency_resolver import DependencyResolver
 from regparser.federalregister import meta_data, FULL_NOTICE_FIELDS
+from regparser.index import dependency, entry
 from regparser.notice.build import build_notice
 
 
@@ -16,10 +16,10 @@ def fetch_sxs(document_number):
 
     DOCUMENT_NUMBER is the identifier associated with a final rule. If a rule
     has been split, use the split identifiers, a.k.a. version ids"""
-    sxs_entry = eregs_index.SxSEntry(document_number)
-    notice_entry = eregs_index.NoticeEntry(document_number)
+    sxs_entry = entry.SxS(document_number)
+    notice_entry = entry.Notice(document_number)
 
-    deps = eregs_index.DependencyGraph()
+    deps = dependency.Graph()
     deps.add(sxs_entry, notice_entry)
 
     deps.validate_for(sxs_entry)
@@ -36,7 +36,7 @@ def fetch_sxs(document_number):
 
 
 class RuleChangesResolver(DependencyResolver):
-    PATH_PARTS = eregs_index.SxSEntry.PREFIX + (
+    PATH_PARTS = entry.SxS.PREFIX + (
         '(?P<doc_number>[a-zA-Z0-9-_]+)',)
 
     def resolution(self):

--- a/regparser/commands/layers.py
+++ b/regparser/commands/layers.py
@@ -50,8 +50,7 @@ def stale_layers(deps, layer_dir):
 def process_layers(stale, cfr_title, cfr_part, version, act_citation):
     """Build all of the stale layers for this version, writing them into the
     index. Assumes all dependencies have already been checked"""
-    tree = entry.Tree(
-        cfr_title, cfr_part, version.identifier).read()
+    tree = entry.Tree(cfr_title, cfr_part, version.identifier).read()
     version_dir = entry.Version(cfr_title, cfr_part)
     layer_dir = entry.Layer(cfr_title, cfr_part)
     for layer_name in stale:

--- a/regparser/commands/layers.py
+++ b/regparser/commands/layers.py
@@ -1,13 +1,13 @@
 import click
 
-from regparser import eregs_index
+from regparser.index import dependency, entry
 from regparser.layer import ALL_LAYERS
 
 
 def dependencies(tree_dir, layer_dir, version_dir):
     """Modify and return the dependency graph pertaining to layers"""
-    deps = eregs_index.DependencyGraph()
-    sxs_dir = eregs_index.SxSEntry()
+    deps = dependency.Graph()
+    sxs_dir = entry.SxS()
     for version_id in tree_dir:
         for layer_name in ALL_LAYERS:
             # Layers depend on their associated tree
@@ -25,7 +25,7 @@ def sxs_source_names(version_dir, stop_version):
     """The SxS layer relies on all of notices that came before a particular
     version"""
     for version_id in version_dir:
-        if version_id in eregs_index.NoticeEntry():
+        if version_id in entry.Notice():
             yield version_id
         if version_id == stop_version:
             break
@@ -33,7 +33,7 @@ def sxs_source_names(version_dir, stop_version):
 
 def sxs_sources(version_dir, version_id):
     """Wrapper reading JSON for the sxs_source_names"""
-    return [(eregs_index.SxSEntry() / doc_num).read()
+    return [(entry.SxS() / doc_num).read()
             for doc_num in sxs_source_names(version_dir, version_id)]
 
 
@@ -50,10 +50,10 @@ def stale_layers(deps, layer_dir):
 def process_layers(stale, cfr_title, cfr_part, version, act_citation):
     """Build all of the stale layers for this version, writing them into the
     index. Assumes all dependencies have already been checked"""
-    tree = eregs_index.TreeEntry(
+    tree = entry.Tree(
         cfr_title, cfr_part, version.identifier).read()
-    version_dir = eregs_index.VersionEntry(cfr_title, cfr_part)
-    layer_dir = eregs_index.LayerEntry(cfr_title, cfr_part)
+    version_dir = entry.Version(cfr_title, cfr_part)
+    layer_dir = entry.Layer(cfr_title, cfr_part)
     for layer_name in stale:
         notices = []
         if layer_name == 'analyses':
@@ -76,9 +76,9 @@ def process_layers(stale, cfr_title, cfr_part, version, act_citation):
 # @todo - allow layers to be passed as a parameter
 def layers(cfr_title, cfr_part, act_title, act_section):
     """Build all layers for all known versions."""
-    tree_dir = eregs_index.TreeEntry(cfr_title, cfr_part)
-    layer_dir = eregs_index.LayerEntry(cfr_title, cfr_part)
-    version_dir = eregs_index.VersionEntry(cfr_title, cfr_part)
+    tree_dir = entry.Tree(cfr_title, cfr_part)
+    layer_dir = entry.Layer(cfr_title, cfr_part)
+    version_dir = entry.Version(cfr_title, cfr_part)
     deps = dependencies(tree_dir, layer_dir, version_dir)
 
     for version_id in tree_dir:

--- a/regparser/commands/parse_rule_changes.py
+++ b/regparser/commands/parse_rule_changes.py
@@ -1,7 +1,7 @@
 import click
 
-from regparser import eregs_index
 from regparser.commands.dependency_resolver import DependencyResolver
+from regparser.index import dependency, entry
 from regparser.notice.build import process_amendments
 
 
@@ -12,10 +12,10 @@ def parse_rule_changes(document_number):
 
     DOCUMENT_NUMBER is the identifier associated with a final rule. If a rule
     has been split, use the split identifiers, a.k.a. version ids."""
-    rule_entry = eregs_index.RuleChangesEntry(document_number)
-    notice_entry = eregs_index.NoticeEntry(document_number)
+    rule_entry = entry.RuleChanges(document_number)
+    notice_entry = entry.Notice(document_number)
 
-    deps = eregs_index.DependencyGraph()
+    deps = dependency.Graph()
     deps.add(rule_entry, notice_entry)
 
     deps.validate_for(rule_entry)
@@ -29,7 +29,7 @@ def parse_rule_changes(document_number):
 
 
 class RuleChangesResolver(DependencyResolver):
-    PATH_PARTS = eregs_index.RuleChangesEntry.PREFIX + (
+    PATH_PARTS = entry.RuleChanges.PREFIX + (
         '(?P<doc_number>[a-zA-Z0-9-_]+)',)
 
     def resolution(self):

--- a/regparser/commands/pipeline.py
+++ b/regparser/commands/pipeline.py
@@ -6,6 +6,7 @@ from regparser.commands.fill_with_rules import fill_with_rules
 from regparser.commands.layers import layers
 from regparser.commands.diffs import diffs
 from regparser.commands.write_to import write_to
+from regparser.commands.sync_xml import sync_xml
 
 
 @click.command()
@@ -25,6 +26,7 @@ def pipeline(ctx, cfr_title, cfr_part, output):
     * a directory prefixed with "git://". This will export to a git
       repository"""
     params = {'cfr_title': cfr_title, 'cfr_part': cfr_part}
+    ctx.invoke(sync_xml)
     ctx.invoke(versions, **params)
     ctx.invoke(annual_editions, **params)
     ctx.invoke(fill_with_rules, **params)

--- a/regparser/commands/preprocess_notice.py
+++ b/regparser/commands/preprocess_notice.py
@@ -40,7 +40,6 @@ def preprocess_notice(document_number):
         notice_entry.write(notice_xml)
         if notice_xml.source_is_local:
             deps.add(str(notice_entry), notice_xml.source)
-        entry.Notice(file_name).write(notice_xml)
 
 
 class NoticeResolver(DependencyResolver):

--- a/regparser/commands/preprocess_notice.py
+++ b/regparser/commands/preprocess_notice.py
@@ -2,7 +2,7 @@ import click
 
 from regparser import federalregister
 from regparser.commands.dependency_resolver import DependencyResolver
-from regparser.index import entry
+from regparser.index import dependency, entry
 from regparser.notice.build import split_doc_num
 from regparser.notice.xml import notice_xmls_for_url
 
@@ -17,8 +17,9 @@ def preprocess_notice(document_number):
     meta = federalregister.meta_data(
         document_number,
         ["effective_on", "full_text_xml_url", "publication_date", "volume"])
-    notice_xmls = notice_xmls_for_url(document_number,
-                                      meta['full_text_xml_url'])
+    notice_xmls = list(notice_xmls_for_url(document_number,
+                                           meta['full_text_xml_url']))
+    deps = dependency.Graph()
     for notice_xml in notice_xmls:
         file_name = document_number
         notice_xml.published = meta['publication_date']
@@ -34,6 +35,11 @@ def preprocess_notice(document_number):
             notice_xml.derive_effective_date()
 
         notice_xml.version_id = file_name
+
+        notice_entry = entry.Notice(file_name)
+        notice_entry.write(notice_xml)
+        if notice_xml.source_is_local:
+            deps.add(str(notice_entry), notice_xml.source)
         entry.Notice(file_name).write(notice_xml)
 
 

--- a/regparser/commands/preprocess_notice.py
+++ b/regparser/commands/preprocess_notice.py
@@ -1,7 +1,8 @@
 import click
 
-from regparser import eregs_index, federalregister
+from regparser import federalregister
 from regparser.commands.dependency_resolver import DependencyResolver
+from regparser.index import entry
 from regparser.notice.build import split_doc_num
 from regparser.notice.xml import notice_xmls_for_url
 
@@ -33,11 +34,11 @@ def preprocess_notice(document_number):
             notice_xml.derive_effective_date()
 
         notice_xml.version_id = file_name
-        eregs_index.NoticeEntry(file_name).write(notice_xml)
+        entry.Notice(file_name).write(notice_xml)
 
 
 class NoticeResolver(DependencyResolver):
-    PATH_PARTS = eregs_index.NoticeEntry.PREFIX + (
+    PATH_PARTS = entry.Notice.PREFIX + (
         '(?P<doc_number>[a-zA-Z0-9-_]+)',)
 
     def resolution(self):

--- a/regparser/commands/sync_xml.py
+++ b/regparser/commands/sync_xml.py
@@ -1,0 +1,11 @@
+import click
+
+from regparser.index.xml_sync import sync
+
+
+@click.command()
+def sync_xml():
+    """Synchronize modified XML. Checkout/pull down the latest modified XML
+    files. If one has been modified, it will notify later steps that they need
+    to be rebuilt"""
+    sync()

--- a/regparser/commands/versions.py
+++ b/regparser/commands/versions.py
@@ -3,9 +3,9 @@ import re
 
 import click
 
-from regparser import eregs_index
 from regparser.federalregister import fetch_notice_json
 from regparser.history.versions import Version
+from regparser.index import dependency, entry
 
 
 def fetch_version_ids(cfr_title, cfr_part, notice_dir):
@@ -44,8 +44,8 @@ def delays(xmls):
 def generate_dependencies(version_dir, version_ids, delays):
     """Creates a dependency graph and adds all dependencies for input xml and
     delays between notices"""
-    notice_dir = eregs_index.NoticeEntry()
-    deps = eregs_index.DependencyGraph()
+    notice_dir = entry.Notice()
+    deps = dependency.Graph()
     for version_id in version_ids:
         deps.add(version_dir / version_id, notice_dir / version_id)
     for delayed, delay in delays.iteritems():
@@ -65,7 +65,7 @@ def write_if_needed(cfr_title, cfr_part, version_ids, xmls, delays):
     """All versions which are stale (either because they were never create or
     because their dependency has been updated) are written to disk. If any
     dependency is missing, an exception is raised"""
-    version_dir = eregs_index.VersionEntry(cfr_title, cfr_part)
+    version_dir = entry.Version(cfr_title, cfr_part)
     deps = generate_dependencies(version_dir, version_ids, delays)
     for version_id in version_ids:
         version_entry = version_dir / version_id
@@ -83,7 +83,7 @@ def versions(cfr_title, cfr_part):
     notice XML and rules modifying the effective date of versions of a
     regulation"""
     cfr_title, cfr_part = str(cfr_title), str(cfr_part)
-    notice_dir = eregs_index.NoticeEntry()
+    notice_dir = entry.Notice()
 
     version_ids = fetch_version_ids(cfr_title, cfr_part, notice_dir)
     xmls = {version_id: (notice_dir / version_id).read()

--- a/regparser/commands/write_to.py
+++ b/regparser/commands/write_to.py
@@ -1,15 +1,15 @@
 import click
 
-from regparser import eregs_index
 from regparser.api_writer import Client
+from regparser.index import entry
 
 
 # The write process is split into a set of functions, each responsible for
 # writing a particular type of entity
 
 def write_trees(client, cfr_title, cfr_part):
-    tree_dir = eregs_index.TreeEntry(cfr_title, cfr_part)
-    for version_id in eregs_index.VersionEntry(cfr_title, cfr_part):
+    tree_dir = entry.Tree(cfr_title, cfr_part)
+    for version_id in entry.Version(cfr_title, cfr_part):
         if version_id in tree_dir:
             click.echo("Writing tree " + version_id)
             tree = (tree_dir / version_id).read()
@@ -17,8 +17,8 @@ def write_trees(client, cfr_title, cfr_part):
 
 
 def write_layers(client, cfr_title, cfr_part):
-    for version_id in eregs_index.VersionEntry(cfr_title, cfr_part):
-        layer_dir = eregs_index.LayerEntry(cfr_title, cfr_part, version_id)
+    for version_id in entry.Version(cfr_title, cfr_part):
+        layer_dir = entry.Layer(cfr_title, cfr_part, version_id)
         for layer_name in layer_dir:
             click.echo("Writing layer {}@{}".format(layer_name, version_id))
             layer = (layer_dir / layer_name).read()
@@ -26,8 +26,8 @@ def write_layers(client, cfr_title, cfr_part):
 
 
 def write_notices(client, cfr_title, cfr_part):
-    sxs_dir = eregs_index.SxSEntry()
-    for version_id in eregs_index.VersionEntry(cfr_title, cfr_part):
+    sxs_dir = entry.SxS()
+    for version_id in entry.Version(cfr_title, cfr_part):
         if version_id in sxs_dir:
             click.echo("Writing notice " + version_id)
             tree = (sxs_dir / version_id).read()
@@ -35,8 +35,8 @@ def write_notices(client, cfr_title, cfr_part):
 
 
 def write_diffs(client, cfr_title, cfr_part):
-    diff_dir = eregs_index.DiffEntry(cfr_title, cfr_part)
-    version_ids = list(eregs_index.VersionEntry(cfr_title, cfr_part))
+    diff_dir = entry.Diff(cfr_title, cfr_part)
+    version_ids = list(entry.Version(cfr_title, cfr_part))
     for lhs_id in version_ids:
         container = diff_dir / lhs_id
         for rhs_id in version_ids:

--- a/regparser/index/__init__.py
+++ b/regparser/index/__init__.py
@@ -1,0 +1,1 @@
+ROOT = '.eregs_index'

--- a/regparser/index/dependency.py
+++ b/regparser/index/dependency.py
@@ -1,0 +1,74 @@
+from contextlib import contextmanager
+import os
+import shelve
+
+from dagger import dagger
+
+from . import ROOT
+
+
+class Missing(Exception):
+    def __init__(self, key, dependency):
+        super(Missing, self).__init__(
+            "Missing dependency. {} is needed for {}".format(
+                dependency, key))
+        self.dependency = dependency
+        self.key = key
+
+
+class Graph(object):
+    """Track dependencies between input and output files, storing them in
+    `dependencies.db` for later retrieval. This lets us know that an output
+    with dependencies needs to be updated if those dependencies have been
+    updated"""
+    DB_FILE = os.path.join(ROOT, "dependencies.db")
+
+    def __init__(self):
+        if not os.path.exists(ROOT):
+            os.makedirs(ROOT)
+        self.dag = dagger()
+        self._ran = False
+
+        with self.dependency_db() as db:
+            for key, dependencies in db.items():
+                self.dag.add(key, dependencies)
+
+    @contextmanager
+    def dependency_db(self):
+        """Python 2 doesn't have a context manager for shelve.open, so we've
+        created one"""
+        db = shelve.open(self.DB_FILE)
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def add(self, output_entry, input_entry):
+        """Add a dependency where output tuple relies on input_tuple"""
+        self._ran = False
+        from_str, to_str = str(output_entry), str(input_entry)
+
+        self.dag.add(from_str, [to_str])
+        with self.dependency_db() as db:
+            deps = db.get(from_str, set())
+            deps.add(to_str)
+            db[from_str] = deps
+
+    def _run_if_needed(self):
+        if not self._ran:
+            self.dag.run()
+            self._ran = True
+
+    def validate_for(self, entry):
+        """Raise an exception if a particular output has stale dependencies"""
+        self._run_if_needed()
+        key = str(entry)
+        with self.dependency_db() as db:
+            for dependency in db[key]:
+                if self.dag.get(dependency).stale:
+                    raise Missing(key, dependency)
+
+    def is_stale(self, entry):
+        """Determine if a file needs to be rebuilt"""
+        self._run_if_needed()
+        return bool(self.dag.get(str(entry)).stale)

--- a/regparser/index/entry.py
+++ b/regparser/index/entry.py
@@ -1,22 +1,15 @@
-"""The eregs_index directory contains the output for many of the shell
-commands. This module provides a quick interface to this index"""
-from contextlib import contextmanager
 import json
 import logging
 import os
-import shelve
 
-from dagger import dagger
 from lxml import etree
 
-from regparser.history.versions import Version
+from regparser.history.versions import Version as VersionStruct
 from regparser.notice.encoder import AmendmentEncoder
 from regparser.notice.xml import NoticeXML
 from regparser.tree.struct import (
     frozen_node_decode_hook, full_node_decode_hook, FullNodeEncoder)
-
-
-ROOT = ".eregs_index"
+from . import ROOT
 
 
 class Entry(object):
@@ -72,7 +65,7 @@ class Entry(object):
         return len(list(self.__iter__()))
 
 
-class NoticeEntry(Entry):
+class Notice(Entry):
     """Processes NoticeXMLs, keyed by notice_xml"""
     PREFIX = (ROOT, 'notice_xml')
 
@@ -83,7 +76,7 @@ class NoticeEntry(Entry):
         return NoticeXML(etree.fromstring(content))
 
 
-class AnnualEntry(Entry):
+class Annual(Entry):
     """Processes XML, keyed by annual"""
     PREFIX = (ROOT, 'annual')
 
@@ -94,7 +87,7 @@ class AnnualEntry(Entry):
         return etree.fromstring(content)
 
 
-class VersionEntry(Entry):
+class Version(Entry):
     """Processes Versions, keyed by version"""
     PREFIX = (ROOT, 'version')
 
@@ -102,12 +95,12 @@ class VersionEntry(Entry):
         return content.json()
 
     def deserialize(self, content):
-        return Version.from_json(content)
+        return VersionStruct.from_json(content)
 
     def __iter__(self):
         """Deserialize all Version objects we're aware of."""
         versions = [(self / path).read()
-                    for path in super(VersionEntry, self).__iter__()]
+                    for path in super(Version, self).__iter__()]
         key = lambda version: (version.effective, version.published)
         for version in sorted(versions, key=key):
             yield version.identifier
@@ -126,102 +119,35 @@ class _JSONEntry(Entry):
         return json.loads(content, object_hook=self.JSON_DECODER)
 
 
-class TreeEntry(_JSONEntry):
+class Tree(_JSONEntry):
     """Processes Nodes, keyed by tree"""
     PREFIX = (ROOT, 'tree')
     JSON_ENCODER = FullNodeEncoder
     JSON_DECODER = staticmethod(full_node_decode_hook)
 
 
-class FrozenTreeEntry(TreeEntry):
-    """Like TreeEntry, but decodes as FrozenNodes"""
+class FrozenTree(Tree):
+    """Like Tree, but decodes as FrozenNodes"""
     JSON_DECODER = staticmethod(frozen_node_decode_hook)
 
 
-class RuleChangesEntry(_JSONEntry):
+class RuleChanges(_JSONEntry):
     """Processes notices, keyed by rule_changes"""
     PREFIX = (ROOT, 'rule_changes')
     JSON_ENCODER = AmendmentEncoder
 
 
-class SxSEntry(_JSONEntry):
+class SxS(_JSONEntry):
     """Processes Section-by-Section analyses, keyed by sxs"""
     PREFIX = (ROOT, 'sxs')
     JSON_ENCODER = AmendmentEncoder
 
 
-class LayerEntry(_JSONEntry):
+class Layer(_JSONEntry):
     """Processes layers, keyed by layer"""
     PREFIX = (ROOT, 'layer')
 
 
-class DiffEntry(_JSONEntry):
+class Diff(_JSONEntry):
     """Processes diffs, keyed by diff"""
     PREFIX = (ROOT, 'diff')
-
-
-class DependencyException(Exception):
-    def __init__(self, key, dependency):
-        super(DependencyException, self).__init__(
-            "Missing dependency. {} is needed for {}".format(
-                dependency, key))
-        self.dependency = dependency
-        self.key = key
-
-
-class DependencyGraph(object):
-    """Track dependencies between input and output files, storing them in
-    `dependencies.db` for later retrieval. This lets us know that an output
-    with dependencies needs to be updated if those dependencies have been
-    updated"""
-    DB_FILE = os.path.join(ROOT, "dependencies.db")
-
-    def __init__(self):
-        if not os.path.exists(ROOT):
-            os.makedirs(ROOT)
-        self.dag = dagger()
-        self._ran = False
-
-        with self.dependency_db() as db:
-            for key, dependencies in db.items():
-                self.dag.add(key, dependencies)
-
-    @contextmanager
-    def dependency_db(self):
-        """Python 2 doesn't have a context manager for shelve.open, so we've
-        created one"""
-        db = shelve.open(self.DB_FILE)
-        try:
-            yield db
-        finally:
-            db.close()
-
-    def add(self, output_entry, input_entry):
-        """Add a dependency where output tuple relies on input_tuple"""
-        self._ran = False
-        from_str, to_str = str(output_entry), str(input_entry)
-
-        self.dag.add(from_str, [to_str])
-        with self.dependency_db() as db:
-            deps = db.get(from_str, set())
-            deps.add(to_str)
-            db[from_str] = deps
-
-    def _run_if_needed(self):
-        if not self._ran:
-            self.dag.run()
-            self._ran = True
-
-    def validate_for(self, entry):
-        """Raise an exception if a particular output has stale dependencies"""
-        self._run_if_needed()
-        key = str(entry)
-        with self.dependency_db() as db:
-            for dependency in db[key]:
-                if self.dag.get(dependency).stale:
-                    raise DependencyException(key, dependency)
-
-    def is_stale(self, entry):
-        """Determine if a file needs to be rebuilt"""
-        self._run_if_needed()
-        return bool(self.dag.get(str(entry)).stale)

--- a/regparser/index/entry.py
+++ b/regparser/index/entry.py
@@ -73,7 +73,7 @@ class Notice(Entry):
         return content.xml_str()
 
     def deserialize(self, content):
-        return NoticeXML(etree.fromstring(content))
+        return NoticeXML(etree.fromstring(content), str(self))
 
 
 class Annual(Entry):

--- a/regparser/index/xml_sync.py
+++ b/regparser/index/xml_sync.py
@@ -1,0 +1,17 @@
+import os
+
+import git
+
+import settings
+from . import ROOT
+
+
+GIT_DIR = os.path.join(ROOT, 'xmls')
+
+
+def sync():
+    if os.path.isdir(GIT_DIR):
+        repo = git.Repo.init(GIT_DIR)
+    else:
+        repo = git.Repo.clone_from(settings.XML_REPO, GIT_DIR)
+    repo.remote().pull()

--- a/settings.py
+++ b/settings.py
@@ -97,6 +97,8 @@ LOCAL_XML_PATHS = []
 # number, appendix, and label.
 APPENDIX_IGNORE_SUBHEADER_LABEL = {}
 
+XML_REPO = 'https://github.com/18F/fr-notices.git'
+
 try:
     from local_settings import *
 except ImportError:

--- a/tests/commands_clear_tests.py
+++ b/tests/commands_clear_tests.py
@@ -3,8 +3,8 @@ from unittest import TestCase
 
 from click.testing import CliRunner
 
-from regparser import eregs_index
 from regparser.commands.clear import clear
+from regparser.index import entry
 
 
 class CommandsClearTests(TestCase):
@@ -30,14 +30,14 @@ class CommandsClearTests(TestCase):
 
     def test_deletes_index(self):
         with self.cli.isolated_filesystem():
-            eregs_index.Entry('aaa', 'bbb').write('ccc')
-            eregs_index.Entry('bbb', 'ccc').write('ddd')
-            self.assertEqual(1, len(eregs_index.Entry("aaa")))
-            self.assertEqual(1, len(eregs_index.Entry("bbb")))
+            entry.Entry('aaa', 'bbb').write('ccc')
+            entry.Entry('bbb', 'ccc').write('ddd')
+            self.assertEqual(1, len(entry.Entry("aaa")))
+            self.assertEqual(1, len(entry.Entry("bbb")))
 
             self.cli.invoke(clear)
-            self.assertEqual(0, len(eregs_index.Entry("aaa")))
-            self.assertEqual(0, len(eregs_index.Entry("bbb")))
+            self.assertEqual(0, len(entry.Entry("aaa")))
+            self.assertEqual(0, len(entry.Entry("bbb")))
 
     def test_deletes_can_be_focused(self):
         """If params are provided to delete certain directories, only those
@@ -49,12 +49,12 @@ class CommandsClearTests(TestCase):
                        'top-level-file', 'other-root/aaa']
 
             for path in to_delete + to_keep:
-                eregs_index.Entry(*path.split('/')).write('')
+                entry.Entry(*path.split('/')).write('')
 
             self.cli.invoke(clear, ['delroot', 'root/delsub'])
             self.assertItemsEqual(['top-level-file', 'root', 'other-root'],
-                                  list(eregs_index.Entry()))
+                                  list(entry.Entry()))
             self.assertItemsEqual(['othersub', 'aaa'],
-                                  list(eregs_index.Entry('root')))
+                                  list(entry.Entry('root')))
             self.assertItemsEqual(['aaa'],
-                                  list(eregs_index.Entry('other-root')))
+                                  list(entry.Entry('other-root')))

--- a/tests/commands_diffs_tests.py
+++ b/tests/commands_diffs_tests.py
@@ -4,8 +4,8 @@ import os
 from unittest import TestCase
 
 from click.testing import CliRunner
-from regparser import eregs_index
 from regparser.commands.diffs import diffs
+from regparser.index import entry
 from regparser.tree.struct import Node
 
 
@@ -14,8 +14,8 @@ class CommandsDiffsTests(TestCase):
     def integration_setup(self):
         self.cli = CliRunner()
         with self.cli.isolated_filesystem():
-            self.tree_dir = eregs_index.TreeEntry('12', '1000')
-            self.diff_dir = eregs_index.DiffEntry('12', '1000')
+            self.tree_dir = entry.Tree('12', '1000')
+            self.diff_dir = entry.Diff('12', '1000')
             (self.tree_dir / 'v1').write(Node(text='V1V1V1', label=['1000']))
             (self.tree_dir / 'v2').write(Node(text='V2V2V2', label=['1000']))
             yield

--- a/tests/commands_fetch_sxs_tests.py
+++ b/tests/commands_fetch_sxs_tests.py
@@ -7,8 +7,8 @@ from click.testing import CliRunner
 from lxml import etree
 from mock import patch
 
-from regparser import eregs_index
 from regparser.commands.fetch_sxs import fetch_sxs
+from regparser.index import dependency, entry
 from regparser.notice.xml import NoticeXML
 from tests.xml_builder import XMLBuilderMixin
 
@@ -27,8 +27,7 @@ class CommandsFetchSxSTests(XMLBuilderMixin, TestCase):
         dependency error"""
         with self.cli.isolated_filesystem():
             result = self.cli.invoke(fetch_sxs, ['1111'])
-            self.assertTrue(isinstance(result.exception,
-                                       eregs_index.DependencyException))
+            self.assertTrue(isinstance(result.exception, dependency.Missing))
 
     @patch('regparser.commands.fetch_sxs.build_notice')
     @patch('regparser.commands.fetch_sxs.meta_data')
@@ -36,7 +35,7 @@ class CommandsFetchSxSTests(XMLBuilderMixin, TestCase):
         """If the notice XML is present, we write the parsed version to disk,
         even if that version's already present"""
         with self.cli.isolated_filesystem():
-            eregs_index.NoticeEntry('1111').write(self.notice_xml)
+            entry.Notice('1111').write(self.notice_xml)
             self.cli.invoke(fetch_sxs, ['1111'])
             meta_data.return_value = {'example': 1}
             self.assertTrue(build_notice.called)
@@ -46,6 +45,6 @@ class CommandsFetchSxSTests(XMLBuilderMixin, TestCase):
                 isinstance(kwargs['xml_to_process'], etree._Element))
 
             build_notice.reset_mock()
-            eregs_index.Entry('rule_changes', '1111').write('content')
+            entry.Entry('rule_changes', '1111').write('content')
             self.cli.invoke(fetch_sxs, ['1111'])
             self.assertTrue(build_notice.called)

--- a/tests/commands_fill_with_rules_tests.py
+++ b/tests/commands_fill_with_rules_tests.py
@@ -2,8 +2,8 @@ from unittest import TestCase
 
 from click.testing import CliRunner
 
-from regparser import eregs_index
 from regparser.commands import fill_with_rules
+from regparser.index import dependency, entry
 from regparser.tree.struct import Node
 
 
@@ -17,9 +17,9 @@ class CommandsFillWithRulesTests(TestCase):
         first version, if missing"""
         with self.cli.isolated_filesystem():
             version_ids = ['111', '222', '333', '444', '555', '666']
-            tree_dir = eregs_index.TreeEntry('12', '1000')
-            rule_dir = eregs_index.RuleChangesEntry()
-            vers_dir = eregs_index.VersionEntry('12', '1000')
+            tree_dir = entry.Tree('12', '1000')
+            rule_dir = entry.RuleChanges()
+            vers_dir = entry.Version('12', '1000')
             # Existing trees
             (tree_dir / '222').write(Node())
             (tree_dir / '555').write(Node())
@@ -58,13 +58,13 @@ class CommandsFillWithRulesTests(TestCase):
         """Should filter a set of version ids to only those with a dependency
         on changes derived from a rule"""
         with self.cli.isolated_filesystem():
-            tree_dir = eregs_index.TreeEntry('12', '1000')
+            tree_dir = entry.Tree('12', '1000')
 
-            deps = eregs_index.DependencyGraph()
-            deps.add(tree_dir / 111, eregs_index.AnnualEntry(12, 1000, 2001))
-            deps.add(tree_dir / 222, eregs_index.RuleChangesEntry(222))
-            deps.add(tree_dir / 333, eregs_index.RuleChangesEntry(333))
-            deps.add(tree_dir / 333, eregs_index.VersionEntry(333))
+            deps = dependency.Graph()
+            deps.add(tree_dir / 111, entry.Annual(12, 1000, 2001))
+            deps.add(tree_dir / 222, entry.RuleChanges(222))
+            deps.add(tree_dir / 333, entry.RuleChanges(333))
+            deps.add(tree_dir / 333, entry.Version(333))
             derived = fill_with_rules.derived_from_rules(
                 ['111', '222', '333', '444'], deps, tree_dir)
             self.assertEqual(derived, ['222', '333'])

--- a/tests/commands_layers_tests.py
+++ b/tests/commands_layers_tests.py
@@ -4,9 +4,9 @@ from unittest import TestCase
 from click.testing import CliRunner
 from mock import Mock, patch
 
-from regparser import eregs_index
 from regparser.commands import layers
 from regparser.history.versions import Version
+from regparser.index import entry
 from regparser.tree.struct import Node
 
 
@@ -21,10 +21,10 @@ class CommandsLayersTests(TestCase):
         version info, and between the SxS layer and all of the preceding sxs
         inputs"""
         with self.cli.isolated_filesystem():
-            tree_dir = eregs_index.Entry('tree')
-            layer_dir = eregs_index.Entry('layer')
-            version_dir = eregs_index.Entry('version')
-            sxs_dir = eregs_index.Entry('sxs')
+            tree_dir = entry.Entry('tree')
+            layer_dir = entry.Entry('layer')
+            version_dir = entry.Entry('version')
+            sxs_dir = entry.Entry('sxs')
 
             # Trees
             (tree_dir / '1111').write('tree1')
@@ -63,9 +63,9 @@ class CommandsLayersTests(TestCase):
         """We should read back serialized notices, but only those which are
         relevant"""
         with self.cli.isolated_filesystem():
-            notice_dir = eregs_index.Entry('notice_xml')
-            version_dir = eregs_index.Entry('version')
-            sxs_dir = eregs_index.SxSEntry()
+            notice_dir = entry.Entry('notice_xml')
+            version_dir = entry.Entry('version')
+            sxs_dir = entry.SxS()
             # 4 won't be picked up as there's no associated version
             for i in (1, 3, 4):
                 (notice_dir / i).write(str(i))
@@ -89,7 +89,7 @@ class CommandsLayersTests(TestCase):
             analyses.return_value.build.return_value = {'2': 2}
 
             version = Version('1234', date(2000, 1, 1), date(2000, 1, 1))
-            eregs_index.TreeEntry('12', '1000', '1234').write(Node())
+            entry.Tree('12', '1000', '1234').write(Node())
 
             with patch.dict(layers.ALL_LAYERS,
                             {'meta': meta, 'analyses': analyses}):

--- a/tests/commands_parse_rule_changes_tests.py
+++ b/tests/commands_parse_rule_changes_tests.py
@@ -4,8 +4,8 @@ from click.testing import CliRunner
 from lxml import etree
 from mock import patch
 
-from regparser import eregs_index
 from regparser.commands.parse_rule_changes import parse_rule_changes
+from regparser.index import dependency, entry
 from regparser.notice.xml import NoticeXML
 from tests.xml_builder import XMLBuilderMixin
 
@@ -24,7 +24,7 @@ class CommandsParseRuleChangesTests(XMLBuilderMixin, TestCase):
         with self.cli.isolated_filesystem():
             result = self.cli.invoke(parse_rule_changes, ['1111'])
             self.assertTrue(isinstance(result.exception,
-                                       eregs_index.DependencyException))
+                                       dependency.Missing))
 
     @patch('regparser.commands.parse_rule_changes.process_amendments')
     def test_writes(self, process_amendments):
@@ -32,7 +32,7 @@ class CommandsParseRuleChangesTests(XMLBuilderMixin, TestCase):
         even if that version's already present"""
         process_amendments.return_value = {'filled': 'values'}
         with self.cli.isolated_filesystem():
-            eregs_index.NoticeEntry('1111').write(self.notice_xml)
+            entry.Notice('1111').write(self.notice_xml)
             self.cli.invoke(parse_rule_changes, ['1111'])
             self.assertTrue(process_amendments.called)
             args = process_amendments.call_args[0]
@@ -40,6 +40,6 @@ class CommandsParseRuleChangesTests(XMLBuilderMixin, TestCase):
             self.assertTrue(isinstance(args[1], etree._Element))
 
             process_amendments.reset_mock()
-            eregs_index.Entry('rule_changes', '1111').write('content')
+            entry.Entry('rule_changes', '1111').write('content')
             self.cli.invoke(parse_rule_changes, ['1111'])
             self.assertTrue(process_amendments.called)

--- a/tests/commands_preprocess_notice_tests.py
+++ b/tests/commands_preprocess_notice_tests.py
@@ -5,14 +5,14 @@ from click.testing import CliRunner
 from mock import patch
 
 from regparser.commands.preprocess_notice import preprocess_notice
-from regparser.index import entry
+from regparser.index import dependency, entry
 from regparser.notice.xml import NoticeXML
 from tests.http_mixin import HttpMixin
 from tests.xml_builder import LXMLBuilder, XMLBuilderMixin
 
 
 class CommandsPreprocessNoticeTests(HttpMixin, XMLBuilderMixin, TestCase):
-    def example_xml(self, effdate_str=""):
+    def example_xml(self, effdate_str="", source=None):
         """Returns a simple notice-like XML structure"""
         self.tree = LXMLBuilder()
         with self.tree.builder("ROOT") as root:
@@ -20,7 +20,7 @@ class CommandsPreprocessNoticeTests(HttpMixin, XMLBuilderMixin, TestCase):
             root.P()
             with root.EFFDATE() as effdate:
                 effdate.P(effdate_str)
-        return NoticeXML(self.tree.render_xml())
+        return NoticeXML(self.tree.render_xml(), source)
 
     def expect_common_json(self, **kwargs):
         """Expect an HTTP call and return a common json respond"""
@@ -81,3 +81,23 @@ class CommandsPreprocessNoticeTests(HttpMixin, XMLBuilderMixin, TestCase):
             self.assertEqual(jan.effective, date(2001, 1, 1))
             self.assertEqual(feb.effective, date(2002, 2, 2))
             self.assertEqual(mar.effective, date(2003, 3, 3))
+
+    @patch('regparser.commands.preprocess_notice.notice_xmls_for_url')
+    def test_dependencies(self, notice_xmls_for_url):
+        """If the xml comes from a local source, we should expect a dependency
+        be present. Otherwise, we should expect no dependency"""
+        cli = CliRunner()
+        self.expect_common_json()
+        notice_xmls_for_url.return_value = [self.example_xml(source='./here')]
+        with cli.isolated_filesystem():
+            cli.invoke(preprocess_notice, ['1234-5678'])
+            entry_str = str(entry.Notice() / '1234-5678')
+            with dependency.Graph().dependency_db() as db:
+                self.assertTrue(entry_str in db)
+
+        notice_xmls_for_url.return_value[0].source = 'http://example.com'
+        with cli.isolated_filesystem():
+            cli.invoke(preprocess_notice, ['1234-5678'])
+            entry_str = str(entry.Notice() / '1234-5678')
+            with dependency.Graph().dependency_db() as db:
+                self.assertFalse(entry_str in db)

--- a/tests/commands_preprocess_notice_tests.py
+++ b/tests/commands_preprocess_notice_tests.py
@@ -55,7 +55,7 @@ class CommandsPreprocessNoticeTests(HttpMixin, XMLBuilderMixin, TestCase):
             self.example_xml("Effective January 1, 2001")]
         with cli.isolated_filesystem():
             cli.invoke(preprocess_notice, ['1234-5678'])
-            written = eregs_index.NoticeEntry('1234-5678').read()
+            written = entry.Notice('1234-5678').read()
             self.assertEqual(written.effective, date(2001, 1, 1))
 
     @patch('regparser.commands.preprocess_notice.notice_xmls_for_url')

--- a/tests/commands_preprocess_notice_tests.py
+++ b/tests/commands_preprocess_notice_tests.py
@@ -4,8 +4,8 @@ from unittest import TestCase
 from click.testing import CliRunner
 from mock import patch
 
-from regparser import eregs_index
 from regparser.commands.preprocess_notice import preprocess_notice
+from regparser.index import entry
 from regparser.notice.xml import NoticeXML
 from tests.http_mixin import HttpMixin
 from tests.xml_builder import LXMLBuilder, XMLBuilderMixin
@@ -38,9 +38,9 @@ class CommandsPreprocessNoticeTests(HttpMixin, XMLBuilderMixin, TestCase):
         notice_xmls_for_url.return_value = [self.example_xml()]
         with cli.isolated_filesystem():
             cli.invoke(preprocess_notice, ['1234-5678'])
-            self.assertEqual(1, len(eregs_index.NoticeEntry()))
+            self.assertEqual(1, len(entry.Notice()))
 
-            written = eregs_index.NoticeEntry('1234-5678').read()
+            written = entry.Notice('1234-5678').read()
             self.assertEqual(written.effective, date(2008, 8, 8))
 
     @patch('regparser.commands.preprocess_notice.notice_xmls_for_url')
@@ -56,7 +56,7 @@ class CommandsPreprocessNoticeTests(HttpMixin, XMLBuilderMixin, TestCase):
             self.example_xml("Effective March 3, 2003")]
         with cli.isolated_filesystem():
             cli.invoke(preprocess_notice, ['1234-5678'])
-            notice_path = eregs_index.NoticeEntry()
+            notice_path = entry.Notice()
             self.assertEqual(3, len(notice_path))
 
             jan = (notice_path / '1234-5678_20010101').read()

--- a/tests/commands_write_to_tests.py
+++ b/tests/commands_write_to_tests.py
@@ -6,9 +6,9 @@ from unittest import TestCase
 
 from click.testing import CliRunner
 
-from regparser import eregs_index
 from regparser.commands.write_to import write_to
 from regparser.history.versions import Version
+from regparser.index import entry
 from regparser.tree.struct import Node
 
 
@@ -22,41 +22,41 @@ class CommandsWriteToTests(TestCase):
 
     def add_versions(self):
         """Add some versions to the index"""
-        eregs_index.VersionEntry('12', '1000', 'v1').write(
+        entry.Version('12', '1000', 'v1').write(
             Version('v1', date(2001, 1, 1), date(2001, 1, 1)))
-        eregs_index.VersionEntry('12', '1000', 'v2').write(
+        entry.Version('12', '1000', 'v2').write(
             Version('v2', date(2002, 2, 2), date(2002, 2, 2)))
-        eregs_index.VersionEntry('12', '1000', 'v3').write(
+        entry.Version('12', '1000', 'v3').write(
             Version('v3', date(2003, 3, 3), date(2003, 3, 3)))
-        eregs_index.VersionEntry('12', '1001', 'other').write(
+        entry.Version('12', '1001', 'other').write(
             Version('other', date(2003, 3, 3), date(2003, 3, 3)))
 
     def add_trees(self):
         """Add some versions to the index"""
-        eregs_index.TreeEntry('12', '1000', 'v2').write(Node('v2'))
-        eregs_index.TreeEntry('12', '1000', 'v3').write(Node('v3'))
-        eregs_index.TreeEntry('12', '1000', 'v4').write(Node('v4'))
+        entry.Tree('12', '1000', 'v2').write(Node('v2'))
+        entry.Tree('12', '1000', 'v3').write(Node('v3'))
+        entry.Tree('12', '1000', 'v4').write(Node('v4'))
 
     def add_layers(self):
         """Add an assortment of layers to the index"""
-        eregs_index.LayerEntry('12', '1000', 'v2', 'layer1').write({'1': 1})
-        eregs_index.LayerEntry('12', '1000', 'v2', 'layer2').write({'2': 2})
-        eregs_index.LayerEntry('12', '1000', 'v3', 'layer2').write({'2': 2})
-        eregs_index.LayerEntry('12', '1000', 'v3', 'layer3').write({'3': 3})
-        eregs_index.LayerEntry('12', '1000', 'v0', 'layer1').write({'1': 1})
+        entry.Layer('12', '1000', 'v2', 'layer1').write({'1': 1})
+        entry.Layer('12', '1000', 'v2', 'layer2').write({'2': 2})
+        entry.Layer('12', '1000', 'v3', 'layer2').write({'2': 2})
+        entry.Layer('12', '1000', 'v3', 'layer3').write({'3': 3})
+        entry.Layer('12', '1000', 'v0', 'layer1').write({'1': 1})
 
     def add_diffs(self):
         """Adds an uneven assortment of diffs between trees"""
-        eregs_index.DiffEntry('12', '1000', 'v1', 'v2').write({'1': 2})
-        eregs_index.DiffEntry('12', '1000', 'v2', 'v2').write({'2': 2})
-        eregs_index.DiffEntry('12', '1000', 'v2', 'v1').write({'2': 1})
-        eregs_index.DiffEntry('12', '1000', 'v0', 'v1').write({'0': 1})
+        entry.Diff('12', '1000', 'v1', 'v2').write({'1': 2})
+        entry.Diff('12', '1000', 'v2', 'v2').write({'2': 2})
+        entry.Diff('12', '1000', 'v2', 'v1').write({'2': 1})
+        entry.Diff('12', '1000', 'v0', 'v1').write({'0': 1})
 
     def add_notices(self):
         """Adds an uneven assortment of notices"""
-        eregs_index.SxSEntry('v0').write({'0': 0})
-        eregs_index.SxSEntry('v1').write({'1': 1})
-        eregs_index.SxSEntry('v2').write({'2': 2})
+        entry.SxS('v0').write({'0': 0})
+        entry.SxS('v1').write({'1': 1})
+        entry.SxS('v2').write({'2': 2})
 
     def assert_file_exists(self, *parts):
         """Helper method to verify that a file was created"""

--- a/tests/index_dependency_tests.py
+++ b/tests/index_dependency_tests.py
@@ -1,41 +1,21 @@
 from contextlib import contextmanager
-from datetime import date
 import os
 from time import time
 from unittest import TestCase
 
 from click.testing import CliRunner
 
-from regparser import eregs_index
-from regparser.history.versions import Version
-
-
-class VersionEntryTests(TestCase):
-    def test_iterator(self):
-        """Versions should be correctly linearized"""
-        with CliRunner().isolated_filesystem():
-            path = eregs_index.VersionEntry("12", "1000")
-            v1 = Version('1111', effective=date(2004, 4, 4),
-                         published=date(2004, 4, 4))
-            v2 = Version('2222', effective=date(2002, 2, 2),
-                         published=date(2004, 4, 4))
-            v3 = Version('3333', effective=date(2004, 4, 4),
-                         published=date(2003, 3, 3))
-            (path / '1111').write(v1)
-            (path / '2222').write(v2)
-            (path / '3333').write(v3)
-
-            self.assertEqual(['2222', '3333', '1111'], list(path))
+from regparser.index import dependency, entry
 
 
 class DependencyGraphTests(TestCase):
     @contextmanager
     def dependency_graph(self):
         with CliRunner().isolated_filesystem():
-            path = eregs_index.Entry('path')
+            path = entry.Entry('path')
             self.depender = path / 'depender'
             self.dependency = path / 'dependency'
-            yield eregs_index.DependencyGraph()
+            yield dependency.Graph()
 
     def test_nonexistent_files_are_stale(self):
         """By definition, if a file is not present, it needs to be rebuilt"""
@@ -54,7 +34,7 @@ class DependencyGraphTests(TestCase):
             dgraph.add(self.depender, self.dependency)
             self.assertTrue(dgraph.is_stale(self.dependency))
             self.assertTrue(dgraph.is_stale(self.depender))
-            with self.assertRaises(eregs_index.DependencyException):
+            with self.assertRaises(dependency.Missing):
                 dgraph.validate_for(self.depender)
 
     def test_updates_to_dependencies_flow(self):
@@ -74,7 +54,7 @@ class DependencyGraphTests(TestCase):
             self.assertTrue(dgraph.is_stale(self.depender))
 
     def test_dependencies_serialized(self):
-        """Every instance of DependencyGraph shares a serialized copy of the
+        """Every instance of dependency.Graph shares a serialized copy of the
         dependencies"""
         with self.dependency_graph() as dgraph:
             dgraph.add(self.depender, self.dependency / '1')
@@ -85,7 +65,7 @@ class DependencyGraphTests(TestCase):
                 dependencies,
                 set([str(self.dependency / 1), str(self.dependency / 2)]))
 
-            with eregs_index.DependencyGraph().dependency_db() as db:
+            with dependency.Graph().dependency_db() as db:
                 dependencies = db[str(self.depender)]
             self.assertEqual(
                 dependencies,

--- a/tests/index_entry_tests.py
+++ b/tests/index_entry_tests.py
@@ -1,0 +1,25 @@
+from datetime import date
+from unittest import TestCase
+
+from click.testing import CliRunner
+
+from regparser.history.versions import Version
+from regparser.index import entry
+
+
+class VersionEntryTests(TestCase):
+    def test_iterator(self):
+        """Versions should be correctly linearized"""
+        with CliRunner().isolated_filesystem():
+            path = entry.Version("12", "1000")
+            v1 = Version('1111', effective=date(2004, 4, 4),
+                         published=date(2004, 4, 4))
+            v2 = Version('2222', effective=date(2002, 2, 2),
+                         published=date(2004, 4, 4))
+            v3 = Version('3333', effective=date(2004, 4, 4),
+                         published=date(2003, 3, 3))
+            (path / '1111').write(v1)
+            (path / '2222').write(v2)
+            (path / '3333').write(v3)
+
+            self.assertEqual(['2222', '3333', '1111'], list(path))

--- a/tests/notice_xml_tests.py
+++ b/tests/notice_xml_tests.py
@@ -123,3 +123,11 @@ class NoticeXMLTests(XMLBuilderMixin, TestCase):
             xml.delays(),
             [FRDelay(11, 100, date(2010, 4, 1)),
              FRDelay(11, 200, date(2010, 10, 10))])
+
+    def test_source_is_local(self):
+        for url in ('https://example.com', 'http://example.com'):
+            self.assertFalse(
+                notice_xml.NoticeXML('<ROOT/>', source=url).source_is_local)
+        for path in ('./dot/relative', 'normal/relative', '/absolute/ref'):
+            self.assertTrue(
+                notice_xml.NoticeXML('<ROOT/>', source=path).source_is_local)


### PR DESCRIPTION
As part of 18f/atf-eregs#82, this adds a step to synchronize XML files when running the pipeline command. If an xml file changes, the following trees, etc. will also get rebuilt.

Other refactors:
* Split `eregs_index.py` into `index/entry.py` and `index/dependency.py`
* `NoticeXML` structures keep a reference to their source file/url
* A dependency is added for any XML that was built from a local file