### PR TITLE
Add a command to insert a paragraph in order

### DIFF
--- a/regparser/grammar/amdpar.py
+++ b/regparser/grammar/amdpar.py
@@ -3,7 +3,7 @@
 import logging
 import string
 
-from pyparsing import CaselessLiteral, FollowedBy, OneOrMore, Optional
+from pyparsing import CaselessLiteral, FollowedBy, Literal, OneOrMore, Optional
 from pyparsing import Suppress, Word, LineEnd, ZeroOrMore
 
 from regparser.grammar import atomic, tokens, unified
@@ -56,7 +56,6 @@ delete_passive = generate_verb(['removed'], tokens.Verb.DELETE, active=False)
 
 move_active = generate_verb(
     ['redesignating', 'redesignate'], tokens.Verb.MOVE, active=True)
-
 move_passive = generate_verb(['redesignated'], tokens.Verb.MOVE, active=False)
 
 designate_active = generate_verb(
@@ -65,6 +64,9 @@ designate_active = generate_verb(
 
 reserve_active = generate_verb(['reserve', 'reserving'],
                                tokens.Verb.RESERVE, active=True)
+
+insert_in_order = Literal("[insert-in-order]").setParseAction(
+    lambda m: tokens.Verb(tokens.Verb.INSERT, active=True))
 
 
 #   Context
@@ -429,12 +431,12 @@ override_label = (
     + Suppress("]")
     ).setParseAction(tokenize_override_ps)
 
-
 #   grammar which captures all of these possibilities
 token_patterns = (
     put_active | put_passive | post_active | post_passive
     | delete_active | delete_passive | move_active | move_passive
     | designate_active | reserve_active
+    | insert_in_order
 
     | interp | marker_subpart | appendix
     | comment_context_with_section | comment_context_without_section

--- a/regparser/grammar/amdpar.py
+++ b/regparser/grammar/amdpar.py
@@ -9,8 +9,8 @@ from pyparsing import (
 
 from regparser.grammar import atomic, tokens, unified
 from regparser.grammar.utils import Marker, WordBoundaries
+from regparser.layer.key_terms import keyterm_to_int
 from regparser.tree.paragraph import p_levels
-from regparser.tree.xml_parser.paragraph_processor import ParagraphProcessor
 
 
 intro_text_marker = (
@@ -426,8 +426,7 @@ def tokenize_override_ps(match):
 _keyterm_label_part = (
     Suppress(Marker("keyterm"))
     + QuotedString(quoteChar='(', endQuoteChar=')')
-).setParseAction(
-    lambda m: "p{}".format(ParagraphProcessor.keyterm_to_int(m[0])))
+).setParseAction(lambda m: "p{}".format(keyterm_to_int(m[0])))
 _simple_label_part = Word(string.ascii_lowercase + string.ascii_uppercase
                           + string.digits)
 _label_part = _keyterm_label_part | _simple_label_part

--- a/regparser/grammar/tokens.py
+++ b/regparser/grammar/tokens.py
@@ -52,6 +52,7 @@ class Verb(Token):
     DESIGNATE = 'DESIGNATE'
     RESERVE = 'RESERVE'
     KEEP = 'KEEP'
+    INSERT = 'INSERT'
 
     def __init__(self, verb, active, and_prefix=False):
         self.verb = verb

--- a/regparser/layer/key_terms.py
+++ b/regparser/layer/key_terms.py
@@ -1,7 +1,9 @@
+import hashlib
+import re
+
 from layer import Layer
 from regparser.layer.paragraph_markers import marker_of
 from regparser.layer.terms import Terms
-import re
 
 
 def eliminate_extras(keyterm):
@@ -14,6 +16,20 @@ def eliminate_extras(keyterm):
         if keyterm.endswith(extra):
             keyterm = keyterm[:-len(extra)]
     return keyterm
+
+
+_NONWORDS = re.compile(r'\W+')
+
+
+def keyterm_to_int(keyterm):
+    """Hash a keyterm's text and convert it into an integer. We'll trim to
+    just 8 hex characters for legibility. We don't need to fear hash
+    collisions as we'll have 16**8 ~ 4 billion possibilities. The birthday
+    paradox tells us we'd only expect collisions after ~ 60 thousand entries.
+    We're expecting at most a few hundred"""
+    phrase = _NONWORDS.sub('', keyterm.lower())
+    hashed = hashlib.sha1(phrase).hexdigest()[:8]
+    return int(hashed, 16)
 
 
 class KeyTerms(Layer):

--- a/regparser/notice/build.py
+++ b/regparser/notice/build.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import logging
 
 from lxml import etree
 
@@ -112,8 +113,9 @@ def create_xmlless_changes(amended_labels, notice_changes):
                 destination = [d for d in amendment['destination'] if d != '?']
                 change['destination'] = destination
                 notice_changes.update({label: change})
-            elif amendment['action'] not in ('POST', 'PUT', 'RESERVE'):
-                print 'NOT HANDLED: %s' % amendment['action']
+            elif amendment['action'] not in ('POST', 'PUT', 'RESERVE',
+                                             'INSERT'):
+                logging.warning("Unknown action: %s", amendment['action'])
 
 
 def create_xml_changes(amended_labels, section, notice_changes):
@@ -128,7 +130,7 @@ def create_xml_changes(amended_labels, section, notice_changes):
 
     for label, amendments in amend_map.iteritems():
         for amendment in amendments:
-            if amendment['action'] in ('POST', 'PUT'):
+            if amendment['action'] in ('POST', 'PUT', 'INSERT'):
                 if 'field' in amendment:
                     nodes = changes.create_field_amendment(label, amendment)
                 else:
@@ -139,7 +141,7 @@ def create_xml_changes(amended_labels, section, notice_changes):
                 change = changes.create_reserve_amendment(amendment)
                 notice_changes.update(change)
             elif amendment['action'] not in ('DELETE', 'MOVE'):
-                print 'NOT HANDLED: %s' % amendment['action']
+                logging.warning("Unknown action: %s", amendment['action'])
 
 
 class AmdparByParent(object):

--- a/regparser/notice/compiler.py
+++ b/regparser/notice/compiler.py
@@ -344,6 +344,14 @@ class RegulationTree(object):
                     parent.children, node, getattr(parent, 'child_labels',
                                                    []))
 
+    def insert_in_order(self, node):
+        """Add a new node, but determine its position in its parent by looking
+        at the siblings' texts"""
+        parent = self.get_parent(node)
+        texts = [child.text for child in parent.children]
+        insert_idx = bisect(texts, node.text)
+        parent.children.insert(insert_idx, node)
+
     def add_section(self, node, subpart_label):
         """ Add a new section to a subpart. """
 
@@ -475,8 +483,12 @@ def one_change(reg, label, change):
     elif change['action'] == 'RESERVE':
         node = dict_to_node(change['node'])
         reg.reserve(label, node)
+    elif change['action'] == 'INSERT':
+        node = dict_to_node(change['node'])
+        reg.insert_in_order(node)
     else:
-        print "%s: %s" % (change['action'], label)
+        logging.warning("Unsure how to compile with this action: %s @ %s",
+                        change['action'], label)
 
 
 def _needs_delay(reg, change):

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -1,9 +1,7 @@
 import abc
-import hashlib
 import logging
-import re
 
-from regparser.layer.key_terms import KeyTerms
+from regparser.layer.key_terms import KeyTerms, keyterm_to_int
 from regparser.layer.formatting import table_xml_to_plaintext
 from regparser.tree.depth import heuristics, markers as mtypes
 from regparser.tree.depth.derive import debug_idx, derive_depths
@@ -17,7 +15,6 @@ class ParagraphProcessor(object):
     compartmentalize processing with various tags. This is an abstract class;
     regtext, interpretations, appendices, etc. should inherit and override
     where needed"""
-    _NONWORDS = re.compile(r'\W+')
 
     # Subclasses should override the following interface
     MATCHERS = []
@@ -75,23 +72,12 @@ class ParagraphProcessor(object):
         node.label = [l.replace('<E T="03">', '').replace('</E>', '')
                       for l in node.label]
 
-    @staticmethod
-    def keyterm_to_int(keyterm):
-        """Hash a keyterm's text and convert it into an integer. We'll trim to
-        just 8 hex characters for legibility. We don't need to fear hash
-        collisions as we'll have 16**8 ~ 4 billion possibilities. The birthday
-        paradox tells us we'd only expect collisions after ~ 60 thousand
-        entries. We're expecting at most a few hundred"""
-        phrase = ParagraphProcessor._NONWORDS.sub('', keyterm.lower())
-        hashed = hashlib.sha1(phrase).hexdigest()[:8]
-        return int(hashed, 16)
-
     def replace_markerless(self, stack, node, depth):
         """Assign a unique index to all of the MARKERLESS paragraphs"""
         if node.label[-1] == mtypes.MARKERLESS:
             keyterm = KeyTerms.get_keyterm(node, ignore_definitions=False)
             if keyterm:
-                p_num = self.keyterm_to_int(keyterm)
+                p_num = keyterm_to_int(keyterm)
             else:
                 # len(n.label[-1]) < 6 filters out keyterm nodes
                 p_num = sum(n.is_markerless() and len(n.label[-1]) < 6

--- a/tests/grammar_amdpar_tests.py
+++ b/tests/grammar_amdpar_tests.py
@@ -511,3 +511,14 @@ class GrammarAmdParTests(TestCase):
             tokens.Paragraph(['1002', 'Appendix:A', 'p1', '2', 'd'],
                              field=None)
         ])
+
+    def test_insert_in_order(self):
+        text = ('11. [label:1234-123-p123456789] is removed. '
+                '[insert-in-order] [label:1234-123-p987654321]')
+        result = parse_text(text)
+        self.assertEqual(result, [
+            tokens.Paragraph(['1234', '123', 'p123456789'], field=None),
+            tokens.Verb(tokens.Verb.DELETE, active=False, and_prefix=False),
+            tokens.Verb(tokens.Verb.INSERT, active=True, and_prefix=False),
+            tokens.Paragraph(['1234', '123', 'p987654321'], field=None)
+        ])

--- a/tests/grammar_amdpar_tests.py
+++ b/tests/grammar_amdpar_tests.py
@@ -1,4 +1,5 @@
 # vim: set encoding=utf-8
+import re
 from unittest import TestCase
 
 from regparser.grammar import amdpar, tokens
@@ -522,3 +523,16 @@ class GrammarAmdParTests(TestCase):
             tokens.Verb(tokens.Verb.INSERT, active=True, and_prefix=False),
             tokens.Paragraph(['1234', '123', 'p987654321'], field=None)
         ])
