### PR TITLE
Fix bug when associating amendments w/ changes

### DIFF
--- a/regparser/notice/build.py
+++ b/regparser/notice/build.py
@@ -145,16 +145,16 @@ def create_xml_changes(amended_labels, section, notice_changes):
 
 
 def process_amendments(notice, notice_xml):
-    """ Process the changes to the regulation that are expressed in the notice.
-    """
-    all_amends = []
+    """Process changes to the regulation that are expressed in the notice."""
+    all_amends = []     # will be added to the notice
     cfr_part = notice['cfr_parts'][0]
     notice_changes = changes.NoticeChanges()
 
+    # process amendments in batches, based on their parent XML
     for amdparent in notice_xml.xpath('//AMDPAR/..'):
         context = [amdparent.get('PART') or cfr_part]
         amendments_by_section = defaultdict(list)
-        normal_amends = []
+        normal_amends = []  # amendments not moving or adding a subpart
         for amdpar in amdparent.xpath('.//AMDPAR'):
             amendments, context = parse_amdpar(amdpar, context)
             section_xml = find_section(amdpar)
@@ -173,8 +173,9 @@ def process_amendments(notice, notice_xml):
                     normal_amends.append(amendment)
                     amendments_by_section[section_xml].append(amendment)
 
-        cfr_part = context[0]
+        cfr_part = context[0]   # carry the part through to the next amdparent
         create_xmlless_changes(normal_amends, notice_changes)
+        # Process amendments relating to a specific section in batches, too
         for section_xml, related_amends in amendments_by_section.items():
             for section in reg_text.build_from_section(cfr_part, section_xml):
                 create_xml_changes(related_amends, section, notice_changes)

--- a/regparser/notice/diff.py
+++ b/regparser/notice/diff.py
@@ -1,29 +1,10 @@
 # vim: set encoding=utf-8
 from itertools import takewhile
-import re
 from copy import copy
-
-from lxml import etree
 
 from regparser.grammar import amdpar, tokens
 from regparser.tree.struct import Node
-from regparser.tree.xml_parser.reg_text import build_from_section
 from regparser.tree.xml_parser.tree_utils import get_node_text
-
-
-def clear_between(xml_node, start_char, end_char):
-    """Gets rid of any content (including xml nodes) between chars"""
-    as_str = etree.tostring(xml_node, encoding=unicode)
-    start_char, end_char = re.escape(start_char), re.escape(end_char)
-    pattern = re.compile(
-        start_char + '[^' + end_char + ']*' + end_char, re.M + re.S + re.U)
-    return etree.fromstring(pattern.sub('', as_str))
-
-
-def remove_char(xml_node, char):
-    """Remove from this node and all its children"""
-    as_str = etree.tostring(xml_node, encoding=unicode)
-    return etree.fromstring(as_str.replace(char, ''))
 
 
 def fix_section_node(paragraphs, amdpar_xml):
@@ -60,8 +41,7 @@ def find_lost_section(amdpar_xml):
 
 
 def find_section(amdpar_xml):
-    """ With an AMDPAR xml, return the first section
-    sibling """
+    """ With an AMDPAR xml, return the first section sibling """
     siblings = [s for s in amdpar_xml.itersiblings()]
 
     if len(siblings) == 0:
@@ -81,27 +61,6 @@ def find_subpart(amdpar_tag):
     for sibling in amdpar_tag.itersiblings():
         if sibling.tag == 'SUBPART':
             return sibling
-
-
-def find_diffs(xml_tree, cfr_part):
-    """Find the XML nodes that are needed to determine diffs"""
-    #   Only final notices have this format
-    for section in xml_tree.xpath('//REGTEXT//SECTION'):
-        section = clear_between(section, '[', ']')
-        section = remove_char(remove_char(section, u'▸'), u'◂')
-        for node in build_from_section(cfr_part, section):
-            def per_node(node):
-                if node_is_empty(node):
-                    for c in node.children:
-                        per_node(c)
-                else:
-                    print node.label, node.text
-            per_node(node)
-
-
-def node_is_empty(node):
-    """Handle different ways the regulation represents no content"""
-    return node.text.strip() == ''
 
 
 def switch_context(token_list, carried_context):

--- a/regparser/notice/diff.py
+++ b/regparser/notice/diff.py
@@ -67,16 +67,13 @@ def find_section(amdpar_xml):
     if len(siblings) == 0:
         return find_lost_section(amdpar_xml)
 
-    section = None
-    for sibling in amdpar_xml.itersiblings():
+    for sibling in siblings:
         if sibling.tag == 'SECTION':
