### PR TITLE
US Code Processor

### DIFF
--- a/regparser/citations.py
+++ b/regparser/citations.py
@@ -6,10 +6,11 @@ from regparser.tree.struct import Node
 
 class Label(object):
     #   @TODO: subparts
-    app_sect_schema = ('part', 'appendix', 'appendix_section', 'p1', 'p2',
-                       'p3', 'p4', 'p5', 'p6')
-    app_schema = ('part', 'appendix', 'p1', 'p2', 'p3', 'p4', 'p5', 'p6')
-    sect_schema = ('part', 'section', 'p1', 'p2', 'p3', 'p4', 'p5', 'p6')
+    _p_markers = tuple('p{}'.format(i) for i in range(1, 10))
+
+    app_sect_schema = ('part', 'appendix', 'appendix_section') + _p_markers
+    app_schema = ('part', 'appendix') + _p_markers
+    sect_schema = ('part', 'section') + _p_markers
     default_schema = sect_schema
 
     comment_schema = ('comment', 'c1', 'c2', 'c3', 'c4')

--- a/regparser/tree/depth/markers.py
+++ b/regparser/tree/depth/markers.py
@@ -12,6 +12,7 @@ upper = (tuple(string.ascii_uppercase)
          + tuple(a+a for a in string.ascii_uppercase))
 ints = tuple(str(i) for i in range(1, 51))
 roman = tuple(itertools.islice(roman_nums(), 0, 50))
+upper_roman = tuple(r.upper() for r in roman)
 em_ints = tuple('<E T="03">' + i + '</E>' for i in ints)
 em_roman = tuple('<E T="03">' + i + '</E>' for i in roman)
 
@@ -25,4 +26,5 @@ stars = (STARS_TAG, INLINE_STARS)
 MARKERLESS = 'MARKERLESS'
 markerless = (MARKERLESS,)
 
-types = [lower, upper, ints, roman, em_ints, em_roman, stars, markerless]
+types = [lower, upper, ints, roman, upper_roman, em_ints, em_roman, stars,
+         markerless]

