### PR TITLE
Superscripts

### DIFF
--- a/regparser/layer/formatting.py
+++ b/regparser/layer/formatting.py
@@ -218,7 +218,7 @@ class FencedData(PlaintextFormatData):
 
 class Subscript(PlaintextFormatData):
     """E.g.     a_{0}"""
-    REGEX = re.compile(r"(?<=[a-zA-Z0-9)])_\{(?P<subscript>\w+)\}")
+    REGEX = re.compile(r"_\{(?P<subscript>[^\}]+)\}")
 
     def match_data(self, match):
         return {'subscript_data': {'subscript': match.group('subscript')}}
@@ -226,7 +226,7 @@ class Subscript(PlaintextFormatData):
 
 class Superscript(PlaintextFormatData):
     """E.g.     x^{2}"""
-    REGEX = re.compile(r"(?<=[a-zA-Z0-0)])\^\{(?P<superscript>\w+)\}")
+    REGEX = re.compile(r"\^\{(?P<superscript>[^\}]+)\}")
 
     def match_data(self, match):
         return {

--- a/regparser/layer/formatting.py
+++ b/regparser/layer/formatting.py
@@ -224,6 +224,15 @@ class Subscript(PlaintextFormatData):
         return {'subscript_data': {'subscript': match.group('subscript')}}
 
 
+class Superscript(PlaintextFormatData):
+    """E.g.     x^{2}"""
+    REGEX = re.compile(r"(?<=[a-zA-Z0-0)])\^\{(?P<superscript>\w+)\}")
+
+    def match_data(self, match):
+        return {
+            'superscript_data': {'superscript': match.group('superscript')}}
+
+
 class Dashes(PlaintextFormatData):
     """E.g.     Some text some text_____"""
     REGEX = re.compile(r"(?P<text>.*)(?P<dashes>_{5,})$")

--- a/regparser/tree/xml_parser/preprocessors.py
+++ b/regparser/tree/xml_parser/preprocessors.py
@@ -8,7 +8,8 @@ import re
 
 from lxml import etree
 
-from regparser.tree.xml_parser.tree_utils import get_node_text
+from regparser.tree.xml_parser.tree_utils import (
+    get_node_text, replace_xml_node_with_text)
 
 
 class PreProcessorBase(object):
@@ -270,7 +271,7 @@ class Footnotes(PreProcessorBase):
                 note = deepcopy(sus[0].getparent())
                 # Modify note to remove the reference text; it's superfluous
                 for su in note.xpath('./SU'):
-                    su.text = ''
+                    replace_xml_node_with_text(su, su.tail or '')
                 ref.attrib['footnote'] = get_node_text(note).strip()
 
 

--- a/tests/layer_formatting_tests.py
+++ b/tests/layer_formatting_tests.py
@@ -427,6 +427,15 @@ class SuperscriptTests(TestCase):
             result, {'text': '^{superscript}', 'locations': [0, 1],
                      'superscript_data': {'superscript': 'superscript'}})
 
+    def test_process_emdash(self):
+        text = u"This is an^{−emdash}"
+        result = list(formatting.Superscript().process(text))
+        self.assertEqual(1, len(result))
+        result = result[0]
+        self.assertEqual(
+            result, {'text': u'^{−emdash}', 'locations': [0],
+                     'superscript_data': {'superscript': u'−emdash'}})
+
 
 class DashesTests(TestCase):
     def test_process(self):

--- a/tests/layer_formatting_tests.py
+++ b/tests/layer_formatting_tests.py
@@ -417,6 +417,17 @@ class SubscriptTests(TestCase):
                                'subscript_data': {'subscript': '2'}})
 
 
+class SuperscriptTests(TestCase):
+    def test_process(self):
+        text = "This is a^{superscript}. And then another^{superscript} again"
+        result = list(formatting.Superscript().process(text))
+        self.assertEqual(1, len(result))
+        result = result[0]
+        self.assertEqual(
+            result, {'text': '^{superscript}', 'locations': [0, 1],
+                     'superscript_data': {'superscript': 'superscript'}})
+
+
 class DashesTests(TestCase):
     def test_process(self):
         text = "This is an fp-dash_____"

