### PR TITLE
Note as a node type

### DIFF
--- a/regparser/notice/compiler.py
+++ b/regparser/notice/compiler.py
@@ -178,15 +178,17 @@ class RegulationTree(object):
     def add_child(self, children, node, order=None):
         """ Add a child to the children, and sort appropriately. This is used
         for non-root nodes. """
+        if order is None:
+            order = []
 
         children = children + [node]    # non-destructive
+        child_labels = set(c.label_id() for c in children)
 
-        if order and set(order) == set(c.label_id() for c in children):
-            lookup = {}
-            for c in children:
-                lookup[c.label_id()] = c
-            return [lookup[label_id] for label_id in order]
-        else:
+        if child_labels.issubset(set(order)):
+            lookup = {c.label_id(): c for c in children}
+            return [lookup[label_id] for label_id in order
+                    if label_id in child_labels]
+        else:   # Must guess at the appropriate order
             sort_order = []
             for c in children:
                 if c.label[-1] == Node.INTERP_MARK:

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -12,6 +12,7 @@ class Node(object):
     SUBPART = u'subpart'
     EMPTYPART = u'emptypart'
     EXTRACT = u'extract'
+    NOTE = u'note'
 
     INTERP_MARK = 'Interp'
 
@@ -44,15 +45,18 @@ class Node(object):
 
     def depth(self):
         """Inspect the label and type to determine the node's depth"""
-        if len(self.label) > 1 and self.node_type in (self.REGTEXT,
-                                                      self.EXTRACT):
-            #   Add one for the subpart level
-            return len(self.label) + 1
-        elif self.node_type in (self.SUBPART, self.EMPTYPART):
+        second = (self.label[1:2] or [""])[0]
+        second_is_digit = second[:1].isdigit()
+        is_interp = self.INTERP_MARK in self.label
+        is_root = len(self.label) <= 1
+        if self.node_type in (self.SUBPART, self.EMPTYPART):
             #   Subparts all on the same level
             return 2
-        else:
+        elif not second_is_digit or is_root or is_interp:
             return len(self.label)
+        else:
+            #   Add one for the subpart level
+            return len(self.label) + 1
 
     @staticmethod
     def is_markerless_label(label):

