### PR TITLE
Use keyterm to derive a markerless identifier

### DIFF
--- a/regparser/tree/priority_stack.py
+++ b/regparser/tree/priority_stack.py
@@ -22,6 +22,7 @@ class PriorityStack(object):
         for layer in self.m_stack:
             if layer and layer[0][0] == level:
                 return [node for _, node in layer]
+        return []
 
     def peek_level_last(self, level):
         """Get the last from a level of nodes in the stack"""

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -61,6 +61,9 @@ class Node(object):
             return None
         return re.match(Node.MARKERLESS_REGEX, label[-1])
 
+    def is_markerless(self):
+        return bool(self.is_markerless_label(self.label))
+
 
 class NodeEncoder(JSONEncoder):
     """Custom JSON encoder to handle Node objects"""

--- a/tests/tree_xml_parser_paragraph_processor_tests.py
+++ b/tests/tree_xml_parser_paragraph_processor_tests.py
@@ -111,6 +111,12 @@ class ParagraphProcessorTest(TestCase):
         self.assertEqual(a.children[0].label, ['root', 'p1', 'a', 'p1'])
         self.assertEqual(b.label, ['root', 'p1', 'b'])
 
+    def test_keyterm_to_int(self):
+        """keyterm_to_int should standardize the keyterm"""
+        to_int = paragraph_processor.ParagraphProcessor.keyterm_to_int
+        self.assertEqual(to_int('Abc 123 More.'), to_int(' abc123 mOrE'))
+        self.assertTrue(to_int('a term') > 10000)
+
     def test_separate_intro_empty_nodes(self):
         """ Make sure separate_intro can handle an empty node list. """
         nodes = []

--- a/tests/tree_xml_parser_paragraph_processor_tests.py
+++ b/tests/tree_xml_parser_paragraph_processor_tests.py
@@ -108,7 +108,7 @@ class ParagraphProcessorTest(TestCase):
         a, b = p1.children
         self.assertEqual(a.label, ['root', 'p1', 'a'])
         self.assertEqual(len(a.children), 1)
-        self.assertEqual(a.children[0].label, ['root', 'p1', 'a', 'p2'])
+        self.assertEqual(a.children[0].label, ['root', 'p1', 'a', 'p1'])
         self.assertEqual(b.label, ['root', 'p1', 'b'])
 
     def test_separate_intro_empty_nodes(self):

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -697,5 +697,8 @@ class RegtextParagraphProcessorTests(XMLBuilderMixin, NodeAccessorMixin,
         root = reg_text.RegtextParagraphProcessor().process(xml, root)
         root = self.node_accessor(root, ['111', '22'])
 
-        self.assertEqual(['p1', 'p2'], root.child_labels)
-        self.assertEqual(['a', 'b'], root['p2'].child_labels)
+        self.assertEqual(2, len(root.child_labels))
+        self.assertTrue(all(c.is_markerless for c in root.children))
+        keyterm_label = root.child_labels[1]
+        self.assertTrue(len(keyterm_label) > 5)
+        self.assertEqual(['a', 'b'], root[keyterm_label].child_labels)


### PR DESCRIPTION
Thus far, we've been using an ever incrementing number to create unique
identifiers for markerless paragraphs. Unfortunately, when a paragraph is
inserted, every node after it is considered to have changed in this scheme.
This changeset uses a different approach, creating a unique identifier by
hashing the keyterm text.

See 18f/atf-eregs#123 for more context