--- a/regparser/tree/depth/optional_rules.py
+++ b/regparser/tree/depth/optional_rules.py
@@ -4,6 +4,8 @@ latter is a list of all variables in the system; the former is a function
 which can be used to constrain the variables. This allows us to define rules
 over subsets of the variables rather than all of them, should that make our
 constraints more useful"""
+from constraint import InSetConstraint
+
 from regparser.tree.depth import markers
 
 
@@ -38,3 +40,13 @@ def star_new_level(constrain, all_variables):
         prev_typ, prev_depth = all_variables[i - 3], all_variables[i - 1]
         typ, depth = all_variables[i], all_variables[i + 2]
         constrain(inner, [prev_typ, prev_depth, typ, depth])
+
+
+def limit_paragraph_types(*p_types):
+    """Constraint paragraphs to a limited set of paragraph types. This can
+    reduce the search space if we know (for example) that the text comes from
+    regulations and hence does not have capitalized roman numerals"""
+    def constrainer(constrain, all_variables):
+        types = [all_variables[i] for i in range(0, len(all_variables), 3)]
+        constrain(InSetConstraint(p_types), types)
+    return constrainer

--- a/regparser/tree/xml_parser/flatsubtree_processor.py
+++ b/regparser/tree/xml_parser/flatsubtree_processor.py
@@ -1,6 +1,6 @@
 from regparser.tree.depth import markers as mtypes
 from regparser.tree.struct import Node
-from regparser.tree.xml_parser import paragraph_processor
+from regparser.tree.xml_parser import paragraph_processor, us_code
 
 
 class FlatParagraphProcessor(paragraph_processor.ParagraphProcessor):
@@ -9,7 +9,8 @@ class FlatParagraphProcessor(paragraph_processor.ParagraphProcessor):
                 paragraph_processor.TableMatcher(),
                 paragraph_processor.FencedMatcher(),
                 paragraph_processor.HeaderMatcher(),
-                paragraph_processor.SimpleTagMatcher('P', 'FP')]
+                paragraph_processor.SimpleTagMatcher('P', 'FP'),
+                us_code.USCodeMatcher()]
 
 
 class FlatsubtreeMatcher(paragraph_processor.BaseMatcher):

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -305,4 +305,8 @@ class RegtextParagraphProcessor(paragraph_processor.ParagraphProcessor):
 
     def additional_constraints(self):
         return [optional_rules.depth_type_inverses,
-                optional_rules.star_new_level]
+                optional_rules.star_new_level,
+                optional_rules.limit_paragraph_types(
+                    mtypes.lower, mtypes.upper, mtypes.ints, mtypes.roman,
+                    mtypes.em_ints, mtypes.em_roman, mtypes.stars,
+                    mtypes.markerless)]

--- a/regparser/tree/xml_parser/us_code.py
+++ b/regparser/tree/xml_parser/us_code.py
@@ -1,0 +1,66 @@
+import re
+
+from regparser.tree.depth import markers as mtypes, optional_rules
+from regparser.tree.struct import Node
+from regparser.tree.xml_parser import paragraph_processor, tree_utils
+
+
+class USCodeParagraphMatcher(paragraph_processor.BaseMatcher):
+    """Convert a paragraph found in the US Code into appropriate Nodes"""
+    _MARKER_RE = re.compile(r'\((?P<marker>[a-z]+|[A-Z]+|[0-9]+)\)')
+
+    def matches(self, xml):
+        return xml.tag == 'P'
+
+    def paragraph_markers(self, text):
+        """We can't use tree_utils.get_paragraph_markers as that makes
+        assumptions about the order of paragraph markers (specifically
+        that the markers will match the order found in regulations). This is
+        simpler, looking only at multiple markers at the beginning of the
+        paragraph"""
+        markers = []
+        match = self._MARKER_RE.match(text)
+        while match:
+            markers.append(match.group('marker'))
+            text = text[match.end():].strip()
+            match = self._MARKER_RE.match(text)
+        return markers
+
+    def derive_nodes(self, xml, processor=None):
+        nodes = []
+        text = tree_utils.get_node_text(xml).strip()
+        tagged_text = tree_utils.get_node_text_tags_preserved(xml).strip()
+        markers_list = self.paragraph_markers(text)
+        with_parens = ['({})'.format(m) for m in markers_list]
+        triplets = zip(markers_list,
+                       tree_utils.split_text(text, with_parens),
+                       tree_utils.split_text(tagged_text, with_parens))
+        for m, text, tagged_text in triplets:
+            node = Node(text=text.strip(), label=[m], source_xml=xml)
+            node.tagged_text = unicode(tagged_text.strip())
+            nodes.append(node)
+        return nodes
+
+
+class USCodeProcessor(paragraph_processor.ParagraphProcessor):
+    """ParagraphProcessor which converts a chunk of XML into Nodes. Only
+    processes P nodes and limits the type of paragraph markers to those found
+    in US Code"""
+    MATCHERS = [USCodeParagraphMatcher()]
+
+    def additional_constraints(self):
+        return [optional_rules.limit_paragraph_types(
+            mtypes.lower, mtypes.ints, mtypes.upper, mtypes.roman,
+            mtypes.upper_roman)]
+
+
+class USCodeMatcher(paragraph_processor.BaseMatcher):
+    """Matches a custom `USCODE` tag and parses it's contents with the
+    USCodeProcessor. Does not use a custom node type at the moment"""
+    def matches(self, xml):
+        return xml.tag == 'USCODE'
+
+    def derive_nodes(self, xml, processor=None):
+        processor = USCodeProcessor()
+        node = Node(label=[mtypes.MARKERLESS], source_xml=xml)
+        return [processor.process(xml, node)]

--- a/tests/citations_tests.py
+++ b/tests/citations_tests.py
@@ -366,6 +366,10 @@ class CitationsLabelTest(TestCase):
     def test_from_node(self):
         for lst, typ in [(['111'], Node.REGTEXT),
                          (['111', '31', 'a', '3'], Node.REGTEXT),
+                         # _Very_ deeply nested, ignoring the recommended
+                         # 6-level paragraph limit
+                         (['111', '2', 'c', '4', 'v', 'F', '7', 'viii',
+                           'p1', 'p1', 'p1'], Node.REGTEXT),
                          (['111', 'A', 'b'], Node.APPENDIX),
                          (['111', 'A', '4', 'a'], Node.APPENDIX),
                          (['111', '21', 'Interp'], Node.INTERP),

--- a/tests/tree_depth_derive_tests.py
+++ b/tests/tree_depth_derive_tests.py
@@ -13,8 +13,8 @@ class DeriveTests(TestCase):
         """Verify that the set of markers resolves to the provided set of
         depths (in any order). Allows extra contraints."""
         solutions = derive_depths(markers, extra)
-        results = [[a.depth for a in s] for s in solutions]
-        self.assertItemsEqual(results, depths_set)
+        results = {tuple(a.depth for a in s) for s in solutions}
+        self.assertItemsEqual(results, {tuple(s) for s in depths_set})
 
     def test_ints(self):
         self.assert_depth_match(['1', '2', '3', '4'],
@@ -197,6 +197,25 @@ class DeriveTests(TestCase):
         self.assert_depth_match(
             [MARKERLESS, STARS_TAG, MARKERLESS],
             [0, 0, 0])
+
+    def test_cap_roman(self):
+        """Capitalized roman numerals can be paragraphs"""
+        self.assert_depth_match(
+            ['x', '1', 'A', 'i', 'I'],
+            [0, 1, 2, 3, 4])
+
+    def test_limit_paragraph_types(self):
+        """Limiting paragraph types limits how the markers are interpreted"""
+        self.assert_depth_match(
+            ['G', 'H', 'I'],
+            [0, 0, 0],
+            [0, 0, 1]
+        )
+        self.assert_depth_match_extra(
+            ['G', 'H', 'I'],
+            [optional_rules.limit_paragraph_types(markers.upper)],
+            [0, 0, 0]
+        )
 
     def test_debug_idx(self):
         """Find the index of the first error when attempting to derive

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -703,3 +703,27 @@ class RegtextParagraphProcessorTests(XMLBuilderMixin, NodeAccessorMixin,
         keyterm_label = root.child_labels[1]
         self.assertTrue(len(keyterm_label) > 5)
         self.assertEqual(['a', 'b'], root[keyterm_label].child_labels)
+
+    def test_process_nested_uscode(self):
+        with self.tree.builder("ROOT") as root:
+            root.P("Some intro")
+            with root.EXTRACT() as extract:
+                extract.HD("The U.S. Code!")
+                with extract.USCODE() as uscode:
+                    uscode.P("(x)(1) Some content")
+                    uscode.P("(A) Sub-sub-paragraph")
+                    uscode.P("(i)(I) Even more nested")
+        xml = self.tree.render_xml()
+        root = reg_text.RegtextParagraphProcessor().process(xml, Node())
+        root = self.node_accessor(root, [])
+
+        self.assertEqual(root['p1'].text, "Some intro")
+        self.assertEqual(root['p2']['p1'].title, 'The U.S. Code!')
+        code = root['p2']['p2']
+        self.assertEqual(code.source_xml.tag, 'USCODE')
+        self.assertEqual(code['x'].text, '(x)')
+        self.assertEqual(code['x']['1'].text, '(1) Some content')
+        self.assertEqual(code['x']['1']['A'].text, '(A) Sub-sub-paragraph')
+        self.assertEqual(code['x']['1']['A']['i'].text, '(i)')
+        self.assertEqual(code['x']['1']['A']['i']['I'].text,
+                         '(I) Even more nested')


### PR DESCRIPTION
These changesets add the logic for regulations to include chunks of US Code (as is the case w/ 27 CFR 478.103). This requires a new paragraph processor (as paragraphs in the US Code follow a different hierarchy than the regtext) as well as a trigger for when to switch into US Code mode. This uses a non-standard tag, `USCODE`, as the trigger, though we can change that in the future if needed.

Work is towards 18f/atf-eregs#223, though there's still the matter of making a permanent data tweak (to add the `USCODE` delimiters) and displaying this correctly in the UI.