--- a/tests/tree_utils_tests.py
+++ b/tests/tree_utils_tests.py
@@ -108,6 +108,12 @@ class TreeUtilsTest(unittest.TestCase):
         self.assert_transform_equality(
             '<P>Note<SU footnote="(parens), see">note</SU> that</P>',
             r'Note[^note](\(parens\), see) that', *no_space)
+        self.assert_transform_equality(
+            '<P>y = x<E T="52">0</E> + mx<E T="51">2</E></P>',
+            'y = x_{0} + mx^{2}', *no_space)
+        self.assert_transform_equality(
+            '<P>y = x<E T="52">0</E> + mx<SU>2</SU></P>',
+            'y = x_{0} + mx^{2}', *no_space)
 
     def test_unwind_stack(self):
         level_one_n = Node(label=['272'])

--- a/tests/tree_xml_parser_preprocessors_tests.py
+++ b/tests/tree_xml_parser_preprocessors_tests.py
@@ -328,15 +328,21 @@ class FootnotesTests(XMLBuilderMixin, TestCase):
                     ftnt.P(_xml="<SU>2</SU> note for two")
 
     def test_add_ref_attributes_missing(self):
-        """We should log a message when a footnote cannot be found"""
+        """SUs in different sections aren't related"""
         with self.tree.builder("ROOT") as root:
-            root.SU("1")
-            with root.FTNT() as ftnt:
-                ftnt.P(_xml="<SU>2</SU> note for two")
+            with root.SECTION() as section:
+                root.SU("1")
+            with root.SECTION() as section:
+                root.SU("1")
+                with root.FTNT() as ftnt:
+                    ftnt.P(_xml="<SU>2</SU> note for two")
 
         with self.assert_xml_transformed() as original_xml:
-            # @todo self.assertLogs has been added in Python 3.4
-            logging = 'regparser.tree.xml_parser.preprocessors.logging'
-            with patch(logging) as logging:
-                self.fn.add_ref_attributes(original_xml)
-                self.assertTrue(logging.warning.called)
+            self.fn.add_ref_attributes(original_xml)
+            with self.tree.builder("ROOT") as root:
+                with root.SECTION() as section:
+                    section.SU("1")
+                with root.SECTION() as section:
+                    section.SU("1", footnote="note for 1")
+                    with section.FTNT() as ftnt:
+                        ftnt.P(_xml="<SU>1</SU> note for one")

--- a/tests/tree_xml_parser_preprocessors_tests.py
+++ b/tests/tree_xml_parser_preprocessors_tests.py
@@ -2,7 +2,6 @@
 from unittest import TestCase
 
 from lxml import etree
-from mock import patch
 
 from regparser.tree.xml_parser import preprocessors
 from tests.xml_builder import XMLBuilderMixin
@@ -331,11 +330,11 @@ class FootnotesTests(XMLBuilderMixin, TestCase):
         """SUs in different sections aren't related"""
         with self.tree.builder("ROOT") as root:
             with root.SECTION() as section:
-                root.SU("1")
+                section.SU("1")
             with root.SECTION() as section:
-                root.SU("1")
-                with root.FTNT() as ftnt:
-                    ftnt.P(_xml="<SU>2</SU> note for two")
+                section.SU("1")
+                with section.FTNT() as ftnt:
+                    ftnt.P(_xml="<SU>1</SU> note for one")
 
         with self.assert_xml_transformed() as original_xml:
             self.fn.add_ref_attributes(original_xml)
@@ -343,6 +342,6 @@ class FootnotesTests(XMLBuilderMixin, TestCase):
                 with root.SECTION() as section:
                     section.SU("1")
                 with root.SECTION() as section:
-                    section.SU("1", footnote="note for 1")
+                    section.SU("1", footnote="note for one")
                     with section.FTNT() as ftnt:
                         ftnt.P(_xml="<SU>1</SU> note for one")


### PR DESCRIPTION
This adds a superscript conversion/layer very similar to our existing subscripts. While superscripts can be signified by `<E T='51'>`, we must also account for `<SU>`s, which are complicated by their dual use with footnotes. To resolve this, we check if potential footnotes and their referenced text both live in the same `<SECTION>`

Also splits out a few helper functions from `get_node_text` and makes the subscript regex more lenient.

This kicks the can down the road regarding using a real markup language. For 18f/atf-eregs#155, though we still need a few changes in the UI to make use of this data