### PR TITLE
Add an expiry to the HTTP cache

### DIFF
--- a/eregs.py
+++ b/eregs.py
@@ -16,10 +16,12 @@ from regparser.index import dependency
 @click.group()
 @click.option('--debug/--no-debug', default=False)
 def cli(debug):
-    coloredlogs.install(level=logging.INFO, fmt="%(levelname)s %(message)s")
+    log_level = logging.INFO
     requests_cache.install_cache('fr_cache')
     if debug:
+        log_level = logging.DEBUG
         sys.excepthook = lambda t, v, tb: ipdb.post_mortem(tb)
+    coloredlogs.install(level=log_level, fmt="%(levelname)s %(message)s")
 
 
 for _, command_name, _ in pkgutil.iter_modules(commands.__path__):

--- a/eregs.py
+++ b/eregs.py
@@ -17,7 +17,7 @@ from regparser.index import dependency
 @click.option('--debug/--no-debug', default=False)
 def cli(debug):
     log_level = logging.INFO
-    requests_cache.install_cache('fr_cache')
+    requests_cache.install_cache('fr_cache', expire_after=60*60*24*3)  # 3 days
     if debug:
         log_level = logging.DEBUG
         sys.excepthook = lambda t, v, tb: ipdb.post_mortem(tb)


### PR DESCRIPTION
We missed a few new rules during the last demo due to having a forever cached set of HTTP responses. This limits the cache to three days. It also sets DEBUG logging when the debug flag is set.

Also see 18F/atf-eregs#280. This issue is tied to 18F/atf-eregs#265