### PR TITLE
Allow paragraphs to be skipped

### DIFF
--- a/regparser/tree/depth/optional_rules.py
+++ b/regparser/tree/depth/optional_rules.py
@@ -53,10 +53,12 @@ def limit_paragraph_types(*p_types):
     return constrainer
 
 
-def gapless_sequence(constrain, all_variables):
+def limit_sequence_gap(size=0):
     """We've loosened the rules around sequences of paragraphs so that
-    paragraphs can be skipped. This rule tightens that again, requiring all
-    normal paragraphs to progress in an unbroken sequence"""
+    paragraphs can be skipped. This allows arbitrary tightening of that rule,
+    effectively allowing gaps of a limited size"""
+    gap_size = size + 1     # we'll always want the difference to be >= 1
+
     def inner(typ, idx, depth, *all_prev):
         ancestor_markers = ancestors(all_prev)
         # Continuing a sequence or becoming more shallow
@@ -66,8 +68,11 @@ def gapless_sequence(constrain, all_variables):
             types = set([prev_typ, typ])
             special_types = set([markers.stars, markers.markerless])
             if not special_types & types and prev_typ == typ:
-                return idx == prev_idx + 1
+                return idx > prev_idx and idx - prev_idx <= gap_size
         return True
 
-    for i in range(0, len(all_variables), 3):
-        constrain(inner, all_variables[i:i+3] + all_variables[:i])
+    def constrainer(constrain, all_variables):
+        for i in range(0, len(all_variables), 3):
+            constrain(inner, all_variables[i:i+3] + all_variables[:i])
+
+    return constrainer

--- a/regparser/tree/depth/pair_rules.py
+++ b/regparser/tree/depth/pair_rules.py
@@ -33,12 +33,10 @@ def decrement_depth(prev, curr):
 
 def continuing_seq(prev, curr):
     """E.g. "d, e" is good, but "e, d" is not. We also want to allow some
-    paragraphs to be skipped, e.g. "d, g", but we put a cap of 5 characters to
-    limit complexity introduced w/ roman numerals i, v, and x"""
+    paragraphs to be skipped, e.g. "d, g" """
     return (curr.depth == prev.depth and
             curr.typ == prev.typ and
-            curr.idx >= prev.idx + 1 and
-            curr.idx <= prev.idx + 5)
+            curr.idx >= prev.idx + 1)
 
 
 def decreasing_stars(prev, curr):

--- a/regparser/tree/depth/pair_rules.py
+++ b/regparser/tree/depth/pair_rules.py
@@ -32,10 +32,13 @@ def decrement_depth(prev, curr):
 
 
 def continuing_seq(prev, curr):
-    """E.g. "d, e" is good, but "e, d" is not."""
+    """E.g. "d, e" is good, but "e, d" is not. We also want to allow some
+    paragraphs to be skipped, e.g. "d, g", but we put a cap of 5 characters to
+    limit complexity introduced w/ roman numerals i, v, and x"""
     return (curr.depth == prev.depth and
             curr.typ == prev.typ and
-            curr.idx == prev.idx + 1)
+            curr.idx >= prev.idx + 1 and
+            curr.idx <= prev.idx + 5)
 
 
 def decreasing_stars(prev, curr):

--- a/regparser/tree/depth/pair_rules.py
+++ b/regparser/tree/depth/pair_rules.py
@@ -1,6 +1,6 @@
 """Rules relating to two paragraph markers in sequence. The rules are
 "positive" in the sense that each allows for a particular scenario (rather
-than denying all other scenarios). They combined in the eponymous function,
+than denying all other scenarios). They combine in the eponymous function,
 where, if any of the rules return True, we pass. Otherwise, we fail."""
 from collections import namedtuple
 

--- a/regparser/tree/depth/rules.py
+++ b/regparser/tree/depth/rules.py
@@ -113,14 +113,11 @@ def triplet_tests(*triplet_seq):
 
 def continue_previous_seq(typ, idx, depth, *all_prev):
     """Constrain the current marker based on all markers leading up to it"""
-    # Group (type, idx, depth) per marker
-    all_prev = [tuple(all_prev[i:i+3]) for i in range(0, len(all_prev), 3)]
-
-    ancestors = _ancestors(all_prev)
+    ancestor_markers = ancestors(all_prev)
     # Becoming more shallow
-    if depth < len(ancestors) - 1:
+    if depth < len(ancestor_markers) - 1:
         # Find the previous marker at this depth
-        prev_typ, prev_idx, prev_depth = ancestors[depth]
+        prev_typ, prev_idx, prev_depth = ancestor_markers[depth]
         return pair_rules(prev_typ, prev_idx, prev_depth, typ, idx, depth)
     else:
         return True
@@ -200,9 +197,12 @@ def depth_type_order(order):
     return inner
 
 
