### PR TITLE
Import List preprocessing

### DIFF
--- a/regparser/tree/xml_parser/import_category.py
+++ b/regparser/tree/xml_parser/import_category.py
@@ -1,0 +1,10 @@
+"""Example processor for the IMPORTCATEGORY tag. This will be replaced with
+something more sophisticated and should be in an ATF-specific submodule"""
+from regparser.tree.struct import Node
+from regparser.tree.xml_parser import flatsubtree_processor
+
+
+class ImportCategoryMatcher(flatsubtree_processor.FlatsubtreeMatcher):
+    def __init__(self):
+        super(ImportCategoryMatcher, self).__init__(tags=['IMPORTCATEGORY'],
+                                                    node_type=Node.EXTRACT)

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -98,8 +98,8 @@ class ParagraphProcessor(object):
         first_xml = nodes[0].source_xml if len(nodes) else None
         table_first = first_xml is not None and first_xml.tag == "GPOTABLE"
         extract_first = nodes[0].node_type == "extract" if len(nodes) else None
-        if not any(
-            [table_first, extract_first]) and any(
+        has_title = nodes[0].title if len(nodes) else None
+        if not any([table_first, extract_first, has_title]) and any(
                 [only_one, switches_after_first]):
             return nodes[0], nodes[1:]
         else:

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -9,8 +9,8 @@ from regparser.tree.depth import markers as mtypes, optional_rules
 from regparser.tree.struct import Node
 from regparser.tree.paragraph import p_level_of, p_levels
 from regparser.tree.xml_parser import (
-    flatsubtree_processor, paragraph_processor, simple_hierarchy_processor,
-    tree_utils)
+    flatsubtree_processor, import_category, paragraph_processor,
+    simple_hierarchy_processor, tree_utils)
 from regparser.tree.xml_parser.appendices import build_non_reg_text
 
 
@@ -298,8 +298,8 @@ class RegtextParagraphProcessor(paragraph_processor.ParagraphProcessor):
                 paragraph_processor.TableMatcher(),
                 paragraph_processor.FencedMatcher(),
                 flatsubtree_processor.FlatsubtreeMatcher(
-                    tags=['EXTRACT', 'IMPORTCATEGORY'],
-                    node_type=Node.EXTRACT),
+                    tags=['EXTRACT'], node_type=Node.EXTRACT),
+                import_category.ImportCategoryMatcher(),
                 flatsubtree_processor.FlatsubtreeMatcher(tags=['EXAMPLE']),
                 paragraph_processor.HeaderMatcher(),
                 ParagraphMatcher(),

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -298,7 +298,8 @@ class RegtextParagraphProcessor(paragraph_processor.ParagraphProcessor):
                 paragraph_processor.TableMatcher(),
                 paragraph_processor.FencedMatcher(),
                 flatsubtree_processor.FlatsubtreeMatcher(
-                    tags=['EXTRACT'], node_type=Node.EXTRACT),
+                    tags=['EXTRACT', 'IMPORTCATEGORY'],
+                    node_type=Node.EXTRACT),
                 flatsubtree_processor.FlatsubtreeMatcher(tags=['EXAMPLE']),
                 paragraph_processor.HeaderMatcher(),
                 ParagraphMatcher(),

--- a/tests/tree_xml_parser_paragraph_processor_tests.py
+++ b/tests/tree_xml_parser_paragraph_processor_tests.py
@@ -138,6 +138,14 @@ class ParagraphProcessorTest(TestCase):
         self.assertIsNone(intro)
         self.assertEqual(nodes, rest)
 
+    def test_separate_intro_with_title(self):
+        """Paragraphs with a title shouldn't be considered intro paragraphs"""
+        nodes = [Node(label=[mtypes.MARKERLESS], title='Some awesome title'),
+                 Node(label=['a']), Node(label=['b']), Node(label='1')]
+        intro, rest = _ExampleProcessor().separate_intro(nodes)
+        self.assertIsNone(intro)
+        self.assertEqual(nodes, rest)
+
     def test_separate_intro_with_table(self):
         """ We don't want tables to be turned into intro paragraphs. """
         # A MARKERLESS node followed by a table node:


### PR DESCRIPTION
See changeset for more details, but this adds a preprocessing step the ATF's 447.21 to split out each category within the import list into it's own EXTRACT (for now). This code doesn't belong in this core repo -- we will need to split it out and add proper tests once the plugin interface is defined. In the meantime, this gets a proof of concept up and closes 18f/atf-eregs#305