### PR TITLE
Add a QuickSearchable grammar wrapper

### DIFF
--- a/regparser/grammar/amdpar.py
+++ b/regparser/grammar/amdpar.py
@@ -8,7 +8,7 @@ from pyparsing import (
     QuotedString, Suppress, Word, ZeroOrMore)
 
 from regparser.grammar import atomic, tokens, unified
-from regparser.grammar.utils import Marker, WordBoundaries
+from regparser.grammar.utils import Marker, QuickSearchable, WordBoundaries
 from regparser.layer.key_terms import keyterm_to_int
 from regparser.tree.paragraph import p_levels
 
@@ -466,7 +466,7 @@ override_label = (
 ).setParseAction(tokenize_override_ps)
 
 #   grammar which captures all of these possibilities
-token_patterns = (
+token_patterns = QuickSearchable(
     put_active | put_passive | post_active | post_passive
     | delete_active | delete_passive | move_active | move_passive
     | designate_active | reserve_active
@@ -505,7 +505,8 @@ token_patterns = (
     | and_token
 )
 
-subpart_label = (atomic.part + Suppress('-')
-                 + atomic.subpart_marker + Suppress(':')
-                 + Word(string.ascii_uppercase, max=1)
-                 + LineEnd())
+subpart_label = QuickSearchable(
+    atomic.part + Suppress('-')
+    + atomic.subpart_marker + Suppress(':')
+    + Word(string.ascii_uppercase, max=1)
+    + LineEnd())

--- a/regparser/grammar/delays.py
+++ b/regparser/grammar/delays.py
@@ -60,4 +60,5 @@ date_parser = (
 ).setParseAction(lambda m: date(int(m[2]), m[0], int(m[1])))
 
 
-tokenizer = (effective_date | notice_citation | delayed | date_parser)
+tokenizer = utils.QuickSearchable(
+    effective_date | notice_citation | delayed | date_parser)

--- a/regparser/grammar/external_citations.py
+++ b/regparser/grammar/external_citations.py
@@ -2,6 +2,8 @@
 import string
 from pyparsing import Word, Literal
 
+from regparser.grammar.utils import QuickSearchable
+
 """ Contruct a grammar that parses references/citations to the United States
 Code, the Code of Federal Regulations, Public Law and Statues at Large. """
 
@@ -22,5 +24,6 @@ public_law_exp = Literal("Public") + Literal("Law") +\
 stat_at_large_exp = Word(string.digits) +\
     Literal("Stat.") + Word(string.digits)
 
-regtext_external_citation = uscode_exp.setResultsName('USC') |\
-    cfr_exp | the_act_exp | public_law_exp | stat_at_large_exp
+regtext_external_citation = QuickSearchable(
+    uscode_exp.setResultsName('USC')
+    | cfr_exp | the_act_exp | public_law_exp | stat_at_large_exp)

--- a/regparser/grammar/interpretation_headers.py
+++ b/regparser/grammar/interpretation_headers.py
@@ -1,6 +1,6 @@
 from pyparsing import LineEnd, LineStart, SkipTo
 
-from regparser.grammar import atomic, unified
+from regparser.grammar import atomic, unified, utils
 
 
 section = (
@@ -31,4 +31,5 @@ appendix = (
 )
 
 
-parser = LineStart() + (section | marker_par | par | appendix)
+parser = utils.QuickSearchable(
+    LineStart() + (section | marker_par | par | appendix))

--- a/regparser/grammar/terms.py
+++ b/regparser/grammar/terms.py
@@ -4,10 +4,11 @@ from pyparsing import (
     Word, ZeroOrMore)
 
 from regparser.grammar import atomic, unified
-from regparser.grammar.utils import DocLiteral, keep_pos, Marker
+from regparser.grammar.utils import (
+    DocLiteral, keep_pos, Marker, QuickSearchable)
 
 
-smart_quotes = (
+smart_quotes = QuickSearchable(
     Suppress(DocLiteral(u'“', "left-smart-quote"))
     + SkipTo(
         DocLiteral(u'”', "right-smart-quote")
@@ -22,7 +23,7 @@ e_tag = (
     + Suppress(Literal("</E>"))
 )
 
-xml_term_parser = (
+xml_term_parser = QuickSearchable(
     LineStart()
     + Optional(Suppress(unified.any_depth_p))
     + e_tag.setResultsName("head")
@@ -38,7 +39,7 @@ xml_term_parser = (
           + Marker("meaning") + Marker("as")))
 )
 
-key_term_parser = (
+key_term_parser = QuickSearchable(
     LineStart()
     + Optional(Suppress(unified.any_depth_p))
     + Suppress(Regex(r"<E[^>]*>"))
@@ -49,7 +50,7 @@ key_term_parser = (
     + Suppress(Literal("</E>"))
 )
 
-scope_term_type_parser = (
+scope_term_type_parser = QuickSearchable(
     Marker("purposes") + Marker("of") + Optional(Marker("this"))
     + SkipTo(",").setResultsName("scope") + Literal(",")
     + Optional(Marker("the") + Marker("term"))

--- a/regparser/grammar/utils.py
+++ b/regparser/grammar/utils.py
@@ -1,11 +1,12 @@
-from pyparsing import alphanums, CaselessLiteral, getTokensEndLoc, Literal
-from pyparsing import Suppress, WordEnd, WordStart
+import re
+
+import pyparsing
 
 
 def keep_pos(source, location, tokens):
     """Wrap the tokens with a class that also keeps track of the match's
     location."""
-    return (WrappedResult(tokens, location, getTokensEndLoc()),)
+    return (WrappedResult(tokens, location, pyparsing.getTokensEndLoc()),)
 
 
 class WrappedResult():
@@ -19,7 +20,7 @@ class WrappedResult():
         return getattr(self.tokens, attr)
 
 
-class DocLiteral(Literal):
+class DocLiteral(pyparsing.Literal):
     """Setting an objects name to a unicode string causes Sphinx to freak
     out. Instead, we'll replace with the provided (ascii) text."""
     def __init__(self, literal, ascii_text):
@@ -28,12 +29,104 @@ class DocLiteral(Literal):
 
 
 def WordBoundaries(grammar):
-    return WordStart(alphanums) + grammar + WordEnd(alphanums)
+    return (pyparsing.WordStart(pyparsing.alphanums)
+            + grammar
+            + pyparsing.WordEnd(pyparsing.alphanums))
 
 
 def Marker(txt):
-    return Suppress(WordBoundaries(CaselessLiteral(txt)))
+    return pyparsing.Suppress(WordBoundaries(pyparsing.CaselessLiteral(txt)))
 
 
 def SuffixMarker(txt):
-    return Suppress(CaselessLiteral(txt) + WordEnd(alphanums))
+    return pyparsing.Suppress(pyparsing.CaselessLiteral(txt)
+                              + pyparsing.WordEnd(pyparsing.alphanums))
+
+
+class QuickSearchable(pyparsing.ParseElementEnhance):
+    """Pyparsing's `scanString` (i.e. searching for a grammar over a string)
+    tests each index within its search string. While that offers maximum
+    flexibility, it is rather slow for our needs. This enhanced grammar type
+    wraps other grammars, deriving from them a first regular expression to use
+    when `scanString`ing. This cuts search time considerably."""
+    def __init__(self, expr):
+        super(QuickSearchable, self).__init__(expr)
+        regex_strs = []
+        for regex_str in QuickSearchable.initial_regex(expr):
+            if '|' in regex_str:
+                # If the regex includes an "or", we need to wrap it in parens
+                regex_str = '(' + regex_str + ')'
+            regex_strs.append(regex_str)
+        # Combine all potential initial_regexes with an "or". Match
+        # Pyparsing's naming convention
+        self.reString = '|'.join(regex_strs)
+        self.re = re.compile(
+            self.reString,
+            # Be as forgiving as possible with flags; false negatives aren't
+            # acceptable but false positives are fine
+            re.IGNORECASE | re.UNICODE | re.MULTILINE | re.DOTALL)
+        self.parseImpl = expr.parseImpl
+
+    def scanString(self, instring, maxMatches=None, overlap=False):
+        """Override `scanString` to attempt parsing only where there's a regex
+        search match (as opposed to every index). Does not implement the full
+        scanString interface."""
+        if maxMatches is not None or overlap:
+            raise ValueError("QuickScannable does not implement the full "
+                             "scanString interface")
+        search_idx = 0
+        while search_idx < len(instring):
+            match = self.re.search(instring, search_idx)
+            if match:
+                try:
+                    pre_loc = self.expr.preParse(instring, match.start())
+                    next_loc, tokens = self.expr._parse(
+                        instring, match.start(), callPreParse=False)
+                    if next_loc > match.start():
+                        yield tokens, pre_loc, next_loc
+                        search_idx = next_loc
+                    else:
+                        search_idx += 1
+                except pyparsing.ParseException:
+                    search_idx = match.start() + 1
+            else:
+                search_idx = len(instring)
+
+    @staticmethod
+    def initial_regex(grammar):
+        """Given a Pyparsing grammar, derive a set of suitable initial regular
+        expressions to aid our search. As grammars may `Or` together multiple
+        sub-expressions, this always returns a `set` of possible regular
+        expression strings. This is _not_ a complete conversion to regexes nor
+        does it account for every Pyparsing element; add as needed"""
+        recurse = QuickSearchable.initial_regex
+        # Optimization: WordStart is generally followed by a more specific
+        # identifier. Rather than searching for the start of a word alone,
+        # search for that identifier as well
+        if (isinstance(grammar, pyparsing.And)
+                and isinstance(grammar.exprs[0], pyparsing.WordStart)):
+            boundry, next_expr = grammar.exprs[:2]
+            word_chars = ''.join(re.escape(char)
+                                 for char in boundry.wordChars)
+            return set('(?<![{}])'.format(word_chars) + regex_str
+                       for regex_str in recurse(next_expr))
+        if (isinstance(grammar, pyparsing.And)
+                and isinstance(grammar.exprs[0], pyparsing.Optional)):
+            return recurse(grammar.exprs[0].expr) | recurse(grammar.exprs[1])
+        elif isinstance(grammar, pyparsing.And):
+            return recurse(grammar.exprs[0])
+        elif isinstance(grammar, (pyparsing.MatchFirst, pyparsing.Or)):
+            return reduce(lambda so_far, expr: so_far | recurse(expr),
+                          grammar.exprs, set())
+        elif isinstance(grammar, (pyparsing.Suppress, QuickSearchable)):
+            return recurse(grammar.expr)
+        elif isinstance(grammar, (pyparsing.Regex, pyparsing.Word)):
+            return set([grammar.reString])
+        elif isinstance(grammar, pyparsing.LineStart):
+            return set(['^'])
+        elif isinstance(grammar, pyparsing.Literal):
+            return set([re.escape(grammar.match)])
+        # Grammar type that we've not accounted for. Fail fast
+        else:
+            raise Exception("Unknown grammar type: {}".format(
+                grammar.__class__))

--- a/regparser/tree/interpretation.py
+++ b/regparser/tree/interpretation.py
@@ -79,9 +79,9 @@ def text_to_labels(text, initial_label, warn=True, force_start=False):
         citations = [c for c in citations if c.full_start == 0]
 
     #   Under certain situations, we need to infer from context
-    initial_pars = list(match for match, start, _
-                        in unified.any_depth_p.scanString(text)
-                        if start == 0)
+    initial_pars = [match
+                    for match, start, _ in unified.any_depth_p.scanString(text)
+                    if start == 0]
 
     if citations:
         if citations[0].in_clause:

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -9,7 +9,7 @@ from pyparsing import LineStart, Optional, Suppress
 from regparser.citations import internal_citations
 from regparser.grammar import appendix as grammar
 from regparser.grammar.interpretation_headers import parser as headers
-from regparser.grammar.utils import Marker
+from regparser.grammar.utils import Marker, QuickSearchable
 from regparser.layer.formatting import table_xml_to_plaintext
 from regparser.layer.key_terms import KeyTerms
 from regparser.tree.depth import markers
@@ -340,7 +340,8 @@ def parsed_title(text, appendix_letter):
                         + Optional(grammar.paren_upper | grammar.paren_lower)
                         + Optional(grammar.paren_digit))
     part_roman_parser = Marker("part") + grammar.aI
-    parser = LineStart() + (digit_str_parser | part_roman_parser)
+    parser = QuickSearchable(
+        LineStart() + (digit_str_parser | part_roman_parser))
 
     for match, _, _ in parser.scanString(text):
         return match
@@ -372,11 +373,13 @@ def title_label_pair(text, appendix_letter, reg_part):
     return pair
 
 
+_parser = QuickSearchable(
+    grammar.paren_upper | grammar.paren_lower | grammar.paren_digit |
+    grammar.period_upper | grammar.period_digit | grammar.period_lower)
+
+
 def initial_marker(text):
-    parser = (grammar.paren_upper | grammar.paren_lower | grammar.paren_digit
-              | grammar.period_upper | grammar.period_digit
-              | grammar.period_lower)
-    for match, start, end in parser.scanString(text):
+    for match, start, end in _parser.scanString(text):
         if start != 0:
             continue
         marker = (match.paren_upper or match.paren_lower or match.paren_digit

--- a/regparser/tree/xml_parser/tree_utils.py
+++ b/regparser/tree/xml_parser/tree_utils.py
@@ -7,6 +7,7 @@ from pyparsing import Literal, Optional, Regex, Suppress
 
 from regparser.citations import remove_citation_overlaps
 from regparser.grammar.unified import any_depth_p
+from regparser.grammar.utils import QuickSearchable
 from regparser.tree.paragraph import p_levels
 from regparser.tree.priority_stack import PriorityStack
 
@@ -68,7 +69,7 @@ for idx, level in enumerate(p_levels):
         marker += Optional(Suppress('(')
                            + Literal(inner_level[0])
                            + Suppress(')'))
-    _first_markers.append(marker)
+    _first_markers.append(QuickSearchable(marker))
 
 
 def get_collapsed_markers(text):

--- a/tests/grammar_utils_tests.py
+++ b/tests/grammar_utils_tests.py
@@ -1,0 +1,34 @@
+from unittest import TestCase
+
+import pyparsing
+
+from regparser.grammar import utils
+
+
+class QuickSearchableTests(TestCase):
+    def _compare_search(self, grammar, text):
+        quick_grammar = utils.QuickSearchable(grammar)
+        self.assertEqual([str(m) for m in grammar.scanString(text)],
+                         [str(m) for m in quick_grammar.scanString(text)])
+
+    def test_finds_same(self):
+        """Expect QuickSearchable to find the same stuff"""
+        self._compare_search(pyparsing.Literal("the"),
+                             "The the theory ThE the")
+        self._compare_search(
+            pyparsing.Literal("some") + pyparsing.Literal("thing"),
+            "something some thing some one thing SomeThing")
+        self._compare_search(
+            pyparsing.WordStart() + pyparsing.Literal("the"),
+            "the the theory ThE the other more")
+        self._compare_search(
+            pyparsing.Optional("the").setResultsName("opt") + "term",
+            "some term the term The Term some the Some term")
+        self._compare_search(
+            pyparsing.Literal("hey") | pyparsing.Literal("you"),
+            "hey there you hey you hey there here heyyo")
+        self._compare_search(
+            pyparsing.Suppress("you") + "there",
+            "hey you there! do you see this? there is here youthere")
+        self._compare_search(pyparsing.Regex(r'\d+'),
+                             "this thing 123 more l337 h47p")


### PR DESCRIPTION
Pyparsing's scanString checks every string index for a parsed string. This is
rather slow, particularly when we're expecting _few_ matches in a given search
string. This adds a wrapper for a Pyparsing grammar which builds an initial
regex to reduce the places we are trying to match the grammar. It should _not_
produce false negatives.

In local testing, it reduces the time to parse all of ATF's regs from scratch
by over 50% (~28m -> ~12m)

Resolves #100 