### PR TITLE
Make preprocessing of <SU> (footnote) elements consistent

### DIFF
--- a/regparser/tree/xml_parser/preprocessors.py
+++ b/regparser/tree/xml_parser/preprocessors.py
@@ -199,7 +199,7 @@ class Footnotes(PreProcessorBase):
 
     def split_comma_footnotes(self, xml):
         """Convert XML such as <SU>1, 2, 3</SU> into distinct SU elements:
-        <SU>1</SU>, <SU>2</SU>, <SU>3</SU> for easier reference"""
+        <SU>1</SU> <SU>2</SU> <SU>3</SU> for easier reference"""
         for ref_xml in xml.xpath(self.XPATH_IS_REF):
             parent = ref_xml.getparent()
             idx_in_parent = parent.index(ref_xml)
@@ -207,6 +207,12 @@ class Footnotes(PreProcessorBase):
 
             refs = [txt.strip() for txt in re.split(r'[,|\s]+', ref_xml.text)]
             tail_texts = self._tails_corresponding_to(ref_xml, refs)
+
+            # Strip commas in the tails, but replace "," with " ".
+            def strip_comma(s):
+                return " " if s in (",", ", ") else s
+
+            tail_texts = [strip_comma(tail) for tail in tail_texts]
 
             for idx, (ref, tail) in enumerate(zip(refs, tail_texts)):
                 node = etree.Element("SU")

--- a/tests/tree_xml_parser_preprocessors_tests.py
+++ b/tests/tree_xml_parser_preprocessors_tests.py
@@ -249,17 +249,26 @@ class FootnotesTests(XMLBuilderMixin, TestCase):
     def test_split_comma_footnotes(self):
         """The XML will sometimes merge multiple references to footnotes into
         a single tag. Verify that they get split"""
-        with self.tree.builder("ROOT") as root:
-            root.P(_xml="Some content<SU>1</SU>")
-            root.P(_xml="More content<SU>2, 3, 4</SU>")
-            root.P(_xml="Last content<SU>5 6</SU>")
-
-        with self.assert_xml_transformed() as original_xml:
-            self.fn.split_comma_footnotes(original_xml)
+        def ftnt_compare(original, expected):
             with self.tree.builder("ROOT") as root:
-                root.P(_xml="Some content<SU>1</SU>")
-                root.P(_xml="More content<SU>2</SU>, <SU>3</SU>, <SU>4</SU>")
-                root.P(_xml="Last content<SU>5</SU> <SU>6</SU>")
+                root.P(_xml=original)
+
+            with self.assert_xml_transformed() as original_xml:
+                self.fn.split_comma_footnotes(original_xml)
+                with self.tree.builder("ROOT") as root:
+                    root.P(_xml=expected)
+
+        ftnt_compare("Some content<SU>1</SU>", "Some content<SU>1</SU>")
+        ftnt_compare("More content<SU>2, 3, 4</SU>",
+                     "More content<SU>2</SU> <SU>3</SU> <SU>4</SU>")
+        ftnt_compare("Even more content<SU>2,3,4</SU>",
+                     "Even more content<SU>2</SU> <SU>3</SU> <SU>4</SU>")
+        ftnt_compare("Yet more <SU>2</SU>, whatever<SU>3, 4</SU>",
+                     "Yet more <SU>2</SU>, whatever<SU>3</SU> <SU>4</SU>")
+        ftnt_compare("Penultimate content<SU>5 6</SU>",
+                     "Penultimate content<SU>5</SU> <SU>6</SU>")
+        ftnt_compare("Last content<SU>7</SU>, <SU>8</SU>",
+                     "Last content<SU>7</SU> <SU>8</SU>")
 
     def test_add_ref_attributes(self):
         """The XML elements which reference footnotes should be modified to


### PR DESCRIPTION
Separate the output with spaces. Fixes <https://github.com/18F/atf-eregs/issues/121>.