### PR TITLE
Depth parsing speedups

### DIFF
--- a/regparser/tree/depth/derive.py
+++ b/regparser/tree/depth/derive.py
@@ -119,8 +119,7 @@ def derive_depths(original_markers, additional_constraints=[]):
 
         if idx > 1:
             pairs = all_vars[3*(idx-2):]
-            problem.addConstraint(rules.markerless_sandwich, pairs)
-            problem.addConstraint(rules.star_sandwich, pairs)
+            problem.addConstraint(rules.triplet_tests, pairs)
 
     # separate loop so that the simpler checks run first
     for idx in range(1, len(marker_list)):

--- a/regparser/tree/depth/optional_rules.py
+++ b/regparser/tree/depth/optional_rules.py
@@ -1,0 +1,40 @@
+"""Depth derivation has a mechanism for _optional_ rules. This module contains
+a collection of such rules. All functions should accept two parameters; the
+latter is a list of all variables in the system; the former is a function
+which can be used to constrain the variables. This allows us to define rules
+over subsets of the variables rather than all of them, should that make our
+constraints more useful"""
+from regparser.tree.depth import markers
+
+
+def depth_type_inverses(constrain, all_variables):
+    """If paragraphs are at the same depth, they must share the same type. If
+    paragraphs are the same type, they must share the same depth"""
+    def inner(typ, idx, depth, *all_prev):
+        if typ == markers.stars or typ == markers.markerless:
+            return True
+        for i in range(0, len(all_prev), 3):
+            prev_typ, prev_idx, prev_depth = all_prev[i:i+3]
+            if prev_depth == depth and prev_typ not in (markers.stars, typ,
+                                                        markers.markerless):
+                return False
+            if prev_typ == typ and prev_depth != depth:
+                return False
+        return True
+
+    for i in range(0, len(all_variables), 3):
+        constrain(inner, all_variables[i:i+3] + all_variables[:i])
+
+
+def star_new_level(constrain, all_variables):
+    """STARS should never have subparagraphs as it'd be impossible to
+    determine where in the hierarchy these subparagraphs belong.
+    @todo: This _probably_ should be a general rule, but there's a test that
+    this breaks in the interpretations. Revisit with CFPB regs"""
+    def inner(prev_typ, prev_depth, typ, depth):
+        return not (prev_typ == markers.stars and depth == prev_depth + 1)
+
+    for i in range(3, len(all_variables), 3):
+        prev_typ, prev_depth = all_variables[i - 3], all_variables[i - 1]
+        typ, depth = all_variables[i], all_variables[i + 2]
+        constrain(inner, [prev_typ, prev_depth, typ, depth])

--- a/regparser/tree/depth/rules.py
+++ b/regparser/tree/depth/rules.py
@@ -192,25 +192,6 @@ def depth_type_order(order):
     return inner
 
 
-def depth_type_inverses(constrain, all_variables):
-    """If paragraphs are at the same depth, they must share the same type. If
-    paragraphs are the same type, they must share the same depth"""
-    def inner(typ, idx, depth, *all_prev):
-        if typ == markers.stars or typ == markers.markerless:
-            return True
-        for i in range(0, len(all_prev), 3):
-            prev_typ, prev_idx, prev_depth = all_prev[i:i+3]
-            if prev_depth == depth and prev_typ not in (markers.stars, typ,
-                                                        markers.markerless):
-                return False
-            if prev_typ == typ and prev_depth != depth:
-                return False
-        return True
-
-    for i in range(0, len(all_variables), 3):
-        constrain(inner, all_variables[i:i+3] + all_variables[:i])
-
-
 def _ancestors(all_prev):
     """Given an assignment of values, construct a list of the relevant
     parents, e.g. 1, i, a, ii, A gives us 1, ii, A"""

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -4,7 +4,7 @@ import re
 from lxml import etree
 
 from regparser import content