-            section = sibling
+            return sibling
 
-    if section is None:
-        paragraphs = [s for s in amdpar_xml.itersiblings() if s.tag == 'P']
-        if len(paragraphs) > 0:
-            return fix_section_node(paragraphs, amdpar_xml)
-    return section
+    paragraphs = [s for s in siblings if s.tag == 'P']
+    if len(paragraphs) > 0:
+        return fix_section_node(paragraphs, amdpar_xml)
 
 
 def find_subpart(amdpar_tag):

--- a/tests/notice_build_tests.py
+++ b/tests/notice_build_tests.py
@@ -283,6 +283,27 @@ class NoticeBuildTest(XMLBuilderMixin, TestCase):
         changes = notice['changes']['105-11-p5'][0]
         self.assertEqual(changes['action'], 'PUT')
 
+    def test_process_amendments_multiple_sections(self):
+        """Regression test verifying multiple SECTIONs in the same REGTEXT"""
+        with self.tree.builder("REGTEXT", PART="111") as regtext:
+            regtext.AMDPAR(u"1. Modify § 111.22 by revising paragraph (b)")
+            with regtext.SECTION() as section:
+                section.SECTNO(u"§ 111.22")
+                section.SUBJECT("Subject Here.")
+                section.STARS()
+                section.P("(b) Revised second paragraph")
+            regtext.AMDPAR(u"2. Modify § 111.33 by revising paragraph (c)")
+            with regtext.SECTION() as section:
+                section.SECTNO(u"§ 111.33")
+                section.SUBJECT("Another Subject")
+                section.STARS()
+                section.P("(c) Revised third paragraph")
+
+        notice = {'cfr_parts': ['111']}
+        build.process_amendments(notice, self.tree.render_xml())
+        self.assertItemsEqual(notice['changes'].keys(),
+                              ['111-22-b', '111-33-c'])
+
     def new_subpart_xml(self):
         with self.tree.builder("RULE") as rule:
             with rule.REGTEXT(PART="105", TITLE="12") as regtext:

--- a/tests/notice_diff_tests.py
+++ b/tests/notice_diff_tests.py
@@ -9,32 +9,6 @@ from tests.xml_builder import XMLBuilderMixin
 
 
 class NoticeDiffTests(XMLBuilderMixin, TestCase):
-
-    def test_clear_between(self):
-        xml = u"""
-        <ROOT>Some content[ removed]
-            <CHILD>Split[ it
-                <SUB>across children</SUB>
-                ]
-            </CHILD>
-        </ROOT>
-        """.strip()
-        result = diff.clear_between(etree.fromstring(xml), '[', ']')
-        cleaned = u"""
-        <ROOT>Some content
-            <CHILD>Split
-            </CHILD>
-        </ROOT>
-        """.strip()
-        self.assertEqual(cleaned, etree.tostring(result))
-
-    def test_remove_char(self):
-        xml = u"""<ROOT> Some stuff▸, then a bit more◂.</ROOT>"""
-        result = diff.remove_char(diff.remove_char(
-            etree.fromstring(xml), u'▸'), u'◂')
-        cleaned = u"""<ROOT> Some stuff, then a bit more.</ROOT>"""
-        self.assertEqual(cleaned, etree.tostring(result))
-
     def test_make_amendments(self):
         tokenized = [
             tokens.Paragraph(['111']),

--- a/tests/notice_diff_tests.py
+++ b/tests/notice_diff_tests.py
@@ -255,7 +255,7 @@ class NoticeDiffTests(XMLBuilderMixin, TestCase):
         section = diff.find_section(amdpar_xml)
         self.assertEqual(section.tag, 'SECTION')
 
-        sectno_xml = section.xpath('//SECTNO')[0]
+        sectno_xml = section.xpath('./SECTNO')[0]
         self.assertEqual(sectno_xml.text, '200.1')
 
     def test_find_subpart(self):


### PR DESCRIPTION
@grapesmoker pointed this out months ago, but it's finally bit us. The code
which ties amendments (e.g. "revising paragraph (b)") with the contents of
those amendments (i.e. the XML nodes representing the text) had a bug where
only the _last_ AMDPAR was being used to determine the associated SECTION XML.

This rewrites that chunk of code to group by section XML rather than CFR part,
which resolves the immediate issue. The code in this area's still pretty
messy, but it's a tad cleaner now

Also switches some string XML to use a builder and removes some dead lines. Related to 18f/atf-eregs#103