--- a/regparser/tree/xml_parser/flatsubtree_processor.py
+++ b/regparser/tree/xml_parser/flatsubtree_processor.py
@@ -18,7 +18,7 @@ class FlatsubtreeMatcher(paragraph_processor.BaseMatcher):
     Detects tags passed to it on init and processes them with the
     FlatParagraphProcessor. Also optionally sets node_type.
     """
-    def __init__(self, tags=[], node_type=Node.REGTEXT):
+    def __init__(self, tags, node_type=Node.REGTEXT):
         self.tags = list(tags)
         self.node_type = node_type
 

--- a/regparser/tree/xml_parser/flatsubtree_processor.py
+++ b/regparser/tree/xml_parser/flatsubtree_processor.py
@@ -1,13 +1,15 @@
 from regparser.tree.depth import markers as mtypes
 from regparser.tree.struct import Node
-from regparser.tree.xml_parser import paragraph_processor, us_code
+from regparser.tree.xml_parser import (
+    paragraph_processor, simple_hierarchy_processor, us_code)
 
 
 class FlatParagraphProcessor(paragraph_processor.ParagraphProcessor):
     """Paragraph Processor which does not try to derive paragraph markers"""
     MATCHERS = [paragraph_processor.StarsMatcher(),
                 paragraph_processor.TableMatcher(),
-                paragraph_processor.FencedMatcher(),
+                simple_hierarchy_processor.SimpleHierarchyMatcher(
+                    ['NOTE', 'NOTES'], Node.NOTE),
                 paragraph_processor.HeaderMatcher(),
                 paragraph_processor.SimpleTagMatcher('P', 'FP'),
                 us_code.USCodeMatcher()]

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -206,12 +206,12 @@ class HeaderMatcher(BaseMatcher):
 
 
 class FencedMatcher(BaseMatcher):
-    """Use github-like fencing to indicate this is a note/code"""
+    """Use github-like fencing to indicate this is code"""
     def matches(self, xml):
-        return xml.tag in ('NOTE', 'NOTES', 'CODE')
+        return xml.tag == 'CODE'
 
     def derive_nodes(self, xml, processor=None):
-        texts = ["```" + self.fence_type(xml)]
+        texts = ["```" + xml.get('LANGUAGE', 'code')]
         for child in xml:
             text = tree_utils.get_node_text(child).strip()
             if text:
@@ -219,9 +219,3 @@ class FencedMatcher(BaseMatcher):
         texts.append("```")
 
         return [Node("\n".join(texts), label=[mtypes.MARKERLESS])]
-
-    def fence_type(self, xml):
-        if xml.tag == 'CODE':
-            return xml.get('LANGUAGE', 'code')
-        else:
-            return xml.tag.lower().rstrip("s")

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -4,14 +4,14 @@ import re
 from lxml import etree
 
 from regparser import content
+from regparser.tree import reg_text
 from regparser.tree.depth import markers as mtypes, optional_rules
 from regparser.tree.struct import Node
 from regparser.tree.paragraph import p_level_of, p_levels
-from regparser.tree.xml_parser import (flatsubtree_processor,
-                                       paragraph_processor)
+from regparser.tree.xml_parser import (
+    flatsubtree_processor, paragraph_processor, simple_hierarchy_processor,
+    tree_utils)
 from regparser.tree.xml_parser.appendices import build_non_reg_text
-from regparser.tree import reg_text
-from regparser.tree.xml_parser import tree_utils
 
 
 def get_reg_part(reg_doc):
@@ -301,7 +301,9 @@ class RegtextParagraphProcessor(paragraph_processor.ParagraphProcessor):
                     tags=['EXTRACT'], node_type=Node.EXTRACT),
                 flatsubtree_processor.FlatsubtreeMatcher(tags=['EXAMPLE']),
                 paragraph_processor.HeaderMatcher(),
-                ParagraphMatcher()]
+                ParagraphMatcher(),
+                simple_hierarchy_processor.SimpleHierarchyMatcher(
+                    tags=['NOTE', 'NOTES'], node_type=Node.NOTE)]
 
     def additional_constraints(self):
         return [optional_rules.depth_type_inverses,

--- a/regparser/tree/xml_parser/simple_hierarchy_processor.py
+++ b/regparser/tree/xml_parser/simple_hierarchy_processor.py
@@ -1,0 +1,60 @@
+import re
+
+from regparser.tree.depth import markers as mtypes, optional_rules
+from regparser.tree.struct import Node
+from regparser.tree.xml_parser import paragraph_processor, tree_utils
+
+
+class DepthParagraphMatcher(paragraph_processor.BaseMatcher):
+    """Convert a paragraph with an optional prefixing paragraph marker into an
+    appropriate node. Does not know about collapsed markers nor most types of
+    nodes."""
+    _MARKER_STR = r'(?P<marker>[a-z]|[ivx]{1,5}|\d{1,2})'
+    _PAREN_REGEX = re.compile(r'\({}\)'.format(_MARKER_STR))
+    _PERIOD_REGEX = re.compile(r'{}\.'.format(_MARKER_STR))
+
+    def matches(self, xml):
+        return xml.tag == 'P'
+
+    def derive_nodes(self, xml, processor=None):
+        text = tree_utils.get_node_text(xml).strip()
+        node = Node(text=text, source_xml=xml)
+        node.tagged_text = unicode(
+            tree_utils.get_node_text_tags_preserved(xml).strip())
+
+        regex = self._PAREN_REGEX if text[:1] == '(' else self._PERIOD_REGEX
+        match = regex.match(text)
+        if match:
+            node.label = [match.group('marker')]
+        else:
+            node.label = [mtypes.MARKERLESS]
+
+        return [node]
+
+
+class SimpleHierarchyProcessor(paragraph_processor.ParagraphProcessor):
+    """ParagraphProcessor which attempts to pull out whatever paragraph marker
+    is available and derive a hierarchy from that."""
+    MATCHERS = [DepthParagraphMatcher()]
+
+    def additional_constraints(self):
+        return [optional_rules.limit_paragraph_types(
+            mtypes.lower, mtypes.ints, mtypes.roman, mtypes.markerless)]
+
+
+class SimpleHierarchyMatcher(paragraph_processor.BaseMatcher):
+    """Detects tags passed to it on init and converts the contents of any
+    matches into a hierarchy based on the SimpleHierarchyProcessor. Sets the
+    node_type of the subtree's root"""
+    def __init__(self, tags, node_type):
+        self.tags = list(tags)
+        self.node_type = node_type
+
+    def matches(self, xml):
+        return xml.tag in self.tags
+
+    def derive_nodes(self, xml, processor=None):
+        processor = SimpleHierarchyProcessor()
+        node = Node(label=[mtypes.MARKERLESS], source_xml=xml,
+                    node_type=self.node_type)
+        return [processor.process(xml, node)]

