### PR TITLE
Refactor components of depth parsing

### DIFF
--- a/regparser/tree/depth/derive.py
+++ b/regparser/tree/depth/derive.py
@@ -1,6 +1,7 @@
 from constraint import Problem
 
 from regparser.tree.depth import markers, rules
+from regparser.tree.depth.pair_rules import pair_rules
 
 
 class ParAssignment(object):
@@ -115,7 +116,7 @@ def derive_depths(original_markers, additional_constraints=[]):
 
         if idx > 0:
             pairs = all_vars[3*(idx-1):]
-            problem.addConstraint(rules.depth_check, pairs)
+            problem.addConstraint(pair_rules, pairs)
 
         if idx > 1:
             pairs = all_vars[3*(idx-2):]

--- a/regparser/tree/depth/derive.py
+++ b/regparser/tree/depth/derive.py
@@ -128,7 +128,7 @@ def derive_depths(original_markers, additional_constraints=[]):
         params = all_vars[3*idx:3*(idx+1)]
         # then add on all previous
         params += all_vars[:3*idx]
-        problem.addConstraint(rules.sequence, params)
+        problem.addConstraint(rules.continue_previous_seq, params)
 
     # @todo: There's probably efficiency gains to making these rules over
     # prefixes (see above) rather than over the whole collection at once

--- a/regparser/tree/depth/pair_rules.py
+++ b/regparser/tree/depth/pair_rules.py
@@ -81,11 +81,18 @@ def markerless_same_level(prev, curr):
             prev.depth == curr.depth)
 
 
+def paragraph_markerless(prev, curr):
+    """A non-markerless paragraph followed by a markerless paragraph can be
+    one level deeper"""
+    return (not prev.is_markerless() and curr.is_markerless() and
+            curr.depth == prev.depth + 1)
+
+
 def pair_rules(prev_typ, prev_idx, prev_depth, typ, idx, depth):
     """Combine all of the above rules"""
     prev = MarkerAssignment(prev_typ, prev_idx, prev_depth)
     curr = MarkerAssignment(typ, idx, depth)
     fns = (decrement_depth, continuing_seq, decreasing_stars,
            same_level_stars, star_marker_level, marker_star_level,
-           new_sequence)
+           new_sequence, markerless_same_level, paragraph_markerless)
     return any(fn(prev, curr) for fn in fns)

