### PR TITLE
Split "or" when finding definitions in keyterms.

### DIFF
--- a/tests/layer_def_finders_tests.py
+++ b/tests/layer_def_finders_tests.py
@@ -203,12 +203,16 @@ class DefinitionKeytermTest(TestCase):
         self.assert_finds_result(
             '<E T="03">Another Phrase.</E>. Paragraph text', 'Definition',
             def_finders.Ref('another phrase', None, 0))
+        # Comma isn't enough to split the definition
         self.assert_finds_result(
             '<E T="03">Officer, office.</E>. Paragraph text', 'Definition',
             def_finders.Ref('officer, office', None, 0))
-        """ @todo
+        # "Or" should split the definition if the terms of simple
         self.assert_finds_result(
             '<E T="03">Frame or receiver.</E>. Paragraph text', 'Definition',
             def_finders.Ref('frame', None, 0),
             def_finders.Ref('receiver', None, 9))
-        """
+        # "Or" should *not* split the definition if the terms are complex
+        self.assert_finds_result(
+            '<E T="03">Common or contract carrier</E>.', 'Definition',
+            def_finders.Ref('common or contract carrier', None, 0))

--- a/tests/layer_def_finders_tests.py
+++ b/tests/layer_def_finders_tests.py
@@ -207,7 +207,7 @@ class DefinitionKeytermTest(TestCase):
         self.assert_finds_result(
             '<E T="03">Officer, office.</E>. Paragraph text', 'Definition',
             def_finders.Ref('officer, office', None, 0))
-        # "Or" should split the definition if the terms of simple
+        # "Or" should split the definition if the terms are simple
         self.assert_finds_result(
             '<E T="03">Frame or receiver.</E>. Paragraph text', 'Definition',
             def_finders.Ref('frame', None, 0),


### PR DESCRIPTION
Often, definitions will contain multiple, synonymous terms, separated by "or".
This splits those phrases apart into their component definitions. A challenge
here is that "or" isn't a good enough signifier (think of phrases like "red"
or green sign"). To accommodate, this only splits the phrase if all of the
subphrases are single words.

This also converts the keyterm definition search to be a straight parse
attempt. As we only care about the beginning of the line, we don't even need
to try at later parts of the string.

Resolves #65 and assists 18f/atf-eregs#127. Appears to work as intended for 27 CFR 478, 479, 555, 646