### PR TITLE
Strip external citations

### DIFF
--- a/regparser/layer/external_citations.py
+++ b/regparser/layer/external_citations.py
@@ -15,7 +15,7 @@ class ExternalCitationParser(Layer):
         for text, locations, representative in self.convert_to_search_replace(
                 citations, node.text, lambda c: c.start, lambda c: c.end):
             layer_elements.append(dict(
-                text=text, locations=locations, url=representative.url,
+                text=text.strip(), locations=locations, url=representative.url,
                 components=representative.components,
                 citation_type=representative.cite_type))
 


### PR DESCRIPTION
Closes 18F/atf-eregs/275.

This mimics regparser/layer/internal_citations.py#L55.
The underlying issue is that citations parsing (both internal and
external) "capture" trailing whitespace. This issue is masked by the
use of strip() before assertions in tests/citations.py.

A cleaner solution would be to fix the underlying issue.