### PR TITLE
Don't look for defs in NOTEs, EXTRACTs, etc.

### DIFF
--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -54,8 +54,9 @@ class Terms(Layer):
                 for scope in self.scope_finder.determine_scope(stack):
                     self.scoped_terms[scope].extend(included)
             self.scoped_terms['EXCLUDED'].extend(excluded)
-        for child in node.children:
-            self.look_for_defs(child, stack)
+
+            for child in node.children:
+                self.look_for_defs(child, stack)
 
     def pre_process(self):
         """Step through every node in the tree, finding definitions. Also keep


### PR DESCRIPTION
Previously, we would look for definitions in _any_ regtext node of the tree,
regardless of whether that node was in an EXTRACT, NOTE, APPENDIX, etc. This
patch changes that to cut off whole subtrees. In this way, we won't find
definitions in NOTE, EXTRACT, etc.

Resolves 18f/atf-eregs#204