### PR TITLE
Gimme the latest!

### DIFF
--- a/regparser/commands/current_version.py
+++ b/regparser/commands/current_version.py
@@ -1,0 +1,63 @@
+from datetime import date
+
+import click
+
+from regparser.history.annual import find_volume
+from regparser.history.versions import Version
+from regparser.index import dependency, entry
+from regparser.notice.fake import build as build_fake_notice
+from regparser.tree import xml_parser
+
+
+_version_id = '{}-annual-{}'.format
+
+
+def process_if_needed(cfr_title, cfr_part, year):
+    """Review dependencies; if they're out of date, parse the annual edition
+    into a tree and store that"""
+    version_id = _version_id(year, cfr_part)
+    annual_entry = entry.Annual(cfr_title, cfr_part, year)
+    tree_entry = entry.Tree(cfr_title, cfr_part, version_id)
+    # This is a little odd, but we use SxS as a source for "notice" data. This
+    # will eventually be removed in favor of storing the version meta data
+    # directly
+    sxs_entry = entry.SxS(version_id)
+
+    deps = dependency.Graph()
+    deps.add(tree_entry, annual_entry)
+    deps.validate_for(tree_entry)
+    if deps.is_stale(tree_entry):
+        tree = xml_parser.reg_text.build_tree(annual_entry.read().xml)
+        tree_entry.write(tree)
+        sxs_entry.write(build_fake_notice(
+            version_id, date.today().isoformat(), cfr_title, cfr_part))
+
+
+def create_version_entry_if_needed(cfr_title, cfr_part, year):
+    """Only write the version entry if it doesn't already exist. If we
+    overwrote one, we'd be invalidating all related trees, etc."""
+    version_id = _version_id(year, cfr_part)
+    version_entries = entry.Version(cfr_title, cfr_part)
+
+    if version_id not in version_entries:
+        (version_entries / version_id).write(
+            Version(identifier=version_id, effective=date.today(),
+                    published=date.today()))
+
+
+@click.command()
+@click.argument('cfr_title', type=int)
+@click.argument('cfr_part', type=int)
+def current_version(cfr_title, cfr_part):
+    """Build a regulation tree for the most recent annual edition. This will
+    also construct a corresponding, empty notice to match. The version will be
+    marked as effective _today_"""
+
+    year = date.today().year
+    vol = find_volume(year, cfr_title, cfr_part)
+    if vol is None:
+        year -= 1
+        vol = find_volume(year, cfr_title, cfr_part)
+
+    create_version_entry_if_needed(cfr_title, cfr_part, year)
+    process_if_needed(cfr_title, cfr_part, year)

--- a/regparser/commands/pipeline.py
+++ b/regparser/commands/pipeline.py
@@ -1,20 +1,23 @@
 import click
 
-from regparser.commands.versions import versions
 from regparser.commands.annual_editions import annual_editions
+from regparser.commands.current_version import current_version
+from regparser.commands.diffs import diffs
 from regparser.commands.fill_with_rules import fill_with_rules
 from regparser.commands.layers import layers
-from regparser.commands.diffs import diffs
-from regparser.commands.write_to import write_to
 from regparser.commands.sync_xml import sync_xml
+from regparser.commands.versions import versions
+from regparser.commands.write_to import write_to
 
 
 @click.command()
 @click.argument('cfr_title', type=int)
 @click.argument('cfr_part', type=int)
 @click.argument('output')
+@click.option('--only-latest', is_flag=True, default=False,
+              help="Don't derive history; use the latest annual edition")
 @click.pass_context
-def pipeline(ctx, cfr_title, cfr_part, output):
+def pipeline(ctx, cfr_title, cfr_part, output, only_latest):
     """Full regulation parsing pipeline. Consists of retrieving and parsing
     annual edition, attempting to parse final rules in between, deriving
     layers and diffs, and writing them to disk or an API
@@ -27,9 +30,12 @@ def pipeline(ctx, cfr_title, cfr_part, output):
       repository"""
     params = {'cfr_title': cfr_title, 'cfr_part': cfr_part}
     ctx.invoke(sync_xml)
-    ctx.invoke(versions, **params)
-    ctx.invoke(annual_editions, **params)
-    ctx.invoke(fill_with_rules, **params)
+    if only_latest:
+        ctx.invoke(current_version, **params)
+    else:
+        ctx.invoke(versions, **params)
+        ctx.invoke(annual_editions, **params)
+        ctx.invoke(fill_with_rules, **params)
     ctx.invoke(layers, **params)
     ctx.invoke(diffs, **params)
-    ctx.forward(write_to)
+    ctx.invoke(write_to, output=output, **params)

--- a/tests/commands_current_version_tests.py
+++ b/tests/commands_current_version_tests.py
@@ -1,0 +1,58 @@
+from datetime import date
+import json
+from random import randint
+from unittest import TestCase
+
+from click.testing import CliRunner
+from mock import patch
+
+from regparser.commands import current_version
+from regparser.index import entry
+
+
+class CommandsCurrentVersionTests(TestCase):
+    def setUp(self):
+        self.title = randint(1, 999)
+        self.part = randint(1, 999)
+        self.year = randint(2000, 2020)
+        self.version_id = '{}-annual-{}'.format(self.year, self.part)
+
+    def test_process_creation(self):
+        """If no tree is present, we should build one"""
+        to_patch = 'regparser.commands.current_version.xml_parser'
+        with CliRunner().isolated_filesystem(), patch(to_patch) as xml_parser:
+            entry.Entry('annual', self.title, self.part, self.year).write(
+                '<ROOT />')
+
+            xml_parser.reg_text.build_tree.return_value = {'my': 'tree'}
+            current_version.process_if_needed(self.title, self.part, self.year)
+            tree = entry.Entry('tree', self.title, self.part,
+                               self.version_id).read()
+            self.assertEqual(json.loads(tree), {'my': 'tree'})
+            notice = entry.SxS(self.version_id).read()
+            self.assertEqual(notice['document_number'], self.version_id)
+            self.assertEqual(notice['cfr_parts'], [self.part])
+
+    def test_process_no_need_to_create(self):
+        """If everything is up to date, we don't need to build new versions"""
+        with CliRunner().isolated_filesystem():
+            annual = entry.Entry('annual', self.title, self.part, self.year)
+            tree = entry.Entry('tree', self.title, self.part, self.version_id)
+            annual.write('ANNUAL')
+            tree.write('TREE')
+
+            current_version.process_if_needed(self.title, self.part, self.year)
+
+            # didn't change
+            self.assertEqual(annual.read(), 'ANNUAL')
+            self.assertEqual(tree.read(), 'TREE')
+
+    def test_create_version(self):
+        """Creates a version associated with the part and year"""
+        with CliRunner().isolated_filesystem():
+            current_version.create_version_entry_if_needed(
+                self.title, self.part, self.year)
+            version = entry.Version(
+                self.title, self.part, self.version_id).read()
+            self.assertEqual(version.effective, date.today())
+            self.assertEqual(version.published, date.today())


### PR DESCRIPTION
Resolves 18f/atf-eregs#160 by adding a mechanism for building only the most recent annual edition of a regulation. This allowed 50 of FEC's 53 regs to parse without issue.

Also resolves an issue where CFR titles with only one volume weren't finding annual editions correctly. See commit messages for more.