### PR TITLE
Update markerless paragraphs correctly when changed via an amendement

### DIFF
--- a/regparser/notice/changes.py
+++ b/regparser/notice/changes.py
@@ -10,7 +10,7 @@ from regparser.grammar.tokens import Verb
 from regparser.layer.paragraph_markers import marker_of
 from regparser.tree import struct
 from regparser.tree.paragraph import p_levels
-from regparser.tree.struct import Node
+
 
 def node_to_dict(node):
     """ Convert a node to a dictionary representation. We skip the
@@ -100,17 +100,17 @@ def resolve_candidates(amend_map, warn=True):
 
 def find_misparsed_node(section_node, label, change, amended_labels):
     """ Nodes can get misparsed in the sense that we don't always know where
-    they are in the tree or have their correct label. The first part 
-    corrects markerless labeled nodes by updating the node's label if 
+    they are in the tree or have their correct label. The first part
+    corrects markerless labeled nodes by updating the node's label if
     the source text has been changed to include the markerless paragraph
     (ex. 123-44-p6 for paragraph 6). we know this because `label` here
     is parsed from that change. The second part uses label to find a
     candidate for a mis-parsed node and creates an appropriate change. """
 
-    is_markerless = Node.is_markerless_label(label)
+    is_markerless = struct.Node.is_markerless_label(label)
     markerless_paragraphs = struct.filter_walk(
         section_node,
-        Node.is_markerless_label)
+        struct.Node.is_markerless_label)
     if is_markerless and len(markerless_paragraphs) == 1:
         change['node'] = markerless_paragraphs[0]
         change['candidate'] = True

--- a/regparser/notice/changes.py
+++ b/regparser/notice/changes.py
@@ -10,7 +10,7 @@ from regparser.grammar.tokens import Verb
 from regparser.layer.paragraph_markers import marker_of
 from regparser.tree import struct
 from regparser.tree.paragraph import p_levels
-
+from regparser.tree.struct import Node
 
 def node_to_dict(node):
     """ Convert a node to a dictionary representation. We skip the
@@ -100,8 +100,21 @@ def resolve_candidates(amend_map, warn=True):
 
 def find_misparsed_node(section_node, label, change, amended_labels):
     """ Nodes can get misparsed in the sense that we don't always know where
-    they are in the tree. This uses label to find a candidate for a mis-parsed
-    node and creates an appropriate change. """
+    they are in the tree or have their correct label. The first part 
+    corrects markerless labeled nodes by updating the node's label if 
+    the source text has been changed to include the markerless paragraph
+    (ex. 123-44-p6 for paragraph 6). we know this because `label` here
+    is parsed from that change. The second part uses label to find a
+    candidate for a mis-parsed node and creates an appropriate change. """
+
+    is_markerless = Node.is_markerless_label(label)
+    markerless_paragraphs = struct.walk(
+        section_node,
+        lambda node: node if node.is_markerless_label(node.label) else None)
+    if is_markerless and len(markerless_paragraphs) == 1:
+        change['node'] = markerless_paragraphs[0]
+        change['candidate'] = True
+        return change
 
     candidates = find_candidate(section_node, label[-1], amended_labels)
     if len(candidates) == 1:

--- a/regparser/notice/changes.py
+++ b/regparser/notice/changes.py
@@ -108,9 +108,9 @@ def find_misparsed_node(section_node, label, change, amended_labels):
     candidate for a mis-parsed node and creates an appropriate change. """
 
     is_markerless = Node.is_markerless_label(label)
-    markerless_paragraphs = struct.walk(
+    markerless_paragraphs = struct.filter_walk(
         section_node,
-        lambda node: node if node.is_markerless_label(node.label) else None)
+        Node.is_markerless_label)
     if is_markerless and len(markerless_paragraphs) == 1:
         change['node'] = markerless_paragraphs[0]
         change['candidate'] = True

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -56,6 +56,7 @@ class Node(object):
     def is_markerless_label(label):
         return re.match(r'p\d+', label[-1])
 
+
 class NodeEncoder(JSONEncoder):
     """Custom JSON encoder to handle Node objects"""
     def default(self, obj):

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -1,3 +1,4 @@
+import re
 from collections import defaultdict
 from json import JSONEncoder
 import hashlib
@@ -50,6 +51,9 @@ class Node(object):
         else:
             return len(self.label)
 
+    @staticmethod
+    def is_markerless_label(label):
+        return re.match(r'p\d+', label[-1])
 
 class NodeEncoder(JSONEncoder):
     """Custom JSON encoder to handle Node objects"""

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -144,8 +144,8 @@ def walk(node, fn):
 
 
 def filter_walk(node, fn):
-    """Perform fn for every node in the tree and return a list of nodes
-    on which the function returns truthy."""
+    """Perform fn on the label for every node in the tree and return a
+    list of nodes on which the function returns truthy."""
     return walk(node, lambda n: n if fn(n.label) else None)
 
 

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -54,6 +54,8 @@ class Node(object):
 
     @staticmethod
     def is_markerless_label(label):
+        if not label:
+            return None
         return re.match(r'p\d+', label[-1])
 
 

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -138,10 +138,12 @@ def walk(node, fn):
         results += walk(child, fn)
     return results
 