--- a/tests/notice_compiler_tests.py
+++ b/tests/notice_compiler_tests.py
@@ -136,19 +136,40 @@ class CompilerTests(TestCase):
         children = reg_tree.add_child(children, n1)
         self.assertEqual(children, [n1, n5])
 
-    def test_add_child_order(self):
+    def test_add_child_no_order(self):
+        """If no order is provided, the notice compiler will make a best guess
+        as to where the node should be inserted"""
         reg_tree = compiler.RegulationTree(None)
-        n1 = Node('n1', label=['205', 'A', '1'])
-        n2 = Node('n2', label=['205', 'A', '2'])
-        n3 = Node('n3', label=['205', 'A', '3'])
-        n4 = Node('n4', label=['205', 'A', '4'])
+        n1, n2, n3, n4 = (Node(label=['1', 'A', str(i)]) for i in range(1, 5))
 
         children = []
-        order = ['205-A-3', '205-A-2', '205-A-1']
+        children = reg_tree.add_child(children, n2)
+        self.assertEqual(children, [n2])
+        children = reg_tree.add_child(children, n1)
+        self.assertEqual(children, [n1, n2])
+        children = reg_tree.add_child(children, n3)
+        self.assertEqual(children, [n1, n2, n3])
+        children = reg_tree.add_child(children, n4)
+        self.assertEqual(children, [n1, n2, n3, n4])
+
+        children = [n1, n2]
+        children = reg_tree.add_child(children, n4)
+        self.assertEqual(children, [n1, n2, n4])
+
+    def test_add_child_order(self):
+        """If an order is provides, the notice compiler will follow that order
+        even when nodes are missing. Further, when adding a new node that is
+        not part of the order, we should expect minimal changes to the other
+        nodes"""
+        reg_tree = compiler.RegulationTree(None)
+        n1, n2, n3, n4 = (Node(label=['1', 'A', str(i)]) for i in range(1, 5))
+        order = ['1-A-3', '1-A-2', '1-A-1']
+
+        children = []
         children = reg_tree.add_child(children, n2, order)
         self.assertEqual(children, [n2])
         children = reg_tree.add_child(children, n1, order)
-        self.assertEqual(children, [n1, n2])
+        self.assertEqual(children, [n2, n1])
         children = reg_tree.add_child(children, n3, order)
         self.assertEqual(children, [n3, n2, n1])
         children = reg_tree.add_child(children, n4, order)

--- a/tests/tree_struct_tests.py
+++ b/tests/tree_struct_tests.py
@@ -5,32 +5,27 @@ from regparser.tree import struct
 
 
 class NodeTest(TestCase):
