### PR TITLE
Make tests more robust

### DIFF
--- a/tests/commands_diffs_tests.py
+++ b/tests/commands_diffs_tests.py
@@ -22,7 +22,7 @@ class CommandsDiffsTests(TestCase):
 
     def assert_diff_keys(self, lhs_id, rhs_id, keys):
         entry = self.diff_dir / lhs_id / rhs_id
-        self.assertEqual(keys, entry.read().keys())
+        self.assertItemsEqual(keys, entry.read().keys())
 
     def test_diffs_generated(self):
         """Diffs are calculated -- they will be empty between the same

--- a/tests/notice_build_tests.py
+++ b/tests/notice_build_tests.py
@@ -31,7 +31,10 @@ class NoticeBuildTest(XMLBuilderMixin, TestCase):
             'type': 'Rule',
             'volume': 66,
         }
-        self.assertEqual(build.build_notice('5', '9292', fr), [{
+        actual_notice = build.build_notice('5', '9292', fr)[0]
+        for key in ['agency_names', 'cfr_parts']:
+            actual_notice[key] = sorted(actual_notice[key])
+        self.assertEqual(actual_notice, {
             'abstract': 'sum sum sum',
             'action': 'actact',
             'agency_names': ['Agency 1', 'Agency 2'],
@@ -51,7 +54,7 @@ class NoticeBuildTest(XMLBuilderMixin, TestCase):
             },
             'publication_date': '1955-12-10',
             'regulation_id_numbers': ['a231a-232q'],
-        }])
+        })
 
     def test_process_xml(self):
         """Integration test for xml processing"""
@@ -159,7 +162,7 @@ class NoticeBuildTest(XMLBuilderMixin, TestCase):
 
         subpart_changes = build.process_designate_subpart(amended_label)
 
-        self.assertEqual(['200-1-a', '200-1-b'], subpart_changes.keys())
+        self.assertItemsEqual(['200-1-a', '200-1-b'], subpart_changes.keys())
 
         for p, change in subpart_changes.items():
             self.assertEqual(change['destination'], ['205', 'Subpart', 'A'])
@@ -176,7 +179,7 @@ class NoticeBuildTest(XMLBuilderMixin, TestCase):
         build.process_amendments(notice, self.tree.render_xml())
 
         section_list = ['105-2', '105-3', '105-1']
-        self.assertEqual(notice['changes'].keys(), section_list)
+        self.assertItemsEqual(notice['changes'].keys(), section_list)
 
         for l, c in notice['changes'].items():
             change = c[0]
@@ -196,7 +199,7 @@ class NoticeBuildTest(XMLBuilderMixin, TestCase):
         notice = {'cfr_parts': ['105']}
         build.process_amendments(notice, self.tree.render_xml())
 
-        self.assertEqual(notice['changes'].keys(), ['105-1-b'])
+        self.assertItemsEqual(notice['changes'].keys(), ['105-1-b'])
 
         changes = notice['changes']['105-1-b'][0]
         self.assertEqual(changes['action'], 'PUT')
@@ -218,7 +221,7 @@ class NoticeBuildTest(XMLBuilderMixin, TestCase):
         notice = {'cfr_parts': ['105']}
         build.process_amendments(notice, self.tree.render_xml())
 
-        self.assertEqual(notice['changes'].keys(), ['105-1-b', '105-1-c'])
+        self.assertItemsEqual(notice['changes'].keys(), ['105-1-b', '105-1-c'])
 
         changes = notice['changes']['105-1-b'][0]
         self.assertEqual(changes['action'], 'PUT')
@@ -278,7 +281,7 @@ class NoticeBuildTest(XMLBuilderMixin, TestCase):
 
         notice = {'cfr_parts': ['105']}
         build.process_amendments(notice, self.tree.render_xml())
-        self.assertEqual(notice['changes'].keys(), ['105-11-p5'])
+        self.assertItemsEqual(notice['changes'].keys(), ['105-11-p5'])
 
         changes = notice['changes']['105-11-p5'][0]
         self.assertEqual(changes['action'], 'PUT')
@@ -339,7 +342,7 @@ class NoticeBuildTest(XMLBuilderMixin, TestCase):
         subpart_changes = build.process_new_subpart(notice, amended_label, par)
 
         new_nodes_added = ['105-Subpart-B', '105-30', '105-30-a']
-        self.assertEqual(new_nodes_added, subpart_changes.keys())
+        self.assertItemsEqual(new_nodes_added, subpart_changes.keys())
 
         for l, n in subpart_changes.items():
             self.assertEqual(n['action'], 'POST')

--- a/tests/notice_build_tests.py
+++ b/tests/notice_build_tests.py
@@ -31,7 +31,9 @@ class NoticeBuildTest(XMLBuilderMixin, TestCase):
             'type': 'Rule',
             'volume': 66,
         }
-        actual_notice = build.build_notice('5', '9292', fr)[0]
+        notices = build.build_notice('5', '9292', fr)
+        self.assertEqual(1, len(notices))
+        actual_notice = notices[0]
         for key in ['agency_names', 'cfr_parts']:
             actual_notice[key] = sorted(actual_notice[key])
         self.assertEqual(actual_notice, {

--- a/tests/notice_changes_tests.py
+++ b/tests/notice_changes_tests.py
@@ -177,7 +177,7 @@ class ChangesTests(TestCase):
         labels_amended = [Amendment('RESERVE', '200-2-a')]
         amend_map = changes.match_labels_and_changes(
             labels_amended, self.section_node())
-        self.assertEqual(['200-2-a'], amend_map.keys())
+        self.assertItemsEqual(['200-2-a'], amend_map.keys())
 
         amendments = amend_map['200-2-a']
         self.assertEqual(amendments[0]['action'], 'RESERVE')

--- a/tests/table_of_contents_tests.py
+++ b/tests/table_of_contents_tests.py
@@ -16,7 +16,7 @@ class TocTest(TestCase):
         parser = table_of_contents.TableOfContentsLayer(None)
         toc = parser.process(n)
         self.assertEqual(len(toc), 3)
-        self.assertEqual(toc[0].keys(), ['index', 'title'])
+        self.assertItemsEqual(toc[0].keys(), ['index', 'title'])
         self.assertEqual(toc[0]['index'], ['1005', '2'])
         self.assertEqual(toc[1]['index'], ['1005', '3'])
         self.assertEqual(toc[2]['index'], ['1005', '4'])
@@ -39,7 +39,7 @@ class TocTest(TestCase):
 
         parser = table_of_contents.TableOfContentsLayer(tree)
         toc_layer = parser.build()
-        self.assertEquals(toc_layer.keys(), ['1005-A'])
+        self.assertItemsEqual(toc_layer.keys(), ['1005-A'])
         self.assertEqual(len(toc_layer['1005-A']), 3)
         self.assertEqual(toc_layer['1005-A'][0]['index'], ['1005', 'A', '2'])
 


### PR DESCRIPTION
Fix assertions that have an unwise dependency on collection order where no
order is guaranteed.