### PR TITLE
Split CFR parsing from internal citations

### DIFF
--- a/regparser/grammar/unified.py
+++ b/regparser/grammar/unified.py
@@ -174,7 +174,7 @@ multiple_comments = (
         + Optional(Suppress(')'))))
 
 # e.g. 12 CFR 1005.10
-internal_cfr_p = (
+cfr_p = (
     atomic.title
     + Suppress("CFR")
     + atomic.part
@@ -184,7 +184,7 @@ internal_cfr_p = (
 
 # e.g. 12 CFR 1005.10, 1006.21, and 1010.10
 multiple_cfr_p = (
-    internal_cfr_p.copy().setParseAction(keep_pos).setResultsName("head")
+    cfr_p.copy().setParseAction(keep_pos).setResultsName("head")
     + OneOrMore(
         atomic.conj_phrases
         + (atomic.part

--- a/tests/citations_tests.py
+++ b/tests/citations_tests.py
@@ -1,7 +1,7 @@
 # vim: set encoding=utf-8
 from unittest import TestCase
 
-from regparser.citations import internal_citations, Label
+from regparser.citations import cfr_citations, internal_citations, Label
 from regparser.tree.struct import Node
 
 
@@ -332,7 +332,7 @@ class CitationsLabelTest(TestCase):
                          Label.determine_schema({'appendix_section': '1'}))
         self.assertEqual(Label.app_schema,
                          Label.determine_schema({'appendix': 'A'}))
-        self.assertEqual(Label.sect_schema,
+        self.assertEqual(Label.regtext_schema,
                          Label.determine_schema({'section': '12'}))
         self.assertEqual(None, Label.determine_schema({}))
 
@@ -384,4 +384,35 @@ class CitationsLabelTest(TestCase):
 
     def test_label_representation(self):
         l = Label(part='105', section='3')
-        self.assertEqual(repr(l), "['105', '3']")
+        self.assertEqual(
+            repr(l),
+            "Label(cfr_title=None, part='105', section='3', p1=None, "
+            "p2=None, p3=None, p4=None, p5=None, p6=None)")
+
+    def test_cfr_citations_single(self):
+        text = 'See 11 CFR 222.3(e)(3)(ii) for more'
+        citations = cfr_citations(text)
+        self.assertEqual(1, len(citations))
+        self.assertEqual('11 CFR 222.3(e)(3)(ii)', to_text(citations[0], text))
+        self.assertEqual(
+            citations[0].label.settings,
+            dict(cfr_title='11', part='222', section='3', p1='e', p2='3',
+                 p3='ii'))
+
+    def test_cfr_citations_multiple(self):
+        text = 'Go look at 2 CFR 111.22, 333.45, and 444.55(e)'
+        citations = cfr_citations(text)
+        self.assertEqual(3, len(citations))
+
+        self.assertEqual('2 CFR 111.22', to_text(citations[0], text))
+        self.assertEqual(citations[0].label.settings,
+                         dict(cfr_title='2', part='111', section='22'))
+
+        self.assertEqual('333.45', to_text(citations[1], text))
+        self.assertEqual(citations[1].label.settings,
+                         dict(cfr_title='2', part='333', section='45'))
+
+        self.assertEqual('444.55(e)', to_text(citations[2], text))
+        self.assertEqual(
+            citations[2].label.settings,
+            dict(cfr_title='2', part='444', section='55', p1='e'))


### PR DESCRIPTION
Previously, there was special case logic for checking if CFR citations, such
as "26 CFR 111.10" and "26 CFR 111.11(a) through (d)" were actually internal
citations. This generalizes that logic so we can use it outside of the context
of trying to find internal citations. To do this, this moves two functions out
of a function scope (single_citation, multiple_citations), renames a few
things, and adds the CFR title to an internal representation of labels. This
last piece required we add some additional conversion steps as a Node's label
doesn't track CFR titles, yet we want citations to have that ability.

For 18f/atf-eregs#182