+
+    def test_keyterm_label(self):
+        """Explicit labels can be defined by their keyterms"""
+        text = '1. [label:123-45-p6] [label:111-22-a-keyterm(some term)]'
+        result = parse_text(text)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(tokens.Paragraph(['123', '45', 'p6']), result[0])
+        self.assertTrue(isinstance(result[1], tokens.Paragraph))
+        self.assertEqual(4, len(result[1].label))
+        self.assertEqual(['111', '22', 'a'], result[1].label[:3])
+        label = result[1].label[-1]
+        self.assertTrue(re.match(r'p\d+', label))
+        self.assertTrue(len(label) > 5)

--- a/tests/layer_keyterms_tests.py
+++ b/tests/layer_keyterms_tests.py
@@ -1,7 +1,7 @@
 # vim: set fileencoding=utf-8
 from unittest import TestCase
 
-from regparser.layer.key_terms import KeyTerms
+from regparser.layer.key_terms import KeyTerms, keyterm_to_int
 from regparser.tree.struct import Node
 
 
@@ -124,3 +124,9 @@ class LayerKeyTermTest(TestCase):
         kt = KeyTerms(None)
         results = kt.process(node)
         self.assertEqual('Apples.', results[0]['key_term'])
+
+    def test_keyterm_to_int(self):
+        """keyterm_to_int should standardize the keyterm"""
+        self.assertEqual(keyterm_to_int('Abc 123 More.'),
+                         keyterm_to_int(' abc123 mOrE'))
+        self.assertTrue(keyterm_to_int('a term') > 10000)