-def _ancestors(all_prev):
+def ancestors(all_prev):
     """Given an assignment of values, construct a list of the relevant
     parents, e.g. 1, i, a, ii, A gives us 1, ii, A"""
+    # Group (type, idx, depth) per marker
+    all_prev = [tuple(all_prev[i:i+3]) for i in range(0, len(all_prev), 3)]
+
     result = [None]*10
     for prev_type, prev_idx, prev_depth in all_prev:
         result[prev_depth] = (prev_type, prev_idx, prev_depth)

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -308,7 +308,7 @@ class RegtextParagraphProcessor(paragraph_processor.ParagraphProcessor):
     def additional_constraints(self):
         return [optional_rules.depth_type_inverses,
                 optional_rules.star_new_level,
-                optional_rules.gapless_sequence,
+                optional_rules.limit_sequence_gap(),
                 optional_rules.limit_paragraph_types(
                     mtypes.lower, mtypes.upper, mtypes.ints, mtypes.roman,
                     mtypes.em_ints, mtypes.em_roman, mtypes.stars,

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -308,6 +308,7 @@ class RegtextParagraphProcessor(paragraph_processor.ParagraphProcessor):
     def additional_constraints(self):
         return [optional_rules.depth_type_inverses,
                 optional_rules.star_new_level,
+                optional_rules.gapless_sequence,
                 optional_rules.limit_paragraph_types(
                     mtypes.lower, mtypes.upper, mtypes.ints, mtypes.roman,
                     mtypes.em_ints, mtypes.em_roman, mtypes.stars,

--- a/regparser/tree/xml_parser/us_code.py
+++ b/regparser/tree/xml_parser/us_code.py
@@ -49,7 +49,7 @@ class USCodeProcessor(paragraph_processor.ParagraphProcessor):
     MATCHERS = [USCodeParagraphMatcher()]
 
     def additional_constraints(self):
-        return [optional_rules.gapless_sequence,
+        return [optional_rules.limit_sequence_gap(),
                 optional_rules.limit_paragraph_types(
                     mtypes.lower, mtypes.ints, mtypes.upper, mtypes.roman,
                     mtypes.upper_roman)]

--- a/regparser/tree/xml_parser/us_code.py
+++ b/regparser/tree/xml_parser/us_code.py
@@ -49,9 +49,10 @@ class USCodeProcessor(paragraph_processor.ParagraphProcessor):
     MATCHERS = [USCodeParagraphMatcher()]
 
     def additional_constraints(self):
-        return [optional_rules.limit_paragraph_types(
-            mtypes.lower, mtypes.ints, mtypes.upper, mtypes.roman,
-            mtypes.upper_roman)]
+        return [optional_rules.gapless_sequence,
+                optional_rules.limit_paragraph_types(
+                    mtypes.lower, mtypes.ints, mtypes.upper, mtypes.roman,
+                    mtypes.upper_roman)]
 
 
 class USCodeMatcher(paragraph_processor.BaseMatcher):

--- a/tests/tree_depth_derive_tests.py
+++ b/tests/tree_depth_derive_tests.py
@@ -64,7 +64,7 @@ class DeriveTests(TestCase):
                                 [0, 1, 2, 2])
 
         self.assert_depth_match_extra(['A', '1', 'a', STARS_TAG, 'd'],
-                                      [optional_rules.gapless_sequence],
+                                      [optional_rules.limit_sequence_gap()],
                                       [0, 1, 2, 2, 2])
 
     def test_ambiguous_stars(self):
@@ -81,7 +81,7 @@ class DeriveTests(TestCase):
     def test_alpha_roman_ambiguous(self):
         self.assert_depth_match_extra(
             ['i', 'ii', STARS_TAG, 'v', STARS_TAG, 'vii'],
-            [optional_rules.gapless_sequence],
+            [optional_rules.limit_sequence_gap()],
             [0, 0, 1, 1, 2, 2],
             [0, 0, 1, 1, 0, 0],
             [0, 0, 0, 0, 0, 0])
@@ -90,7 +90,7 @@ class DeriveTests(TestCase):
         self.assert_depth_match_extra(
             [STARS_TAG, 'c', '1', STARS_TAG, 'ii', 'iii', '2', 'i', 'ii',
              STARS_TAG, 'v', STARS_TAG, 'vii', 'A'],
-            [optional_rules.gapless_sequence],
+            [optional_rules.limit_sequence_gap()],
             [0, 0, 1, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 3],
             [0, 0, 1, 2, 2, 2, 1, 2, 2, 3, 3, 2, 2, 3],
             [0, 0, 1, 2, 2, 2, 1, 2, 2, 3, 3, 4, 4, 5],
@@ -149,13 +149,13 @@ class DeriveTests(TestCase):
         """Two markers of the same type should have the same depth"""
         self.assert_depth_match_extra(
             ['1', STARS_TAG, 'b', STARS_TAG, 'C', STARS_TAG, 'd'],
-            [optional_rules.gapless_sequence],
+            [optional_rules.limit_sequence_gap()],
             [0, 1, 1, 2, 2, 3, 3],
             [0, 1, 1, 2, 2, 1, 1])
 
         self.assert_depth_match_extra(
             ['1', STARS_TAG, 'b', STARS_TAG, 'C', STARS_TAG, 'd'],
-            [optional_rules.gapless_sequence,
+            [optional_rules.limit_sequence_gap(),
              optional_rules.depth_type_inverses],
             [0, 1, 1, 2, 2, 1, 1])
 
@@ -163,13 +163,13 @@ class DeriveTests(TestCase):
         """Two markers of the same depth should have the same type"""
         self.assert_depth_match_extra(
             ['1', STARS_TAG, 'c', '2', INLINE_STARS, 'i', STARS_TAG, 'iii'],
-            [optional_rules.gapless_sequence],
+            [optional_rules.limit_sequence_gap()],
             [0, 1, 1, 0, 1, 1, 1, 1],
             [0, 1, 1, 0, 1, 1, 2, 2])
 
         self.assert_depth_match_extra(
             ['1', STARS_TAG, 'c', '2', INLINE_STARS, 'i', STARS_TAG, 'iii'],
-            [optional_rules.gapless_sequence,
+            [optional_rules.limit_sequence_gap(),
              optional_rules.depth_type_inverses],
             [0, 1, 1, 0, 1, 1, 2, 2])
 
@@ -185,13 +185,15 @@ class DeriveTests(TestCase):
         self.assert_depth_match(
             ['a', STARS_TAG, 'i'],
             [0, 0, 0],
-            [0, 0, 1]
+            [0, 0, 1],
+            [0, 1, 0]
         )
 
         self.assert_depth_match_extra(
             ['a', STARS_TAG, 'i'],
             [optional_rules.star_new_level],
-            [0, 0, 0]
+            [0, 0, 0],
+            [0, 1, 0]
         )
 
     def test_marker_stars_markerless_symmetry(self):
@@ -211,7 +213,8 @@ class DeriveTests(TestCase):
         """Capitalized roman numerals can be paragraphs"""
         self.assert_depth_match(
             ['x', '1', 'A', 'i', 'I'],
-            [0, 1, 2, 3, 4])
+            [0, 1, 2, 3, 4],
+            [0, 1, 2, 3, 2])
 
     def test_limit_paragraph_types(self):
         """Limiting paragraph types limits how the markers are interpreted"""
@@ -226,16 +229,22 @@ class DeriveTests(TestCase):
             [0, 0, 0]
         )
 
-    def test_gapless_sequence(self):
-        """The gapless_sequence rule should limit our ability to derive depths
-        with gaps between adjacent paragraphs"""
-        self.assert_depth_match(['a', 'b', 'c', 'd', 'e', '1', 'i'],
-                                [0, 0, 0, 0, 0, 1, 2],
-                                [0, 0, 0, 0, 0, 1, 0])
+    def test_limit_sequence_gap(self):
+        """The limit_sequence_gap rule should limit our ability to derive
+        depths with gaps between adjacent paragraphs. It should be
+        configurable to allow any value"""
+        self.assert_depth_match(['a', '1', 'i'],
+                                [0, 1, 2],
+                                [0, 1, 0])
 
-        self.assert_depth_match_extra(['a', 'b', 'c', 'd', 'e', '1', 'i'],
-                                      [optional_rules.gapless_sequence],
-                                      [0, 0, 0, 0, 0, 1, 2])
+        self.assert_depth_match_extra(['a', '1', 'i'],
+                                      [optional_rules.limit_sequence_gap()],
+                                      [0, 1, 2])
+
+        self.assert_depth_match_extra(['a', '1', 'i'],
+                                      [optional_rules.limit_sequence_gap(10)],
+                                      [0, 1, 2],
+                                      [0, 1, 0])
 
     def test_debug_idx(self):
         """Find the index of the first error when attempting to derive


### PR DESCRIPTION
Builds on #170 ([diff](https://github.com/cmc333333/regulations-parser/compare/251-refactor-depths...cmc333333:251-skipped-p)) to allow paragraph markers to be skipped, e.g.

```
(c)
NOTE: (d) and (e) have been reserved
(f)
```

It does this by removing the constraint that markers must be "gapless" sequences. This makes that constraint optional (and configurable, in terms of acceptable gap size). Further, it re-adds that optional constraint to US Code and RegText processors to retain previous workings.

Resolves 18f/atf-eregs#251 -- once we add a paragraph processor specific to the import list, we just need to exclude (or configure) this optional constraint.