### PR TITLE
Modify next_marker logic to account for MARKERLESS

### DIFF
--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -278,15 +278,19 @@ class ParagraphMatcher(paragraph_processor.BaseMatcher):
     def next_marker(self, xml):
         """Find the first marker in a paragraph that follows this xml node.
         May return None"""
+        good_tags = ('P', 'FP', mtypes.STARS_TAG)
+
         node = xml.getnext()
-        while node is not None:
+        while node is not None and node.tag not in good_tags:
+            node = node.getnext()
+
+        if getattr(node, 'tag', None) == mtypes.STARS_TAG:
+            return mtypes.STARS_TAG
+        elif node is not None:
             tagged_text = tree_utils.get_node_text_tags_preserved(node)
             markers = get_markers(tagged_text.strip())
-            if node.tag == mtypes.STARS_TAG:
-                return node.tag
-            elif markers:
+            if markers:
                 return markers[0]
-            node = node.getnext()
 
 
 class RegtextParagraphProcessor(paragraph_processor.ParagraphProcessor):

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -655,21 +655,21 @@ class ParagraphMatcherTests(XMLBuilderMixin, TestCase):
         """Find the first paragraph marker following a paragraph"""
         with self.tree.builder("ROOT") as root:
             root.P("(A) AAA")
-            root.P("ABCD")
+            root.PRTPART()
             root.P("(d) ddd")
             root.P("(1) 111")
-        xml = self.tree.render_xml()[1]
+        xml = self.tree.render_xml()[0]
         self.assertEqual(reg_text.ParagraphMatcher().next_marker(xml), 'd')
 
     def test_next_marker_stars(self):
         """STARS tag has special significance."""
         with self.tree.builder("ROOT") as root:
             root.P("(A) AAA")
-            root.P("ABCD")
+            root.PRTPART()
             root.STARS()
             root.P("(d) ddd")
             root.P("(1) 111")
-        xml = self.tree.render_xml()[1]
+        xml = self.tree.render_xml()[0]
         self.assertEqual(reg_text.ParagraphMatcher().next_marker(xml),
                          mtypes.STARS_TAG)
 
@@ -678,6 +678,7 @@ class ParagraphMatcherTests(XMLBuilderMixin, TestCase):
         with self.tree.builder("ROOT") as root:
             root.P("(1) 111")
             root.P("Content")
+            root.P("(i) iii")
         xml = self.tree.render_xml()[0]
         self.assertIsNone(reg_text.ParagraphMatcher().next_marker(xml))
 


### PR DESCRIPTION
Previously, when determining if a paragraph should be split into
subparagraphs, we'd skip over any paragraphs without markers/stars. This meant
that it'd skip over MARKERLESS paragraphs, which is not intended. This patch
modifies this logic to skip over only XML nodes we aren't expecting.

Resolves 18f/atf-eregs#128

This works correctly for 27 CFR 478, 479, 555, 646