### PR TITLE
Fixes bug where xml preprocessing explodes if there is no tail on the element

### DIFF
--- a/regparser/tree/xml_parser/preprocessors.py
+++ b/regparser/tree/xml_parser/preprocessors.py
@@ -96,7 +96,7 @@ class MoveAdjoiningChars(PreProcessorBase):
         # if an e tag has an emdash or period after it, put the
         # char inside the e tag
         for e in xml.xpath("//P/E"):
-            orphan = self.ORPHAN_REGEX.match(e.tail)
+            orphan = self.ORPHAN_REGEX.match(e.tail or '')
 
             if orphan:
                 e.text = e.text + orphan.group(1)

--- a/tests/tree_xml_parser_preprocessors_tests.py
+++ b/tests/tree_xml_parser_preprocessors_tests.py
@@ -126,6 +126,8 @@ class MoveAdjoiningCharsTests(XMLBuilderMixin, TestCase):
                                 '<E T="03">Things.</E> more things')
         self.assert_transformed('<E T="03">Things</E>. more things.',
                                 '<E T="03">Things.</E> more things.')
+        self.assert_transformed('<E T="03">Things</E>',
+                                '<E T="03">Things</E>')
 
 
 class ApprovalsFPTests(XMLBuilderMixin, TestCase):


### PR DESCRIPTION
Addresses https://github.com/18F/regulations-parser/pull/125/files#r46366640