### PR TITLE
Tests and fix for Node.depth() not treating EXTRACTs correctly.

### DIFF
--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -42,7 +42,8 @@ class Node(object):
 
     def depth(self):
         """Inspect the label and type to determine the node's depth"""
-        if len(self.label) > 1 and self.node_type == self.REGTEXT:
+        if len(self.label) > 1 and self.node_type in (self.REGTEXT,
+                                                      self.EXTRACT):
             #   Add one for the subpart level
             return len(self.label) + 1
         elif self.node_type in (self.SUBPART, self.EMPTYPART):
@@ -50,7 +51,6 @@ class Node(object):
             return 2
         else:
             return len(self.label)
-
 
 class NodeEncoder(JSONEncoder):
     """Custom JSON encoder to handle Node objects"""

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -52,6 +52,7 @@ class Node(object):
         else:
             return len(self.label)
 
+
 class NodeEncoder(JSONEncoder):
     """Custom JSON encoder to handle Node objects"""
     def default(self, obj):

--- a/tests/tree_struct_tests.py
+++ b/tests/tree_struct_tests.py
@@ -32,7 +32,6 @@ class NodeTest(TestCase):
                                      node_type=struct.Node.EMPTYPART).depth())
 
 
-
 class DepthTreeTest(TestCase):
 
     def test_walk(self):

--- a/tests/tree_struct_tests.py
+++ b/tests/tree_struct_tests.py
@@ -3,6 +3,35 @@ from unittest import TestCase
 
 from regparser.tree import struct
 
+class NodeTest(TestCase):
+
+    def test_depth(self):
+        label = ["111", "1", "a", "p1"]
+        self.assertEqual(1, struct.Node("x", label=label[:1]).depth())
+        self.assertEqual(3, struct.Node("x", label=label[:2]).depth())
+        self.assertEqual(4, struct.Node("x", label=label[:3]).depth())
+        self.assertEqual(5, struct.Node("x", label=label).depth())
+        self.assertEqual(4, struct.Node("x", label=label,
+                                        node_type=struct.Node.INTERP).depth())
+        self.assertEqual(5, struct.Node("x", label=label,
+                                        node_type=struct.Node.EXTRACT).depth())
+        self.assertEqual(2, struct.Node("x", label=label[:1],
+                                        node_type=struct.Node.SUBPART).depth())
+        self.assertEqual(2, struct.Node("x", label=label[:2],
+                                        node_type=struct.Node.SUBPART).depth())
+        self.assertEqual(2, struct.Node("x", label=label[:3],
+                                        node_type=struct.Node.SUBPART).depth())
+        self.assertEqual(2,
+                         struct.Node("x", label=label[:1],
+                                     node_type=struct.Node.EMPTYPART).depth())
+        self.assertEqual(2,
+                         struct.Node("x", label=label[:2],
+                                     node_type=struct.Node.EMPTYPART).depth())
+        self.assertEqual(2,
+                         struct.Node("x", label=label[:3],
+                                     node_type=struct.Node.EMPTYPART).depth())
+
+
 
 class DepthTreeTest(TestCase):
 

--- a/tests/tree_struct_tests.py
+++ b/tests/tree_struct_tests.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 
 from regparser.tree import struct
 
+
 class NodeTest(TestCase):
 
     def test_depth(self):


### PR DESCRIPTION
This fixes the issue where after an EXTRACT in the Definitions section the rest of the definitions would be omitted.