### PR TITLE
Ignore blank lines in `NOTE`s

### DIFF
--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -213,7 +213,9 @@ class FencedMatcher(BaseMatcher):
     def derive_nodes(self, xml, processor=None):
         texts = ["```" + self.fence_type(xml)]
         for child in xml:
-            texts.append(tree_utils.get_node_text(child).strip())
+            text = tree_utils.get_node_text(child).strip()
+            if text:
+                texts.append(text)
         texts.append("```")
 
         return [Node("\n".join(texts), label=[mtypes.MARKERLESS])]

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -423,6 +423,7 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
         with self.section() as root:
             root.P("(a) aaaa")
             with root.NOTES() as extract:
+                extract.PRTPAGE(P="8")
                 extract.P("1. Some content")
                 extract.P("2. Other content")
         node = reg_text.build_from_section('8675', self.tree.render_xml())[0]


### PR DESCRIPTION
27 CFR 447 has some funkiness in its diffs due to `PRTPAGE` tags inside `NOTE`s