--- a/regparser/tree/depth/pair_rules.py
+++ b/regparser/tree/depth/pair_rules.py
@@ -1,0 +1,91 @@
+"""Rules relating to two paragraph markers in sequence. The rules are
+"positive" in the sense that each allows for a particular scenario (rather
+than denying all other scenarios). They combined in the eponymous function,
+where, if any of the rules return True, we pass. Otherwise, we fail."""
+from collections import namedtuple
+
+from regparser.tree.depth import markers
+
+
+# @todo - this might be helpful in other rules, too
+class MarkerAssignment(namedtuple('MarkerAssignment',
+                                  ('typ', 'idx', 'depth'))):
+    def is_markerless(self):
+        """We will often check whether an assignment is MARKERLESS. This
+        function makes that clearer"""
+        return self.typ == markers.markerless
+
+    def is_stars(self):
+        """We will often check whether an assignment is either STARS or inline
+        stars (* * *). This function makes that clearer"""
+        return self.typ == markers.stars
+
+    def is_inline_stars(self):
+        """Inline stars (* * *) often behave quite differently from both STARS
+        and other markers."""
+        return self.is_stars() and self.idx == 1
+
+
+def decrement_depth(prev, curr):
+    """Decrementing depth is okay unless we're using inline stars"""
+    return curr.depth < prev.depth and not curr.is_inline_stars()
+
+
+def continuing_seq(prev, curr):
+    """E.g. "d, e" is good, but "e, d" is not."""
+    return (curr.depth == prev.depth and
+            curr.typ == prev.typ and
+            curr.idx == prev.idx + 1)
+
+
+def decreasing_stars(prev, curr):
+    """Two stars in a row can exist if the second is shallower than the
+    first"""
+    return prev.is_stars() and curr.is_stars() and curr.depth < prev.depth
+
+
+def same_level_stars(prev, curr):
+    """Two stars in a row can exist on the same level if the previous is
+    inline"""
+    two_stars = prev.is_stars() and curr.is_stars()
+    return two_stars and prev.depth == curr.depth and prev.is_inline_stars()
+
+
+def star_marker_level(prev, curr):
+    """Allow markers to be on the same level as a preceding star"""
+    return (prev.is_stars() and not curr.is_stars() and
+            prev.depth == curr.depth)
+
+
+def marker_star_level(prev, curr):
+    """Allow a marker to be followed by stars if those stars are deeper. If
+    not inline, also allow the stars to be at the same depth"""
+    possible_depths = {prev.depth + 1}
+    if curr.is_stars() and not curr.is_inline_stars():
+        possible_depths.add(prev.depth)
+
+    return (not prev.is_stars() and curr.is_stars() and
+            curr.depth in possible_depths)
+
+
+def new_sequence(prev, curr):
+    """Allow depth to be incremented if starting a new sequence"""
+    return (curr.idx == 0 and
+            curr.depth == prev.depth + 1 and
+            curr.typ != prev.typ)
+
+
+def markerless_same_level(prev, curr):
+    """Markerless sequences are allowed if they are on the same level"""
+    return (prev.is_markerless() and curr.is_markerless() and
+            prev.depth == curr.depth)
+
+
+def pair_rules(prev_typ, prev_idx, prev_depth, typ, idx, depth):
+    """Combine all of the above rules"""
+    prev = MarkerAssignment(prev_typ, prev_idx, prev_depth)
+    curr = MarkerAssignment(typ, idx, depth)
+    fns = (decrement_depth, continuing_seq, decreasing_stars,
+           same_level_stars, star_marker_level, marker_star_level,
+           new_sequence)
+    return any(fn(prev, curr) for fn in fns)

--- a/regparser/tree/depth/rules.py
+++ b/regparser/tree/depth/rules.py
@@ -10,6 +10,7 @@ this symmetry, we explicitly reject one solution; this reduces the number of
 permutations we care about dramatically.
 """
 from regparser.tree.depth import markers
+from regparser.tree.depth.pair_rules import pair_rules
 
 
 def must_be(value):
@@ -120,13 +121,7 @@ def continue_previous_seq(typ, idx, depth, *all_prev):
     if depth < len(ancestors) - 1:
         # Find the previous marker at this depth
         prev_typ, prev_idx, prev_depth = ancestors[depth]
-        types = set([prev_typ, typ])
-        if markers.stars in types:          # Special cases around STARS...
-            return len(types) == 2
-        elif markers.markerless in types:   # ... and MARKERLESS
-            return len(types) == 1
-        else:
-            return idx == prev_idx + 1 and prev_typ == typ
+        return pair_rules(prev_typ, prev_idx, prev_depth, typ, idx, depth)
     else:
         return True
 

--- a/regparser/tree/depth/rules.py
+++ b/regparser/tree/depth/rules.py
@@ -110,32 +110,25 @@ def triplet_tests(*triplet_seq):
     )
 
 
-def sequence(typ, idx, depth, *all_prev):
+def continue_previous_seq(typ, idx, depth, *all_prev):
     """Constrain the current marker based on all markers leading up to it"""
     # Group (type, idx, depth) per marker
     all_prev = [tuple(all_prev[i:i+3]) for i in range(0, len(all_prev), 3)]
-    prev_typ, prev_idx, prev_depth = all_prev[-1]
 
-    if typ == markers.stars:    # Accounted for elsewhere
-        return True
-    # If following stars and on the same level, we're good
-    elif (typ != prev_typ and prev_typ == markers.stars and
-            depth == prev_depth):
-        return True     # Stars
-    elif typ == markers.markerless:
-        if typ == prev_typ:
-            return depth == prev_depth
+    ancestors = _ancestors(all_prev)
+    # Becoming more shallow
+    if depth < len(ancestors) - 1:
+        # Find the previous marker at this depth
+        prev_typ, prev_idx, prev_depth = ancestors[depth]
+        types = set([prev_typ, typ])
+        if markers.stars in types:          # Special cases around STARS...
+            return len(types) == 2
+        elif markers.markerless in types:   # ... and MARKERLESS
+            return len(types) == 1
         else:
-            return depth <= prev_depth + 1
-    else:
-        ancestors = _ancestors(all_prev)
-        # Starting a new sequence
-        if len(ancestors) == depth:
-            return idx == 0 and typ != prev_typ
-        elif len(ancestors) > depth:
-            prev_typ, prev_idx, prev_depth = ancestors[depth]
             return idx == prev_idx + 1 and prev_typ == typ
-    return False
+    else:
+        return True
 
 
 def same_parent_same_type(*all_vars):

--- a/regparser/tree/depth/rules.py
+++ b/regparser/tree/depth/rules.py
@@ -9,7 +9,6 @@ may not matter if we're planning to ignore the final STARS anyway. To "break"
 this symmetry, we explicitly reject one solution; this reduces the number of
 permutations we care about dramatically.
 """