+    def assert_depth(self, depth, label, node_type=struct.Node.REGTEXT):
+        node = struct.Node("x", label=label, node_type=node_type)
+        self.assertEqual(depth, node.depth())
 
     def test_depth(self):
-        label = ["111", "1", "a", "p1"]
-        self.assertEqual(1, struct.Node("x", label=label[:1]).depth())
-        self.assertEqual(3, struct.Node("x", label=label[:2]).depth())
-        self.assertEqual(4, struct.Node("x", label=label[:3]).depth())
-        self.assertEqual(5, struct.Node("x", label=label).depth())
-        self.assertEqual(4, struct.Node("x", label=label,
-                                        node_type=struct.Node.INTERP).depth())
-        self.assertEqual(5, struct.Node("x", label=label,
-                                        node_type=struct.Node.EXTRACT).depth())
-        self.assertEqual(2, struct.Node("x", label=label[:1],
-                                        node_type=struct.Node.SUBPART).depth())
-        self.assertEqual(2, struct.Node("x", label=label[:2],
-                                        node_type=struct.Node.SUBPART).depth())
-        self.assertEqual(2, struct.Node("x", label=label[:3],
-                                        node_type=struct.Node.SUBPART).depth())
-        self.assertEqual(2,
-                         struct.Node("x", label=label[:1],
-                                     node_type=struct.Node.EMPTYPART).depth())
-        self.assertEqual(2,
-                         struct.Node("x", label=label[:2],
-                                     node_type=struct.Node.EMPTYPART).depth())
-        self.assertEqual(2,
-                         struct.Node("x", label=label[:3],
-                                     node_type=struct.Node.EMPTYPART).depth())
+        self.assert_depth(1, ["111"])
+
+        self.assert_depth(3, ["111", "1"])
+        self.assert_depth(4, ["111", "1", "a"])
+        self.assert_depth(5, ["111", "1", "a", "p1"])
+        self.assert_depth(5, ["111", "1", "a", "p1"], struct.Node.EXTRACT)
+        self.assert_depth(5, ["111", "1", "a", "p1"], struct.Node.NOTE)
+
+        self.assert_depth(3, ["111", "1", "Interp"], struct.Node.INTERP)
+        self.assert_depth(4, ["111", "1", "Interp", "a"], struct.Node.INTERP)
+        self.assert_depth(4, ["111", "A", "3", "a"], struct.Node.APPENDIX)
+        self.assert_depth(4, ["111", "A", "3", "a"], struct.Node.EXTRACT)
+        self.assert_depth(4, ["111", "A", "3", "a"], struct.Node.NOTE)
+
+        self.assert_depth(2, ["111", "Subpart", "A"], struct.Node.SUBPART)
+        self.assert_depth(2, ["111", "Subpart"], struct.Node.EMPTYPART)
 
 
 class DepthTreeTest(TestCase):

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -426,14 +426,14 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
                 extract.PRTPAGE(P="8")
                 extract.P("1. Some content")
                 extract.P("2. Other content")
-        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+        node = self.node_accessor(
+            reg_text.build_from_section('8675', self.tree.render_xml())[0],
+            ['8675', '309'])
 