--- a/tests/notice_build_tests.py
+++ b/tests/notice_build_tests.py
@@ -377,6 +377,24 @@ class NoticeBuildTest(XMLBuilderMixin, TestCase):
         self.assertEqual(['106', '1', 'a'], amd1.label)
         self.assertEqual(['106', 'C'], amd2.label)
 
+    def test_process_amendments_insert_in_order(self):
+        with self.tree.builder("ROOT") as root:
+            with root.REGTEXT(TITLE="10") as regtext:
+                regtext.AMDPAR('[insert-in-order] [label:123-45-p6]')
+                with regtext.SECTION() as section:
+                    section.SECTNO(u"§ 123.45")
+                    section.SUBJECT("Some Subject.")
+                    section.STARS()
+                    section.P("This is the sixth paragraph")
+                    section.STARS()
+        notice = {'cfr_parts': ['123']}
+        build.process_amendments(notice, self.tree.render_xml())
+
+        self.assertEqual(1, len(notice['amendments']))
+        amendment = notice['amendments'][0]
+        self.assertEqual(['123', '45', 'p6'], amendment.label)
+        self.assertEqual('INSERT', amendment.action)
+
     def test_introductory_text(self):
         """ Sometimes notices change just the introductory text of a paragraph
         (instead of changing the entire paragraph tree).  """