+
 def filter_walk(node, fn):
     """Perform fn for every node in the tree and return a list of nodes
     on which the function returns truthy."""
     return walk(node, lambda n: n if fn(n.label) else None)
+
 
 def find_first(root, predicate):
     """Walk the tree and find the first node which matches the predicate"""

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -138,6 +138,10 @@ def walk(node, fn):
         results += walk(child, fn)
     return results
 
+def filter_walk(node, fn):
+    """Perform fn for every node in the tree and return a list of nodes
+    on which the function returns truthy."""
+    return walk(node, lambda n: n if fn(n.label) else None)
 
 def find_first(root, predicate):
     """Walk the tree and find the first node which matches the predicate"""

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -16,6 +16,8 @@ class Node(object):
 
     INTERP_MARK = 'Interp'
 
+    MARKERLESS_REGEX = re.compile(r'p\d+')
+
     def __init__(self, text='', children=[], label=[], title=None,
                  node_type=REGTEXT, source_xml=None):
 
@@ -56,7 +58,7 @@ class Node(object):
     def is_markerless_label(label):
         if not label:
             return None
-        return re.match(r'p\d+', label[-1])
+        return re.match(Node.MARKERLESS_REGEX, label[-1])
 
 
 class NodeEncoder(JSONEncoder):

--- a/tests/notice_build_tests.py
+++ b/tests/notice_build_tests.py
@@ -267,6 +267,22 @@ class NoticeBuildTest(XMLBuilderMixin, TestCase):
         self.assertEqual(delete.action, 'DELETE')
         self.assertEqual(delete.label, ['104', '13', 'b'])
 
+    def test_process_amendments_markerless(self):
+        with self.tree.builder("REGTEXT", PART="105", TITLE="12") as regtext:
+            regtext.AMDPAR(u"1. Revise [label:105-11-p5] as blah")
+            with regtext.SECTION() as section:
+                section.SECTNO(u"§ 105.11")
+                section.SUBJECT("Purpose.")
+                section.STARS()
+                section.P("Some text here")
+
+        notice = {'cfr_parts': ['105']}
+        build.process_amendments(notice, self.tree.render_xml())
+        self.assertEqual(notice['changes'].keys(), ['105-11-p5'])
+
+        changes = notice['changes']['105-11-p5'][0]
+        self.assertEqual(changes['action'], 'PUT')
+
     def new_subpart_xml(self):
         with self.tree.builder("RULE") as rule:
             with rule.REGTEXT(PART="105", TITLE="12") as regtext:

--- a/tests/tree_struct_tests.py
+++ b/tests/tree_struct_tests.py
@@ -25,6 +25,17 @@ class DepthTreeTest(TestCase):
         self.assertEqual([n1, n2, n4, n3], order)
         self.assertEqual(["1", "4", "3"], ret_val)
 
+    def test_filter_walk(self):
+        node = struct.Node(label="1", children=[struct.Node(label="3"),
+                                               struct.Node(label="5")])
+        
+        def get_first(label):
+            if label == ["3"]:
+                return True
+
+        match = struct.filter_walk(node, get_first)
+        self.assertEqual(["3"], match[0].label)
+
     def test_find(self):
         n1 = struct.Node('n1', label=['n1'])
         n2 = struct.Node('n2', label=['n2'])

--- a/tests/tree_struct_tests.py
+++ b/tests/tree_struct_tests.py
@@ -6,6 +6,7 @@ from regparser.tree import struct
 
 class DepthTreeTest(TestCase):
 
+
     def test_walk(self):
         n1 = struct.Node("1")
         n2 = struct.Node("2")
@@ -240,3 +241,11 @@ class FrozenNodeTests(TestCase):
         self.assertNotEqual(id(same2), id(diff))
         self.assertEqual(same1.hash, same2.hash)
         self.assertNotEqual(same1.hash, diff.hash)
+
+
+class NodeTests(TestCase):
+    def test_is_markerless_label(self):
+        self.assertIsNone(struct.Node.is_markerless_label(''))
+        self.assertIsNone(struct.Node.is_markerless_label(None))
+        self.assertTrue(struct.Node.is_markerless_label(['134', 'p33']))
+        self.assertIsNone(struct.Node.is_markerless_label(['245', '23']))

--- a/tests/tree_struct_tests.py
+++ b/tests/tree_struct_tests.py
@@ -5,8 +5,6 @@ from regparser.tree import struct
 
 
 class DepthTreeTest(TestCase):
-
-
     def test_walk(self):
         n1 = struct.Node("1")
         n2 = struct.Node("2")
@@ -28,12 +26,11 @@ class DepthTreeTest(TestCase):
 
     def test_filter_walk(self):
         node = struct.Node(label="1", children=[struct.Node(label="3"),
-                                               struct.Node(label="5")])
-        
+                                                struct.Node(label="5")])
+
         def get_first(label):
             if label == ["3"]:
                 return True
-
         match = struct.filter_walk(node, get_first)
         self.assertEqual(["3"], match[0].label)
 


### PR DESCRIPTION
Addresses https://github.com/18F/atf-eregs/issues/40

Requires a manual change to the notice XML for 2015-25190 to replace 'the definition of “Customs officer"' to "[label:555-11-p25]".

Bulk of the work done by @cmc333333, I just did some renaming/finishing.