-        a = node.children[0]
-        self.assertEqual(1, len(a.children))
-        extract = a.children[0]
-        self.assertEqual(['8675', '309', 'a', 'p1'], extract.label)
-        content = ["```note", "1. Some content", "2. Other content", "```"]
-        self.assertEqual("\n".join(content), extract.text)
+        self.assertEqual(['a'], node.child_labels)
+        self.assertEqual(['p1'], node['a'].child_labels)
+        self.assertEqual(Node.NOTE, node['a']['p1'].node_type)
+        self.assertEqual(['1', '2'], node['a']['p1'].child_labels)
 
     def test_build_from_section_whitespace(self):
         """The whitespace in the section text (and intro paragraph) should get

--- a/tests/tree_xml_parser_simple_hierarchy_processor_tests.py
+++ b/tests/tree_xml_parser_simple_hierarchy_processor_tests.py
@@ -1,0 +1,63 @@
+from unittest import TestCase
+
+from regparser.tree.xml_parser.simple_hierarchy_processor import (
+        SimpleHierarchyMatcher)
+from tests.xml_builder import XMLBuilderMixin
+from tests.node_accessor import NodeAccessorMixin
+
+
+class SimpleHierarchyTests(XMLBuilderMixin, NodeAccessorMixin, TestCase):
+    def test_deep_hierarchy(self):
+        """Run through a full example, converting an XML node into an
+        appropriate tree of nodes"""
+        with self.tree.builder("ROOT") as root:
+            root.P("(a) AAA")
+            root.P("(b) BBB")
+            root.P("i. BIBIBI")
+            root.P("ii. BIIBIIBII")
+            root.P("(1) BII1BII1BII1")
+            root.P("(2) BII2BII2BII2")
+            root.P("iii. BIIIBIIIBIII")
+            root.P("(c) CCC")
+
+        matcher = SimpleHierarchyMatcher(['ROOT'], 'some_type')
+        nodes = matcher.derive_nodes(self.tree.render_xml())
+        self.assertEqual(1, len(nodes))
+
+        node = self.node_accessor(nodes[0], nodes[0].label)
+        self.assertEqual('some_type', node.node_type)
+        self.assertEqual(['a', 'b', 'c'], node.child_labels)
+        self.assertNotEqual('some_type', node['a'].node_type)
+        self.assertEqual(node['a'].text, '(a) AAA')
+        self.assertEqual([], node['a'].child_labels)
+        self.assertEqual(node['c'].text, '(c) CCC')
+        self.assertEqual([], node['c'].child_labels)
+
+        self.assertEqual(node['b'].text, '(b) BBB')
+        self.assertEqual(['i', 'ii', 'iii'], node['b'].child_labels)
+        self.assertEqual(node['b']['i'].text, 'i. BIBIBI')
+        self.assertEqual([], node['b']['i'].child_labels)
+        self.assertEqual(node['b']['iii'].text, 'iii. BIIIBIIIBIII')
+        self.assertEqual([], node['b']['iii'].child_labels)
+
+        self.assertEqual(node['b']['ii'].text, 'ii. BIIBIIBII')
+        self.assertEqual(['1', '2'], node['b']['ii'].child_labels)
+        self.assertEqual(node['b']['ii']['1'].text, '(1) BII1BII1BII1')
+        self.assertEqual([], node['b']['ii']['1'].child_labels)
+        self.assertEqual(node['b']['ii']['2'].text, '(2) BII2BII2BII2')
+        self.assertEqual([], node['b']['ii']['2'].child_labels)
+
+    def test_no_children(self):
+        """Elements with only one, markerless paragraph should not have
+        children"""
+        with self.tree.builder("NOTE") as root:
+            root.P("Some text here")
+
+        matcher = SimpleHierarchyMatcher(['NOTE'], 'note')
+        nodes = matcher.derive_nodes(self.tree.render_xml())
+        self.assertEqual(1, len(nodes))
+        node = nodes[0]
+
+        self.assertEqual('note', node.node_type)
+        self.assertEqual('Some text here', node.text)
+        self.assertEqual([], node.children)


### PR DESCRIPTION
This adds smarts for parsing for `NOTE` and `NOTES`, specifically the ability to determine paragraph hierarchy within them. To do this, it adds a new type of paragraph matcher and processer which determines the paragraph marker for any paragraphs beginning with `(a)` or `a.` (or `i` or `1`). We've seen notes use both formats.

It also fixes a problem with notice compilation (which was re-ordering nodes based on heuristics and caused problems with `NOTE`s as a result) and the `depth()` function of `Nodes`, which was looking at the node type rather than "where" the node was located in the tree.

For 18f/atf-eregs#187