### PR TITLE
Better hierarchy in IMPORTCATEGORY

### DIFF
--- a/regparser/grammar/amdpar.py
+++ b/regparser/grammar/amdpar.py
@@ -9,8 +9,7 @@ from pyparsing import (
 
 from regparser.grammar import atomic, tokens, unified
 from regparser.grammar.utils import Marker, QuickSearchable, WordBoundaries
-from regparser.layer.key_terms import keyterm_to_int
-from regparser.tree.paragraph import p_levels
+from regparser.tree.paragraph import p_levels, hash_for_paragraph
 from regparser.tree.reg_text import subjgrp_label
 
 
@@ -451,7 +450,7 @@ def tokenize_override_ps(match):
 _keyterm_label_part = (
     Suppress(Marker("keyterm")) +
     QuotedString(quoteChar='(', endQuoteChar=')')
-).setParseAction(lambda m: "p{}".format(keyterm_to_int(m[0])))
+).setParseAction(lambda m: "p{}".format(hash_for_paragraph(m[0])))
 _simple_label_part = Word(string.ascii_lowercase + string.ascii_uppercase +
                           string.digits)
 _label_part = _keyterm_label_part | _simple_label_part
@@ -478,7 +477,7 @@ subject_group = (
 # Phrases like '“Nonimmigrant visa”' become 'p12345678'
 _double_quote_label = QuotedString(
         quoteChar=u'“', endQuoteChar=u'”'
-).setParseAction(lambda m: "p{}".format(keyterm_to_int(m[0])))
+).setParseAction(lambda m: "p{}".format(hash_for_paragraph(m[0])))
 # Phrases like "definition for the term “Nonimmigrant visa”" become a
 # paragraph token with the appropriate paragraph label set
 definition = (

--- a/regparser/layer/key_terms.py
+++ b/regparser/layer/key_terms.py
@@ -1,4 +1,3 @@
-import hashlib
 import re
 
 from layer import Layer
@@ -16,20 +15,6 @@ def eliminate_extras(keyterm):
         if keyterm.endswith(extra):
             keyterm = keyterm[:-len(extra)]
     return keyterm
-
-
-_NONWORDS = re.compile(r'\W+')
-
-
-def keyterm_to_int(keyterm):
-    """Hash a keyterm's text and convert it into an integer. We'll trim to
-    just 8 hex characters for legibility. We don't need to fear hash
-    collisions as we'll have 16**8 ~ 4 billion possibilities. The birthday
-    paradox tells us we'd only expect collisions after ~ 60 thousand entries.
-    We're expecting at most a few hundred"""
-    phrase = _NONWORDS.sub('', keyterm.lower())
-    hashed = hashlib.sha1(phrase).hexdigest()[:8]
-    return int(hashed, 16)
 
 
 class KeyTerms(Layer):

--- a/regparser/tree/depth/derive.py
+++ b/regparser/tree/depth/derive.py
@@ -2,6 +2,7 @@ from constraint import Problem
 
 from regparser.tree.depth import markers, rules
 from regparser.tree.depth.pair_rules import pair_rules
+from regparser.tree.struct import Node
 
 
 class ParAssignment(object):
@@ -50,7 +51,7 @@ def _compress_markerless(marker_list):
     result = []
     saw_markerless = False
     for marker in marker_list:
-        if marker != markers.MARKERLESS:
+        if not Node.is_markerless_label([marker]):
             saw_markerless = False
             result.append(marker)
         elif not saw_markerless:
@@ -66,7 +67,7 @@ def _decompress_markerless(assignment, marker_list):
     saw_markerless = False
     a_idx = -1      # idx in the assignment dict
     for m_idx, marker in enumerate(marker_list):
-        if marker != markers.MARKERLESS:
+        if not Node.is_markerless_label([marker]):
             saw_markerless = False
             a_idx += 1
         elif not saw_markerless:

--- a/regparser/tree/paragraph.py
+++ b/regparser/tree/paragraph.py
@@ -1,3 +1,4 @@
+import hashlib
 import itertools
 import re
 import string
@@ -26,6 +27,21 @@ def p_level_of(marker):
         if marker in markers:
             potential_levels.append(level)
     return potential_levels
+
+
+_NONWORDS = re.compile(r'\W+')
+
+
+def hash_for_paragraph(text):
+    """Hash a chunk of text and convert it into an integer for use with a
+    MARKERLESS paragraph identifier. We'll trim to just 8 hex characters for
+    legibility. We don't need to fear hash collisions as we'll have 16**8 ~ 4
+    billion possibilities. The birthday paradox tells us we'd only expect
+    collisions after ~ 60 thousand entries.  We're expecting at most a few
+    hundred"""
+    phrase = _NONWORDS.sub('', text.lower())
+    hashed = hashlib.sha1(phrase).hexdigest()[:8]
+    return int(hashed, 16)
 
 
 class ParagraphParser():

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -4,6 +4,8 @@ import hashlib
 
 from lxml import etree
 
+from regparser.tree.depth.markers import MARKERLESS
+
 
 class Node(object):
     APPENDIX = u'appendix'
@@ -58,11 +60,12 @@ class Node(object):
             #   Add one for the subpart level
             return len(self.label) + 1
 
-    @staticmethod
-    def is_markerless_label(label):
+    @classmethod
+    def is_markerless_label(cls, label):
         if not label:
             return None
-        return re.match(Node.MARKERLESS_REGEX, label[-1])
+        return (cls.MARKERLESS_REGEX.match(label[-1]) or
+                label[-1] == MARKERLESS)
 
     def is_markerless(self):
         return bool(self.is_markerless_label(self.label))

--- a/regparser/tree/xml_parser/import_category.py
+++ b/regparser/tree/xml_parser/import_category.py
@@ -1,10 +1,42 @@
-"""Example processor for the IMPORTCATEGORY tag. This will be replaced with
-something more sophisticated and should be in an ATF-specific submodule"""
+from copy import deepcopy
+import logging
+import re
+
+from regparser.tree.depth import markers as mtypes
+from regparser.tree.paragraph import hash_for_paragraph
 from regparser.tree.struct import Node
-from regparser.tree.xml_parser import flatsubtree_processor
+from regparser.tree.xml_parser import paragraph_processor, tree_utils
 
 
-class ImportCategoryMatcher(flatsubtree_processor.FlatsubtreeMatcher):
-    def __init__(self):
-        super(ImportCategoryMatcher, self).__init__(tags=['IMPORTCATEGORY'],
-                                                    node_type=Node.EXTRACT)
+class ImportCategoryMatcher(paragraph_processor.BaseMatcher):
+    """The IMPORTCATEGORY gets converted into a subtree with an appropriate
+    title and unique paragraph marker"""
+    CATEGORY_RE = re.compile(r'categor(y|ies) (?P<category>[ivx]+).*',
+                             re.IGNORECASE)
+
+    def matches(self, xml):
+        return xml.tag == 'IMPORTCATEGORY'
+
+    def derive_nodes(self, xml, processor):
+        """Finds and deletes the category header before recursing. Adds this
+        header as a title."""
+        xml = deepcopy(xml)     # we'll be modifying this
+        header = xml.xpath('./HD')[0]
+        xml.remove(header)
+        header_text = tree_utils.get_node_text(header)
+
+        node = Node(title=header_text, label=[self.marker(header_text)])
+        return [processor.process(xml, node)]
+
+    @classmethod
+    def marker(cls, header_text):
+        """Derive a unique, repeatable identifier for this subtree. This
+        allows the same category to be reordered (e.g. if a note has been
+        added), or a header with multiple reserved categories to be split
+        (which would also re-order the categories that followed)"""
+        match = cls.CATEGORY_RE.match(header_text)
+        if match:
+            return 'p{}'.format(hash_for_paragraph(match.group('category')))
+        else:
+            logging.warn("Couldn't derive category: %s", header_text)
+            return mtypes.MARKERLESS

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -1,10 +1,11 @@
 import abc
 import logging
 
-from regparser.layer.key_terms import KeyTerms, keyterm_to_int
+from regparser.layer.key_terms import KeyTerms
 from regparser.layer.formatting import table_xml_to_plaintext
 from regparser.tree.depth import heuristics, markers as mtypes
 from regparser.tree.depth.derive import debug_idx, derive_depths
+from regparser.tree.paragraph import hash_for_paragraph
 from regparser.tree.struct import Node
 from regparser.tree.xml_parser import tree_utils
 
@@ -77,7 +78,7 @@ class ParagraphProcessor(object):
         if node.label[-1] == mtypes.MARKERLESS:
             keyterm = KeyTerms.get_keyterm(node, ignore_definitions=False)
             if keyterm:
-                p_num = keyterm_to_int(keyterm)
+                p_num = hash_for_paragraph(keyterm)
             else:
                 # len(n.label[-1]) < 6 filters out keyterm nodes
                 p_num = sum(n.is_markerless() and len(n.label[-1]) < 6

--- a/tests/layer_keyterms_tests.py
+++ b/tests/layer_keyterms_tests.py
@@ -1,12 +1,11 @@
 # vim: set fileencoding=utf-8
 from unittest import TestCase
 
-from regparser.layer.key_terms import KeyTerms, keyterm_to_int
+from regparser.layer.key_terms import KeyTerms
 from regparser.tree.struct import Node
 
 
 class LayerKeyTermTest(TestCase):
-
     def test_find_keyterm(self):
         node = Node(
             '(a) Apples. Apples are grown in New Zealand.',
@@ -124,9 +123,3 @@ class LayerKeyTermTest(TestCase):
         kt = KeyTerms(None)
         results = kt.process(node)
         self.assertEqual('Apples.', results[0]['key_term'])
-
-    def test_keyterm_to_int(self):
-        """keyterm_to_int should standardize the keyterm"""
-        self.assertEqual(keyterm_to_int('Abc 123 More.'),
-                         keyterm_to_int(' abc123 mOrE'))
-        self.assertTrue(keyterm_to_int('a term') > 10000)

--- a/tests/tree_paragraph_tests.py
+++ b/tests/tree_paragraph_tests.py
@@ -1,6 +1,8 @@
+import uuid
+from unittest import TestCase
+
 from regparser.tree.paragraph import hash_for_paragraph, ParagraphParser
 from regparser.tree.struct import Node
-from unittest import TestCase
 
 
 class DepthParagraphTest(TestCase):
@@ -173,7 +175,11 @@ class DepthParagraphTest(TestCase):
         self.assertEqual(["205", "14", "b"], child_b.label)
 
     def test_hash_for_paragraph(self):
-        """hash_for_paragraph should standardize the given parametwr"""
+        """hash_for_paragraph should standardize the given parameter. It
+        should also use numbers in a large range -- an arbitrary hash should
+        result in a relatively large number"""
         self.assertEqual(hash_for_paragraph('Abc 123 More.'),
                          hash_for_paragraph(' abc123 mOrE'))
-        self.assertTrue(hash_for_paragraph('a term') > 10000)
+        random_term = uuid.uuid4().hex
+        self.assertTrue(hash_for_paragraph(random_term) > 10000,
+                        msg="Hashed too small: {}".format(random_term))

--- a/tests/tree_paragraph_tests.py
+++ b/tests/tree_paragraph_tests.py
@@ -1,4 +1,4 @@
-from regparser.tree.paragraph import ParagraphParser
+from regparser.tree.paragraph import hash_for_paragraph, ParagraphParser
 from regparser.tree.struct import Node
 from unittest import TestCase
 
@@ -171,3 +171,9 @@ class DepthParagraphTest(TestCase):
         self.assertEqual(["205", "14", "a", "2"], child_a_2.label)
         self.assertEqual(["205", "14", "a", "3"], child_a_3.label)
         self.assertEqual(["205", "14", "b"], child_b.label)
+
+    def test_hash_for_paragraph(self):
+        """hash_for_paragraph should standardize the given parametwr"""
+        self.assertEqual(hash_for_paragraph('Abc 123 More.'),
+                         hash_for_paragraph(' abc123 mOrE'))
+        self.assertTrue(hash_for_paragraph('a term') > 10000)

--- a/tests/tree_struct_tests.py
+++ b/tests/tree_struct_tests.py
@@ -2,6 +2,7 @@ import json
 from unittest import TestCase
 
 from regparser.tree import struct
+from regparser.tree.depth.markers import MARKERLESS
 
 
 class NodeTest(TestCase):
@@ -280,7 +281,8 @@ class FrozenNodeTests(TestCase):
 
 class NodeTests(TestCase):
     def test_is_markerless_label(self):
-        self.assertIsNone(struct.Node.is_markerless_label(''))
-        self.assertIsNone(struct.Node.is_markerless_label(None))
+        self.assertFalse(struct.Node.is_markerless_label(''))
+        self.assertFalse(struct.Node.is_markerless_label(None))
         self.assertTrue(struct.Node.is_markerless_label(['134', 'p33']))
-        self.assertIsNone(struct.Node.is_markerless_label(['245', '23']))
+        self.assertFalse(struct.Node.is_markerless_label(['245', '23']))
+        self.assertTrue(struct.Node.is_markerless_label(['245', MARKERLESS]))


### PR DESCRIPTION
Renames/refactors a bit, but mostly modifies the way IMPORTCATEGORY tags are handled. See commit messages for details.

Continuing to skip tests around the ATF-specific code.

Resolves 18f/atf-eregs#253

Relies on #174 -- please review that first