### PR TITLE
Compare-to: make "nonexistent" warning more obvious

### DIFF
--- a/regparser/commands/compare_to.py
+++ b/regparser/commands/compare_to.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 
 import click
@@ -35,7 +36,7 @@ def compare(local_path, remote_url):
     diff"""
     remote_response = requests.get(remote_url)
     if remote_response.status_code == 404:
-        click.echo("Nonexistent: " + remote_url)
+        logging.warn("Nonexistent: %s", remote_url)
     else:
         remote = remote_response.json()
         with open(local_path) as f:

--- a/tests/commands_compare_to_tests.py
+++ b/tests/commands_compare_to_tests.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 
 import click
 from click.testing import CliRunner
+from mock import patch
 
 from regparser.commands import compare_to
 from tests.http_mixin import HttpMixin
@@ -67,9 +68,10 @@ class CommandsCompareToTests(HttpMixin, TestCase):
     def test_compare_404(self):
         """If the remote file doesn't exist, we should be notified"""
         self.expect_json_http(status=404)
-        result = self.run_compare('local_file', 'http://example.com/remote')
-        self.assertEqual('Nonexistent: http://example.com/remote\n',
-                         result.output)
+        with patch('regparser.commands.compare_to.logging') as logging:
+            self.run_compare('local_file', 'http://example.com/remote')
+        self.assertEqual(logging.warn.call_args[0],
+                         ('Nonexistent: %s', 'http://example.com/remote'))
 
     def test_compare_no_diff(self):
         """We shouldn't get any notification if the files are the same"""


### PR DESCRIPTION
Rather than just writing to stdout that a file exists locally but not
remotely, use logging.warn. This will emit a nicely colored message.