### PR TITLE
Hooks for preprocessor extensions

### DIFF
--- a/regparser/builder.py
+++ b/regparser/builder.py
@@ -15,7 +15,7 @@ from regparser.history.delays import modify_effective_dates
 from regparser.notice import fake as notice_fake
 from regparser.notice.compiler import compile_regulation
 from regparser.tree import struct, xml_parser
-from regparser.tree.xml_parser import preprocessors
+from regparser.tree.xml_parser import extended_preprocessors as all_preprocs
 
 
 class Builder(object):
@@ -237,7 +237,7 @@ def tree_and_builder(filename, title, checkpoint_path=None, doc_number=None):
     else:
         raise ValueError("Building from text input is no longer supported")
 
-    for preprocessor in preprocessors.ALL:
+    for preprocessor in all_preprocs.ALL:
         preprocessor().transform(reg_xml)
 
     reg_tree = checkpointer.checkpoint(

--- a/regparser/tree/xml_parser/extended_preprocessors.py
+++ b/regparser/tree/xml_parser/extended_preprocessors.py
@@ -3,6 +3,9 @@ from importlib import import_module
 
 ALL = []
 for preprocessor in settings.PREPROCESSORS:
-    mod_string, class_name = preprocessor.rsplit('.', 1)
+    if ":" in preprocessor:
+        mod_string, class_name = preprocessor.rsplit(':', 1)
+    else:
+        mod_string, class_name = preprocessor.rsplit('.', 1)
     mod = import_module(mod_string)
     ALL.append(getattr(mod, class_name))

--- a/regparser/tree/xml_parser/extended_preprocessors.py
+++ b/regparser/tree/xml_parser/extended_preprocessors.py
@@ -1,0 +1,9 @@
+import settings
+from importlib import import_module
+
+ALL = []
+for preprocessor in settings.PREPROCESSORS:
+    mod_string, class_name = preprocessor.rsplit('.', 1)
+    if "uscode" in preprocessor.lower(): import rlcompleter; import pdb; zcomp = locals(); zcomp.update(globals()); pdb.Pdb.complete = rlcompleter.Completer(zcomp).complete; pdb.set_trace()
+    mod = import_module(mod_string)
+    ALL.append(getattr(mod, class_name))

--- a/regparser/tree/xml_parser/extended_preprocessors.py
+++ b/regparser/tree/xml_parser/extended_preprocessors.py
@@ -4,6 +4,5 @@ from importlib import import_module
 ALL = []
 for preprocessor in settings.PREPROCESSORS:
     mod_string, class_name = preprocessor.rsplit('.', 1)
-    if "uscode" in preprocessor.lower(): import rlcompleter; import pdb; zcomp = locals(); zcomp.update(globals()); pdb.Pdb.complete = rlcompleter.Completer(zcomp).complete; pdb.set_trace()
     mod = import_module(mod_string)
     ALL.append(getattr(mod, class_name))

--- a/regparser/tree/xml_parser/preprocessors.py
+++ b/regparser/tree/xml_parser/preprocessors.py
@@ -326,27 +326,6 @@ class AtfI50031(PreProcessorBase):
                 next_el = extract.getnext()
 
 
-class USCode(PreProcessorBase):
-    """478.103 contains a chunk of the US Code, but does not delineate it
-    clearly from the rest of the text of the containing poster. We've created
-    `USCODE` tags to clear up this confusion, but we need to modify the XML to
-    insert them in the appropriate spot"""
-    MARKER = ("//SECTNO[contains(., '478.103')]/.."     # In 478.103
-              "//HD[contains(., '18 U.S.C.')]")  # US Code header
-
-    def transform(self, xml):
-        for hd in xml.xpath(self.MARKER):
-            uscode = etree.Element("USCODE")
-            next_el = hd.getnext()
-            while next_el is not None and next_el.tag != 'HD':
-                uscode.append(next_el)
-                next_el = hd.getnext()
-
-            hd_parent = hd.getparent()
-            hd_idx = hd_parent.index(hd)
-            hd_parent.insert(hd_idx + 1, uscode)
-
-
 class ImportCategories(PreProcessorBase):
     """447.21 contains an import list, but the XML doesn't delineate the
     various categories well. We've created `IMPORTCATEGORY` tags to handle the
@@ -390,7 +369,3 @@ class ImportCategories(PreProcessorBase):
                 next_el = iterator.getnext()
                 category_el.append(iterator)
                 iterator = next_el
-
-
-# Surface all of the PreProcessorBase classes
-ALL = PreProcessorBase.__subclasses__()

--- a/regparser/tree/xml_parser/xml_wrapper.py
+++ b/regparser/tree/xml_parser/xml_wrapper.py
@@ -1,8 +1,6 @@
 from copy import deepcopy
-
 from lxml import etree
-
-from regparser.tree.xml_parser import preprocessors
+from regparser.tree.xml_parser import extended_preprocessors as all_preprocs
 
 
 class XMLWrapper(object):
@@ -29,7 +27,7 @@ class XMLWrapper(object):
         attempts to fix some of those (general) flaws. For specific issues, we
         tend to instead use the files in settings.LOCAL_XML_PATHS"""
 
-        for preprocessor in preprocessors.ALL:
+        for preprocessor in all_preprocs.ALL:
             preprocessor().transform(self.xml)
 
         return self

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ pyparsing==2.0.5  # 2.0.6 has a unicode bug, fixed in current trunk: http://sour
 python-constraint==1.2
 requests==2.9.1
 requests-cache==0.4.10
+stevedore==1.10.0
 -e .

--- a/settings.py
+++ b/settings.py
@@ -126,7 +126,7 @@ PREPROCESSORS = [
 try:
     stevedore_mgr = extension.ExtensionManager(
         namespace="eregs_ns.parser.preprocessors", invoke_on_load=False)
-    stevedore_mgr.map(lambda ext: PREPROCESSORS.extend(ext.plugin))
+    stevedore_mgr.map(lambda ext: PREPROCESSORS.append(ext.entry_point_target))
 except NoMatches:
     pass
 

--- a/settings.py
+++ b/settings.py
@@ -1,3 +1,6 @@
+from stevedore import extension
+from stevedore.exception import NoMatches
+
 OUTPUT_DIR = ''
 API_BASE = ''
 META = {}
@@ -108,6 +111,24 @@ CUSTOM_CITATIONS = {
     "ATF I 5300.1": "https://atf-eregs.apps.cloud.gov/static/atf_eregs/5300_1.pdf",
     "ATF I 5300.2": "https://www.atf.gov/file/58806/download"}
 
+PREPROCESSORS = [
+    "regparser.tree.xml_parser.preprocessors.MoveLastAMDPar",
+    "regparser.tree.xml_parser.preprocessors.SupplementAMDPar",
+    "regparser.tree.xml_parser.preprocessors.ParenthesesCleanup",
+    "regparser.tree.xml_parser.preprocessors.MoveAdjoiningChars",
+    "regparser.tree.xml_parser.preprocessors.ApprovalsFP",
+    "regparser.tree.xml_parser.preprocessors.ExtractTags",
+    "regparser.tree.xml_parser.preprocessors.Footnotes",
+    "regparser.tree.xml_parser.preprocessors.AtfI50032",
+    "regparser.tree.xml_parser.preprocessors.AtfI50031",
+]
+
+try:
+    stevedore_mgr = extension.ExtensionManager(
+        namespace="eregs_ns.parser.preprocessors", invoke_on_load=False)
+    stevedore_mgr.map(lambda ext: PREPROCESSORS.extend(ext.plugin))
+except NoMatches:
+    pass
 
 try:
     from local_settings import *


### PR DESCRIPTION
Using stevedore to manage loading of preprocessors specific to projects. This commit only handles preprocessors, but should provide an outline for how to add hooks for any area of the parser.