### PR TITLE
Handle TTITLE elements of GPOTABLEs as full-width header cells.

### DIFF
--- a/tests/layer_formatting_tests.py
+++ b/tests/layer_formatting_tests.py
@@ -6,7 +6,7 @@ from lxml import etree
 from regparser.layer import formatting
 from regparser.tree.struct import Node
 from tests.xml_builder import XMLBuilderMixin
-from regparser.notice import preprocessors
+from regparser.tree.xml_parser import preprocessors
 
 
 class LayerFormattingTests(XMLBuilderMixin, TestCase):


### PR DESCRIPTION
 This is an interim approach, as we should probably turn them into HTML caption elements in the UI. Fixes https://github.com/18F/atf-eregs/issues/105