### PR TITLE
Allow subscripts to follow more letters

### DIFF
--- a/regparser/layer/formatting.py
+++ b/regparser/layer/formatting.py
@@ -218,11 +218,10 @@ class FencedData(PlaintextFormatData):
 
 class Subscript(PlaintextFormatData):
     """E.g.     a_{0}"""
-    REGEX = re.compile(r"(?P<variable>[a-zA-Z0-9]+)_\{(?P<subscript>\w+)\}")
+    REGEX = re.compile(r"(?<=[a-zA-Z0-9)])_\{(?P<subscript>\w+)\}")
 
     def match_data(self, match):
-        return {'subscript_data': {'variable': match.group('variable'),
-                                   'subscript': match.group('subscript')}}
+        return {'subscript_data': {'subscript': match.group('subscript')}}
 
 
 class Dashes(PlaintextFormatData):

--- a/tests/layer_formatting_tests.py
+++ b/tests/layer_formatting_tests.py
@@ -396,10 +396,25 @@ class SubscriptTests(TestCase):
         result = list(formatting.Subscript().process(text))
         self.assertEqual(1, len(result))
         result = result[0]
-        self.assertEqual(result['text'], "a_{subscript}")
-        self.assertEqual(result['locations'], [0, 1])
-        self.assertEqual(result['subscript_data'],
-                         {'variable': 'a', 'subscript': 'subscript'})
+        self.assertEqual(
+            result, {'text': '_{subscript}', 'locations': [0, 1],
+                     'subscript_data': {'subscript': 'subscript'}})
+
+    def test_process_parens(self):
+        """Example from 27 CFR 555.180(d)(3)(ii)"""
+        text = ("(ii) 2,3-Dimethyl-2,3-dinitrobutane (DMNB), C_{6} H_{12} "
+                "(NO_{2})_{2}, molecular weight 176, when the minimum "
+                "concentration in the finished explosive is 0.1 percent by "
+                "mass;")
+        result = list(formatting.Subscript().process(text))
+        self.assertEqual(3, len(result))
+        twelve, two, six = sorted(result, key=lambda d: d['text'])
+        self.assertEqual(six, {'text': '_{6}', 'locations': [0],
+                               'subscript_data': {'subscript': '6'}})
+        self.assertEqual(twelve, {'text': '_{12}', 'locations': [0],
+                                  'subscript_data': {'subscript': '12'}})
+        self.assertEqual(two, {'text': '_{2}', 'locations': [0, 1],
+                               'subscript_data': {'subscript': '2'}})
 
 
 class DashesTests(TestCase):


### PR DESCRIPTION
Subscripts used to require that the letter immediately preceding the subscript
be a letter or number. We now also accept the closing paren character. More
importantly, this drops support for the "variable" data field. Although that
information could be useful, trying to figure out nested parentheses isn't
worth the effort.

This change is backwards compatible; -site, which renders the data _was_
converting the text `variable_{subscript}` into `{{variable}}<sub>{{subscript}}</sub>`.
Now we're only giving it `_{subscript}` and leaving the "variable" empty.

For 18f/atf-eregs#155