### PR TITLE
Account for more whitespace

### DIFF
--- a/regparser/grammar/atomic.py
+++ b/regparser/grammar/atomic.py
@@ -1,10 +1,17 @@
 # vim: set encoding=utf-8
 """Atomic components; probably shouldn't use these directly"""
+from HTMLParser import HTMLParser
 import string
 
-from pyparsing import Optional, Regex, Suppress, Word
+from pyparsing import Optional, ParserElement, Regex, Suppress, Word
 
 from regparser.grammar.utils import Marker, SuffixMarker, WordBoundaries
+
+
+# Set whitespace for all parsing; include unicode whitespace chars
+ParserElement.setDefaultWhitespaceChars(
+    string.whitespace +
+    HTMLParser().unescape('&ensp;&emsp;&thinsp;&zwnj;&zwj;&lrm;&rlm;'))
 
 
 lower_p = (

--- a/tests/grammar_unified_tests.py
+++ b/tests/grammar_unified_tests.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from HTMLParser import HTMLParser
 from unittest import TestCase
 
 from regparser.grammar import unified
@@ -61,3 +62,15 @@ class GrammarCommonTests(TestCase):
             result = unified.marker_comment.parseString(t)
             self.assertEqual("3", result.section)
             self.assertEqual("4", result.c1)
+
+    def _decode(self, txt):
+        """Convert from HTML entities"""
+        return HTMLParser().unescape(txt)
+
+    def test_whitespace(self):
+        """Verify that various types of whitespace are ignored"""
+        for whitespace in (" ", "\n", "\t", self._decode(u'&#8201;')):
+            text = u'§{}478.39a'.format(whitespace)
+            result = unified.marker_part_section.parseString(text)
+            self.assertEqual("478", result.part)
+            self.assertEqual("39a", result.section)

--- a/tests/notice_sxs_tests.py
+++ b/tests/notice_sxs_tests.py
@@ -553,7 +553,7 @@ class NoticeSxsTests(TestCase):
         self.assertEqual(['1111-39', '1111-39-d'],
                          sxs.parse_into_labels(text, '101'))
 
-        text = "Appendix H—Closed-End Model Forms and Clauses-7(i)"
+        text = u"Appendix H—Closed-End Model Forms and Clauses-7(i)"
         self.assertEqual(['101-H'], sxs.parse_into_labels(text, '101'))
 
     def test_is_child_of(self):


### PR DESCRIPTION
By default Pyparsing only treats " \t\n" as whitespace chars. Unfortunately,
we've ran across a notice with a "thin-space" unicode character. This patch
configures Pyparsing to account for multiple unicode whitespace chars.

An alternative would be to preprocess all XML and replace thin spaces (and the
like) with normal spaces. We'll see once this rule is released in an annual
edition if that's the correct approach.

For 18f/atf-eregs#265