### PR TITLE
AMDPAR definition paragraphs are identified

### DIFF
--- a/regparser/grammar/amdpar.py
+++ b/regparser/grammar/amdpar.py
@@ -465,6 +465,20 @@ override_label = (
     Suppress("]")
 ).setParseAction(tokenize_override_ps)
 
+
+# Phrases like '“Nonimmigrant visa”' become 'p12345678'
+_double_quote_label = QuotedString(
+        quoteChar=u'“', endQuoteChar=u'”'
+).setParseAction(lambda m: "p{}".format(keyterm_to_int(m[0])))
+# Phrases like "definition for the term “Nonimmigrant visa”" become a
+# paragraph token with the appropriate paragraph label set
+definition = (
+    Marker("definition") +
+    (Marker("of") | Marker("for")) +
+    Optional(Marker("the") + Marker("term")) +
+    _double_quote_label.copy().setResultsName("paragraph")
+).setParseAction(lambda m: tokens.Paragraph(paragraphs=[m.paragraph]))
+
 #   grammar which captures all of these possibilities
 token_patterns = QuickSearchable(
     put_active | put_passive | post_active | post_passive |
@@ -497,6 +511,8 @@ token_patterns = QuickSearchable(
     section |
     #   Must come after intro_text_of
     intro_text |
+
+    definition |
 
     # Finally allow for an explicit override label
     override_label |

--- a/tests/notice_diff_tests.py
+++ b/tests/notice_diff_tests.py
@@ -1,4 +1,5 @@
 # vim: set encoding=utf-8
+import re
 from unittest import TestCase
 
 from lxml import etree
@@ -668,6 +669,21 @@ class NoticeDiffTests(XMLBuilderMixin, TestCase):
         self.assertEqual(a3.label, ['1111', '22', 'a', 'Interp', '3'])
         self.assertEqual(a2add.action, tokens.Verb.POST)
         self.assertEqual(a2add.label, ['1111', '22', 'a', 'Interp', '2'])
+
+    def test_parse_amdpar_definition(self):
+        """We should correctly deduce which paragraphs are being updated, even
+        when they are identified by definition alone"""
+        text = ("Section 478.11 is amended by adding a definition for the "
+                u"term “Nonimmigrant visa” in alphabetical order to read as "
+                "follows:")
+        xml = etree.fromstring('<AMDPAR>%s</AMDPAR>' % text)
+        amends, _ = diff.parse_amdpar(xml, [])
+        self.assertEqual(1, len(amends))
+        self.assertEqual(amends[0].action, tokens.Verb.POST)
+        self.assertEqual(3, len(amends[0].label))
+        self.assertEqual(['478', '11'], amends[0].label[:2])
+        # Paragraph has a hash
+        self.assertTrue(re.match(r'p\d{4}\d+', amends[0].label[2]))
 
 
 class AmendmentTests(TestCase):


### PR DESCRIPTION
When definition paragraphs do not include a paragraph marker, they are
identified _by their embedded definition_. This tweak to the AMDPARser allows
these paragraphs to be found when referred to as:
* definition of “Appropriate ATF Officer”
* definition for “Person”
* definition for the term “Nonimmigrant visa”
* definition of the term “Article”

Resolves 18F/atf-eregs#281