### PR TITLE
Add --debug flag + logging colors to `eregs` command

### DIFF
--- a/eregs.py
+++ b/eregs.py
@@ -3,6 +3,7 @@ from importlib import import_module
 import pkgutil
 import sys
 
+import coloredlogs
 import click
 import ipdb
 import requests_cache   # @todo - replace with cache control
@@ -15,7 +16,7 @@ from regparser.index import dependency
 @click.group()
 @click.option('--debug/--no-debug', default=False)
 def cli(debug):
-    logging.basicConfig(level=logging.INFO)
+    coloredlogs.install(level=logging.INFO, fmt="%(levelname)s %(message)s")
     requests_cache.install_cache('fr_cache')
     if debug:
         sys.excepthook = lambda t, v, tb: ipdb.post_mortem(tb)

--- a/eregs.py
+++ b/eregs.py
@@ -1,8 +1,10 @@
 import logging
 from importlib import import_module
 import pkgutil
+import sys
 
 import click
+import ipdb
 import requests_cache   # @todo - replace with cache control
 
 from regparser import commands
@@ -11,9 +13,12 @@ from regparser.index import dependency
 
 
 @click.group()
-def cli():
+@click.option('--debug/--no-debug', default=False)
+def cli(debug):
     logging.basicConfig(level=logging.INFO)
     requests_cache.install_cache('fr_cache')
+    if debug:
+        sys.excepthook = lambda t, v, tb: ipdb.post_mortem(tb)
 
 
 for _, command_name, _ in pkgutil.iter_modules(commands.__path__):
@@ -41,6 +46,7 @@ def main(prev_dependency=None):
             click.echo("Attempting to resolve dependency: " + e.dependency)
             resolvers[0].resolution()
             main(e.dependency)
+
 
 if __name__ == '__main__':
     main()

--- a/regparser/notice/compiler.py
+++ b/regparser/notice/compiler.py
@@ -158,6 +158,9 @@ class RegulationTree(object):
         if not parent:  # e.g. because the node doesn't exist in the tree yet
             parent_label_id = get_parent_label(node)
             parent = find(self.tree, parent_label_id)
+        if not parent:
+            logging.error("Could not find parent of %s. Misparsed amendment?",
+                          node.label_id())
         return parent
 
     def add_to_root(self, node):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 click==5.1
+coloredlogs==5.0
 dagger==1.3.0
 GitPython==1.0.1
 inflection==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ click==5.1
 dagger==1.3.0
 GitPython==1.0.1
 inflection==0.3.1
+ipdb==0.8.1
 json-delta==1.1.3
 lxml==3.5.0
 pyparsing==2.0.5

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     ],
     install_requires=[
         "click",
+        "coloredLogs",
         "dagger",
         "GitPython",
         "inflection",

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         "dagger",
         "GitPython",
         "inflection",
+        "ipdb",
         "json-delta",
         "lxml",
         "pyparsing",


### PR DESCRIPTION
Executing `eregs --debug pipeline 27 478 output` will now drop into a ipdb
debugging session on error. This is optional as the interface is quite
unexpected.

Python's default logging output was a bit difficult to read. This uses a
library to add some nicer colors. It also adds a logging message in the
notice compiler

Requires new libs

Example:
<img width="702" alt="screen shot 2015-12-14 at 1 44 38 pm" src="https://cloud.githubusercontent.com/assets/326918/11790249/b97e44a0-a268-11e5-9620-b2a8890824da.png">