-
 from regparser.tree.depth import markers
 
 
@@ -24,42 +23,6 @@ def type_match(marker):
     """The type of the associated variable must match its marker. Lambda
     explanation as in the above rule."""
     return lambda typ, idx: idx < len(typ) and typ[idx] == marker
-
-
-def depth_check(prev_typ, prev_idx, prev_depth, typ, idx, depth):
-    """Constrain the depth of sequences of markers."""
-    # decrementing depth is okay unless inline stars
-    dec = depth < prev_depth and not (typ == markers.stars and idx == 1)
-    # continuing a sequence
-    cont = depth == prev_depth and prev_typ == typ and idx == prev_idx + 1
-    stars = _stars_check(prev_typ, prev_idx, prev_depth, typ, idx, depth)
-    # depth can be incremented if starting a new sequence
-    inc = depth == prev_depth + 1 and idx == 0 and typ != prev_typ
-    # markerless in sequence must have the same level
-    mless_seq = (prev_typ == typ and prev_depth == depth and
-                 typ == markers.markerless)
-    return dec or cont or stars or inc or mless_seq
-
-
-def _stars_check(prev_typ, prev_idx, prev_depth, typ, idx, depth):
-    """Constrain pairs of markers where one is a star."""
-    # Seq of stars
-    if prev_typ == markers.stars and typ == prev_typ:
-        # Decreasing depth is always okay
-        dec = depth < prev_depth
-        # Can only be on the same level if prev is inline
-        same = depth == prev_depth and prev_idx == 1
-        return dec or same
-    # Marker following stars
-    elif prev_typ == markers.stars:
-        return depth == prev_depth
-    # Inline Stars following marker
-    elif typ == markers.stars and idx == 1:
-        return depth == prev_depth + 1
-    elif typ == markers.stars:
-        return depth in (prev_depth, prev_depth + 1)
-    else:
-        return False
 
 
 def markerless_sandwich(pprev_typ, pprev_idx, pprev_depth,


### PR DESCRIPTION
Move all constraints on pairs of paragraph markers into a single module; give
them all the same interface and explain their nature. Also use a named tuple
to make it clear what's being compared.

We had a `sequence` rule which was repeating many of the checks we performed
on pairs of paragraph markers. This removes that redundancy and hopefully
makes it more clear what's being tested

This is a bit more code in terms of number of lines, but should be easier to
test and reason about.

Part of 18f/atf-eregs#251