--- a/tests/notice_compiler_tests.py
+++ b/tests/notice_compiler_tests.py
@@ -1,4 +1,5 @@
 # vim: set encoding=utf-8
+from random import randint
 from unittest import TestCase
 
 from regparser.notice import compiler
@@ -157,6 +158,27 @@ class CompilerTests(TestCase):
         children = [n1, n2]
         children = reg_tree.add_child(children, n4, order)
         self.assertEqual(children, [n1, n2, n4])
+
+    def test_insert_in_order(self):
+        """Verify that nodes are added in their alphabetic position. We should
+        be accommodating for some fuzziness"""
+        root = Node(label=['111'],
+                    children=[Node(char, label=['111', str(randint(0, 999))])
+                              for char in "abcdefghi"])
+        root.children.insert(7, Node('diff', label=['111', 'diff']))
+        reg_tree = compiler.RegulationTree(root)
+        self.assertEqual(
+            [child.text for child in reg_tree.tree.children],
+            ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'diff', 'h', 'i'])
+
+        reg_tree.insert_in_order(Node('bb', label=['111', 'bb']))
+        self.assertEqual(
+            [child.text for child in reg_tree.tree.children],
+            ['a', 'b', 'bb', 'c', 'd', 'e', 'f', 'g', 'diff', 'h', 'i'])
+        reg_tree.insert_in_order(Node('ii', label=['111', 'ii']))
+        self.assertEqual(
+            [child.text for child in reg_tree.tree.children],
+            ['a', 'b', 'bb', 'c', 'd', 'e', 'f', 'g', 'diff', 'h', 'i', 'ii'])
 
     def tree_with_paragraphs(self):
         n1 = Node('n1', label=['205', '1'])

--- a/tests/tree_xml_parser_paragraph_processor_tests.py
+++ b/tests/tree_xml_parser_paragraph_processor_tests.py
@@ -111,12 +111,6 @@ class ParagraphProcessorTest(TestCase):
         self.assertEqual(a.children[0].label, ['root', 'p1', 'a', 'p1'])
         self.assertEqual(b.label, ['root', 'p1', 'b'])
 
-    def test_keyterm_to_int(self):
-        """keyterm_to_int should standardize the keyterm"""
-        to_int = paragraph_processor.ParagraphProcessor.keyterm_to_int
-        self.assertEqual(to_int('Abc 123 More.'), to_int(' abc123 mOrE'))
-        self.assertTrue(to_int('a term') > 10000)
-
     def test_separate_intro_empty_nodes(self):
         """ Make sure separate_intro can handle an empty node list. """
         nodes = []


### PR DESCRIPTION
This will be particularly useful when we have a section of definitions where a new definition is added. Further, this PR adds the ability for labels to be described in terms of their contained keyterms, which should make referencing them much easier and give us some flexibility to swap out the underlying hashing mechanic.

For example, we might have the instruction

> Section 478.11 is amended by adding a definition for the term “Nonimmigrant visa” in alphabetical order to read as follows:

Until now there'd be no way to do that without copy-pasting the entirety of 478.11. With this changeset, however, we can say:

>  [insert-in-order] [label:478-11-keyterm(Nonimmigrant visa)]

See changeset comments for more. Resolves 18f/atf-eregs#148