### PR TITLE
Provide a consistent sort order for Version object

### DIFF
--- a/regparser/history/versions.py
+++ b/regparser/history/versions.py
@@ -16,3 +16,9 @@ class Version(namedtuple('Version', ['identifier', 'published', 'effective'])):
             json_dict[key] = datetime.strptime(json_dict[key],
                                                '%Y-%m-%d').date()
         return Version(**json_dict)
+
+    def __lt__(self, other):
+        """We'd like to sort in a slightly different field order"""
+        left = (self.effective, self.published, self.identifier)
+        right = (other.effective, other.published, other.identifier)
+        return left < right

--- a/regparser/index/entry.py
+++ b/regparser/index/entry.py
@@ -100,8 +100,7 @@ class Version(Entry):
         """Deserialize all Version objects we're aware of."""
         versions = [(self / path).read()
                     for path in super(Version, self).__iter__()]
-        key = lambda version: (version.effective, version.published)
-        for version in sorted(versions, key=key):
+        for version in sorted(versions):
             yield version.identifier
 
 

--- a/tests/history_versions_tests.py
+++ b/tests/history_versions_tests.py
@@ -7,10 +7,10 @@ from regparser.history.versions import Version
 
 class HistoryVersionsTest(TestCase):
     def test_order(self):
-        v1 = Version('1111', date(2001, 1, 1), date(2001, 1, 1))
-        v2 = Version('2222', date(2001, 1, 1), date(2002, 2, 2))
-        v3 = Version('3333', date(2003, 3, 3), date(2002, 2, 2))
-        v4 = Version('4444', date(2003, 3, 3), date(2002, 2, 2))
+        v1 = Version('first', date(2001, 1, 1), date(2001, 1, 1))
+        v2 = Version('eff', date(2001, 1, 1), date(2002, 2, 2))
+        v3 = Version('pub', date(2003, 3, 3), date(2002, 2, 2))
+        v4 = Version('pub >id', date(2003, 3, 3), date(2002, 2, 2))
 
         for permutation in permutations([v1, v2, v3, v4]):
             self.assertEqual(sorted(permutation), [v1, v2, v3, v4])

--- a/tests/history_versions_tests.py
+++ b/tests/history_versions_tests.py
@@ -1,0 +1,16 @@
+from datetime import date
+from itertools import permutations
+from unittest import TestCase
+
+from regparser.history.versions import Version
+
+
+class HistoryVersionsTest(TestCase):
+    def test_order(self):
+        v1 = Version('1111', date(2001, 1, 1), date(2001, 1, 1))
+        v2 = Version('2222', date(2001, 1, 1), date(2002, 2, 2))
+        v3 = Version('3333', date(2003, 3, 3), date(2002, 2, 2))
+        v4 = Version('4444', date(2003, 3, 3), date(2002, 2, 2))
+
+        for permutation in permutations([v1, v2, v3, v4]):
+            self.assertEqual(sorted(permutation), [v1, v2, v3, v4])


### PR DESCRIPTION
We have been relying on a custom key function which looked at the effective
and publication dates for versions. Now that we've ran in to two notices
published on the same date with the same effective date, we need to also take
into consideration the document id (aka version id). This also moves the
sorting logic into the Version class.

Resolves #129