### PR TITLE
Rework citations for ATF rulings

### DIFF
--- a/regparser/commands/citations.py
+++ b/regparser/commands/citations.py
@@ -1,0 +1,27 @@
+import codecs
+import sys
+
+import click
+
+from regparser.citations import cfr_citations
+
+
+@click.command()
+@click.argument('input_files', nargs=-1, type=click.File('rb'))
+@click.option('--unique/--no-unique', default=False,
+              help='Remove duplicate citations')
+def citations(input_files, unique):
+    """Find all CFR citations in a file (or stdin)"""
+    if not input_files:
+        input_files = [codecs.getreader('utf8')(sys.stdin)]
+    for f in input_files:
+        text = f.read()
+        citations = cfr_citations(text, include_fill=True)
+        if unique:
+            labels = {citation.label for citation in citations}
+            for label in sorted(labels):
+                click.echo(label)
+        else:
+            for citation in sorted(citations, key=lambda c: c.start):
+                click.echo(u"{}: {}\n".format(
+                    text[citation.start:citation.end], citation.label))

--- a/regparser/grammar/atomic.py
+++ b/regparser/grammar/atomic.py
@@ -2,7 +2,7 @@
 """Atomic components; probably shouldn't use these directly"""
 import string
 
-from pyparsing import CaselessLiteral, Optional, Regex, Suppress, Word
+from pyparsing import Optional, Regex, Suppress, Word
 
 from regparser.grammar.utils import Marker, SuffixMarker, WordBoundaries
 
@@ -95,7 +95,9 @@ conj_phrases = (
     | Marker("and")
     | Marker("or")
     | (Marker("except") + Marker("for"))
-    | Suppress("-")
-    | WordBoundaries(CaselessLiteral("through")).setResultsName("through"))
+    | Suppress(
+        Marker("through") | "-" | u"–"
+        ).setParseAction(lambda: True).setResultsName("through")
+)
 
 title = Word(string.digits).setResultsName("cfr_title")

--- a/regparser/grammar/unified.py
+++ b/regparser/grammar/unified.py
@@ -119,9 +119,11 @@ def make_multiple(head, tail=None, wrap_tail=False):
     # Use `Empty` over `copy` as `head`/`tail` may be single-element grammars,
     # in which case we don't want to completely rename the results
     head = (head + Empty()).setParseAction(keep_pos).setResultsName("head")
-    tail = (tail + Empty()).setParseAction(keep_pos).setResultsName(
+    # We need to address just the matching text separately from the
+    # conjunctive phrase
+    tail = (tail + Empty()).setParseAction(keep_pos).setResultsName("match")
+    tail = (atomic.conj_phrases + tail).setResultsName(
         "tail", listAllMatches=True)
-    tail = atomic.conj_phrases + tail
     if wrap_tail:
         tail = Optional(Suppress('(')) + tail + Optional(Suppress(')'))
     return head + OneOrMore(tail)

--- a/regparser/grammar/utils.py
+++ b/regparser/grammar/utils.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 from pyparsing import alphanums, CaselessLiteral, getTokensEndLoc, Literal
 from pyparsing import Suppress, WordEnd, WordStart
 
@@ -8,12 +10,15 @@ def keep_pos(source, location, tokens):
     return (WrappedResult(tokens, location, getTokensEndLoc()),)
 
 
+Position = namedtuple('Position', ['start', 'end'])
+
+
 class WrappedResult():
     """Keep track of matches along with their position. This is a bit of a
     hack to get around PyParsing's tendency to drop that info."""
     def __init__(self, tokens, start, end):
         self.tokens = tokens
-        self.pos = (start, end)
+        self.pos = Position(start, end)
 
     def __getattr__(self, attr):
         return getattr(self.tokens, attr)

--- a/regparser/tree/paragraph.py
+++ b/regparser/tree/paragraph.py
@@ -8,7 +8,7 @@ from regparser.utils import roman_nums
 
 p_levels = [
     list(string.ascii_lowercase),
-    [str(i) for i in range(1, 51)],
+    [str(i) for i in range(1, 999)],
     list(itertools.islice(roman_nums(), 0, 50)),
     list(string.ascii_uppercase),
     ['<E T="03">' + str(i) + '</E>' for i in range(1, 51)],

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,7 @@
 cov-core==1.15.0
 coverage==4.0.2
 datatree==0.1.8.1
+pep8==1.5.7
 flake8==2.5.0
 httpretty==0.8.10
 mock==1.3.0

--- a/tests/citations_tests.py
+++ b/tests/citations_tests.py
@@ -338,6 +338,28 @@ class CitationsTest(TestCase):
             citations[2].label.settings,
             dict(cfr_title='2', part='444', section='55', p1='e'))
 
+    def test_cfr_citations_through(self):
+        text = u'See 27 CFR 479.112, 479.114 – 479.119'
+        citations = cfr_citations(text)
+        self.assertEqual(3, len(citations))
+        twelve, fourteen, nineteen = citations
+
+        self.assertEqual('27 CFR 479.112', to_text(twelve, text))
+        self.assertEqual(twelve.label.settings,
+                         dict(cfr_title='27', part='479', section='112'))
+        self.assertEqual('479.114', to_text(fourteen, text))
+        self.assertEqual(fourteen.label.settings,
+                         dict(cfr_title='27', part='479', section='114'))
+        self.assertEqual('479.119', to_text(nineteen, text))
+        self.assertEqual(nineteen.label.settings,
+                         dict(cfr_title='27', part='479', section='119'))
+
+        citations = cfr_citations(text, include_fill=True)
+        self.assertEqual(
+            [citation.label.settings for citation in citations],
+            [dict(cfr_title='27', part='479', section=str(i))
+             for i in (112, 114, 115, 116, 117, 118, 119)])
+
 
 class CitationsLabelTest(TestCase):
     def test_using_default_schema(self):


### PR DESCRIPTION
Builds on #142; we can close that if this gets merged first.

At the high level, this adds a little script for printing out CFR citations found in a text file, including filling in any sections/paragraphs implicit in phrases like "paragraph (a)(3)(ii) through (vi)". See the individual changesets for details and let me know if I should break this PR up.

Resolves 18f/atf-eregs#182