### PR TITLE
Rework compare_to interface

### DIFF
--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -152,11 +152,10 @@ Tools
 * ``clear`` - Removes content from the index. Useful if you have tweaked the
   parser's workings. Additional parameters can describe specific directories
   you would like to remove.
-* ``compare_to`` - Once the index has been populated, this command can be used
-  to compare what your local output would be to a known copy, as stored in an
-  instance of ``regulations-core`` (the API). This command will compare the
-  requested JSON files and provide an interface for seeing the differences, if
-  present.
+* ``compare_to`` - This command compares a set of local JSON files with a
+  known copy, as stored in an instance of ``regulations-core`` (the API). The
+  command will compare the requested JSON files and provide an interface for
+  seeing the differences, if present.
 
 Legacy Commands
 ---------------


### PR DESCRIPTION
Previously, `compare_to` required a CFR title and part as it called the
`write_to` function. It made its comparisons by writing all of the JSON output
to a temporary directory and walking that directory for comparisons.

This patch changes that interface so that it compares _any_ arbitrary local
JSON to a remote service. This is useful as it:

1. doesn't need to duplicate all of the JSON files. This isn't a problem for
smaller regs, but could pose issues for larger regs with many versions
2. doesn't restrict us to comparing a single regulation
3. removes the coupling with write_to
4. allows us use glob syntax for defining what to compare