-from regparser.tree.depth import markers as mtypes, rules
+from regparser.tree.depth import markers as mtypes, optional_rules
 from regparser.tree.struct import Node
 from regparser.tree.paragraph import p_level_of, p_levels
 from regparser.tree.xml_parser import (flatsubtree_processor,
@@ -304,4 +304,5 @@ class RegtextParagraphProcessor(paragraph_processor.ParagraphProcessor):
                 ParagraphMatcher()]
 
     def additional_constraints(self):
-        return [rules.depth_type_inverses]
+        return [optional_rules.depth_type_inverses,
+                optional_rules.star_new_level]

--- a/tests/tree_depth_derive_tests.py
+++ b/tests/tree_depth_derive_tests.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from regparser.tree.depth import markers, rules
+from regparser.tree.depth import markers, optional_rules, rules
 from regparser.tree.depth.derive import debug_idx, derive_depths
 from regparser.tree.depth.markers import INLINE_STARS, MARKERLESS, STARS_TAG
 
@@ -149,7 +149,7 @@ class DeriveTests(TestCase):
 
         self.assert_depth_match_extra(
             ['1', STARS_TAG, 'b', STARS_TAG, 'C', STARS_TAG, 'd'],
-            [rules.depth_type_inverses],
+            [optional_rules.depth_type_inverses],
             [0, 1, 1, 2, 2, 1, 1])
 
     def test_depth_type_inverses_d2t(self):
@@ -161,15 +161,29 @@ class DeriveTests(TestCase):
 
         self.assert_depth_match_extra(
             ['1', STARS_TAG, 'c', '2', INLINE_STARS, 'i', STARS_TAG, 'iii'],
-            [rules.depth_type_inverses],
+            [optional_rules.depth_type_inverses],
             [0, 1, 1, 0, 1, 1, 2, 2])
 
     def test_depth_type_inverses_markerless(self):
         """Markerless paragraphs should not trigger an incompatibility"""
         self.assert_depth_match_extra(
             ['1', MARKERLESS, '2', 'a'],
-            [rules.depth_type_inverses],
+            [optional_rules.depth_type_inverses],
             [0, 1, 0, 1])
+
+    def test_star_new_level(self):
+        """STARS shouldn't have subparagraphs"""
+        self.assert_depth_match(
+            ['a', STARS_TAG, 'i'],
+            [0, 0, 0],
+            [0, 0, 1]
+        )
+
+        self.assert_depth_match_extra(
+            ['a', STARS_TAG, 'i'],
+            [optional_rules.star_new_level],
+            [0, 0, 0]
+        )
 
     def test_debug_idx(self):
         """Find the index of the first error when attempting to derive
@@ -178,4 +192,6 @@ class DeriveTests(TestCase):
         self.assertEqual(debug_idx(['1', '4']), 1)
         self.assertEqual(debug_idx(['1', '2', '4']), 2)
         self.assertEqual(
-            debug_idx(['1', 'a', '2', 'A'], [rules.depth_type_inverses]), 3)
+            debug_idx(['1', 'a', '2', 'A'],
+                      [optional_rules.depth_type_inverses]),
+            3)

--- a/tests/tree_depth_derive_tests.py
+++ b/tests/tree_depth_derive_tests.py
@@ -185,6 +185,19 @@ class DeriveTests(TestCase):
             [0, 0, 0]
         )
 
+    def test_marker_stars_markerless_symmetry(self):
+        self.assert_depth_match(
+            [MARKERLESS, 'a', STARS_TAG, MARKERLESS],
+            [0, 1, 1, 0],
+            [0, 1, 2, 2],
+            [0, 1, 1, 2]
+        )
+
+    def test_markerless_stars_symmetry(self):
+        self.assert_depth_match(
+            [MARKERLESS, STARS_TAG, MARKERLESS],
+            [0, 0, 0])
+
     def test_debug_idx(self):
         """Find the index of the first error when attempting to derive
         depths"""


### PR DESCRIPTION
Assists (maybe resolves?) 18f/atf-eregs#84. This adds a few new rules to depth parsing which removes some symmetries and cases we should ignore. See changesets for specifics.

This speeds up `nosetests` by a few seconds for me and processes the list in 84 in ~1 minute on my machine. Obviously not ideal, but workable, at least.