### PR TITLE
Changes for getting FEC regs parsed

### DIFF
--- a/regparser/tree/depth/derive.py
+++ b/regparser/tree/depth/derive.py
@@ -147,23 +147,33 @@ def derive_depths(original_markers, additional_constraints=[]):
         solutions.append(Solution(assignment))
     return solutions
 
+
 def derive_depths_relaxed(original_markers):
+    """Derive paragraph depth with reduced constraints,
+    including removal of emphasis and disabling of the
+    depth_type_inverses optional rule.
+    """
+
     deemphasized_markers = []
-    logging.warning("Could not derive paragraph depths. Retrying with relaxed constraints.")
+    logging.warning("""Could not derive paragraph depths. Retrying
+        with relaxed constraints.""")
     for marker in original_markers:
         emphasized = re.match(r"<E .*>(.*)</E>", marker)
         if emphasized:
             deemphasized_markers.append(emphasized.groups()[0])
         else:
             deemphasized_markers.append(marker)
-   
-    solutions = derive_depths(deemphasized_markers, [optional_rules.star_new_level,
-        optional_rules.limit_paragraph_types(
-            markers.lower, markers.upper, markers.ints, markers.roman,
-            markers.em_ints, markers.em_roman, markers.stars,
-            markers.markerless)])
+
+    solutions = derive_depths(deemphasized_markers,
+                              [optional_rules.star_new_level,
+                               optional_rules.limit_paragraph_types(
+                                markers.lower, markers.upper, markers.ints,
+                                markers.roman, markers.em_ints,
+                                markers.em_roman, markers.stars,
+                                markers.markerless)])
 
     return solutions
+
 
 def debug_idx(markers, constraints=[]):
     """Binary search through the markers to find the point at which

--- a/regparser/tree/depth/derive.py
+++ b/regparser/tree/depth/derive.py
@@ -1,6 +1,6 @@
 from constraint import Problem
 
-from regparser.tree.depth import markers, rules, optional_rules
+from regparser.tree.depth import markers, rules
 from regparser.tree.depth.pair_rules import pair_rules
 
 import logging
@@ -148,7 +148,7 @@ def derive_depths(original_markers, additional_constraints=[]):
     return solutions
 
 
-def derive_depths_relaxed(original_markers):
+def derive_depths_relaxed(original_markers, additional_constraints=[]):
     """Derive paragraph depth with reduced constraints,
     including removal of emphasis and disabling of the
     depth_type_inverses optional rule.
@@ -164,13 +164,7 @@ def derive_depths_relaxed(original_markers):
         else:
             deemphasized_markers.append(marker)
 
-    solutions = derive_depths(deemphasized_markers,
-                              [optional_rules.star_new_level,
-                               optional_rules.limit_paragraph_types(
-                                markers.lower, markers.upper, markers.ints,
-                                markers.roman, markers.em_ints,
-                                markers.em_roman, markers.stars,
-                                markers.markerless)])
+    solutions = derive_depths(deemphasized_markers, additional_constraints)
 
     return solutions
 

--- a/regparser/tree/depth/derive.py
+++ b/regparser/tree/depth/derive.py
@@ -3,7 +3,6 @@ from constraint import Problem
 from regparser.tree.depth import markers, rules
 from regparser.tree.depth.pair_rules import pair_rules
 
-import logging
 import re
 
 
@@ -155,8 +154,6 @@ def derive_depths_relaxed(original_markers, additional_constraints=[]):
     """
 
     deemphasized_markers = []
-    logging.warning("""Could not derive paragraph depths. Retrying
-        with relaxed constraints.""")
     for marker in original_markers:
         emphasized = re.match(r"<E .*>(.*)</E>", marker)
         if emphasized:

--- a/regparser/tree/depth/derive.py
+++ b/regparser/tree/depth/derive.py
@@ -3,8 +3,6 @@ from constraint import Problem
 from regparser.tree.depth import markers, rules
 from regparser.tree.depth.pair_rules import pair_rules
 
-import re
-
 
 class ParAssignment(object):
     """A paragraph's type, index, depth assignment"""
@@ -144,25 +142,6 @@ def derive_depths(original_markers, additional_constraints=[]):
     for assignment in problem.getSolutionIter():
         assignment = _decompress_markerless(assignment, original_markers)
         solutions.append(Solution(assignment))
-    return solutions
-
-
-def derive_depths_relaxed(original_markers, additional_constraints=[]):
-    """Derive paragraph depth with reduced constraints,
-    including removal of emphasis and disabling of the
-    depth_type_inverses optional rule.
-    """
-
-    deemphasized_markers = []
-    for marker in original_markers:
-        emphasized = re.match(r"<E .*>(.*)</E>", marker)
-        if emphasized:
-            deemphasized_markers.append(emphasized.groups()[0])
-        else:
-            deemphasized_markers.append(marker)
-
-    solutions = derive_depths(deemphasized_markers, additional_constraints)
-
     return solutions
 
 

--- a/regparser/tree/depth/derive.py
+++ b/regparser/tree/depth/derive.py
@@ -1,7 +1,10 @@
 from constraint import Problem
 
-from regparser.tree.depth import markers, rules
+from regparser.tree.depth import markers, rules, optional_rules
 from regparser.tree.depth.pair_rules import pair_rules
+
+import re
+import logging
 
 
 class ParAssignment(object):
@@ -78,7 +81,7 @@ def _decompress_markerless(assignment, marker_list):
     return result
 
 
-def derive_depths(original_markers, additional_constraints=[]):
+def derive_depths(original_markers, additional_constraints=[], relaxed_constraints=False):
     """Use constraint programming to derive the paragraph depths associated
     with a list of paragraph markers. Additional constraints (e.g. expected
     marker types, etc.) can also be added. Such constraints are functions of
@@ -121,6 +124,8 @@ def derive_depths(original_markers, additional_constraints=[]):
         if idx > 1:
             pairs = all_vars[3*(idx-2):]
             problem.addConstraint(rules.triplet_tests, pairs)
+            if not relaxed_constraints:
+                problem.addConstraint(rules.markerless_sandwich, pairs)
 
     # separate loop so that the simpler checks run first
     for idx in range(1, len(marker_list)):
@@ -142,6 +147,23 @@ def derive_depths(original_markers, additional_constraints=[]):
     for assignment in problem.getSolutionIter():
         assignment = _decompress_markerless(assignment, original_markers)
         solutions.append(Solution(assignment))
+
+    if not solutions and not relaxed_constraints:
+        deemphasized_markers = []
+        logging.warning("Could not derive paragraph depths. Retrying with relaxed constraints.")
+        for marker in original_markers:
+            emphasized = re.match(r"<E .*>(.*)</E>", marker)
+            if emphasized:
+                deemphasized_markers.append(emphasized.groups()[0])
+            else:
+                deemphasized_markers.append(marker)
+       
+        solutions = derive_depths(deemphasized_markers, [optional_rules.star_new_level,
+            optional_rules.limit_paragraph_types(
+                markers.lower, markers.upper, markers.ints, markers.roman,
+                markers.em_ints, markers.em_roman, markers.stars,
+                markers.markerless)], relaxed_constraints=True)
+        
     return solutions
 
 

--- a/regparser/tree/depth/heuristics.py
+++ b/regparser/tree/depth/heuristics.py
@@ -56,8 +56,9 @@ def prefer_shallow_depths(solutions, weight=0.1):
     else:
         return solutions
 
+
 def prefer_no_markerless_sandwich(solutions, weight=1.0):
-    """Prefer solutions which don't use MARKERLESS to switch depth, like 
+    """Prefer solutions which don't use MARKERLESS to switch depth, like
             a
             MARKERLESS
                 a
@@ -66,21 +67,20 @@ def prefer_no_markerless_sandwich(solutions, weight=1.0):
     for solution in solutions:
         flags = 0
         for idx in range(2, len(solution.assignment)):
-            pprev_typ = solution.assignment[idx - 2].typ
-            pprev_idx = idx - 2
             pprev_depth = solution.assignment[idx - 2].depth
             prev_typ = solution.assignment[idx - 1].typ
-            prev_idx = idx - 1
             prev_depth = solution.assignment[idx - 1].depth
-            typ = solution.assignment[idx].typ
             depth = solution.assignment[idx].depth
 
             sandwich = prev_typ == markers.markerless
-            inc_depth = depth == prev_depth + 1 and prev_depth == pprev_depth + 1
-            if sandwich and inc_depth:
+            incremented = depth == prev_depth + 1
+            incrementing = prev_depth == pprev_depth + 1
+
+            if sandwich and incremented and incrementing:
                 flags += 1
 
         total = len(solution.assignment)
-        result.append(solution.copy_with_penalty(weight * flags / float(total)))
+        result.append(solution.copy_with_penalty(
+                        weight * flags / float(total)))
 
     return result

--- a/regparser/tree/depth/heuristics.py
+++ b/regparser/tree/depth/heuristics.py
@@ -76,10 +76,17 @@ def prefer_no_markerless_sandwich(solutions, weight=1.0):
             incremented = depth == prev_depth + 1
             incrementing = prev_depth == pprev_depth + 1
 
+            print "ptype: %s" % str(prev_typ)
+            print "s %s" % sandwich
+            print "ind %s" % incremented
+            print "ing %s" % incrementing
+
+
             if sandwich and incremented and incrementing:
                 flags += 1
 
         total = len(solution.assignment)
+        print "penalty; %f" % (weight * flags / float(total))
         result.append(solution.copy_with_penalty(
                         weight * flags / float(total)))
 

--- a/regparser/tree/depth/heuristics.py
+++ b/regparser/tree/depth/heuristics.py
@@ -81,7 +81,6 @@ def prefer_no_markerless_sandwich(solutions, weight=1.0):
             print "ind %s" % incremented
             print "ing %s" % incrementing
 
-
             if sandwich and incremented and incrementing:
                 flags += 1
 

--- a/regparser/tree/depth/heuristics.py
+++ b/regparser/tree/depth/heuristics.py
@@ -76,16 +76,10 @@ def prefer_no_markerless_sandwich(solutions, weight=1.0):
             incremented = depth == prev_depth + 1
             incrementing = prev_depth == pprev_depth + 1
 
-            print "ptype: %s" % str(prev_typ)
-            print "s %s" % sandwich
-            print "ind %s" % incremented
-            print "ing %s" % incrementing
-
             if sandwich and incremented and incrementing:
                 flags += 1
 
         total = len(solution.assignment)
-        print "penalty; %f" % (weight * flags / float(total))
         result.append(solution.copy_with_penalty(
                         weight * flags / float(total)))
 

--- a/regparser/tree/depth/markers.py
+++ b/regparser/tree/depth/markers.py
@@ -11,7 +11,7 @@ def emphasize(marker):
     their <E> tags to distinguish them from previous levels. This function
     will wrap a marker in an <E> tag"""
     marker_plain = deemphasize(marker)
-    return '<E T="03">{}</E>'.format(marker_plain)
+    return u'<E T="03">{}</E>'.format(marker_plain)
 
 
 def deemphasize(marker):

--- a/regparser/tree/depth/rules.py
+++ b/regparser/tree/depth/rules.py
@@ -104,7 +104,6 @@ def triplet_tests(*triplet_seq):
     """Run propositions around a sequence of three markers. We combine them
     here so that they act as a single constraint"""
     return (
-        markerless_sandwich(*triplet_seq) and
         star_sandwich_symmetry(*triplet_seq) and
         marker_stars_markerless_symmetry(*triplet_seq) and
         markerless_stars_symmetry(*triplet_seq)

--- a/regparser/tree/depth/rules.py
+++ b/regparser/tree/depth/rules.py
@@ -26,19 +26,6 @@ def type_match(marker):
     return lambda typ, idx: idx < len(typ) and typ[idx] == marker
 
 
-def markerless_sandwich(pprev_typ, pprev_idx, pprev_depth,
-                        prev_typ, prev_idx, prev_depth,
-                        typ, idx, depth):
-    """MARKERLESS shouldn't be used to skip a depth, like:
-        a
-            MARKERLESS
-                a
-    """
-    sandwich = prev_typ == markers.markerless
-    inc_depth = depth == prev_depth + 1 and prev_depth == pprev_depth + 1
-    return not (sandwich and inc_depth)
-
-
 def marker_stars_markerless_symmetry(pprev_typ, pprev_idx, pprev_depth,
                                      prev_typ, prev_idx, prev_depth,
                                      typ, idx, depth):

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -5,8 +5,8 @@ from regparser.layer.key_terms import KeyTerms, keyterm_to_int
 from regparser.layer.formatting import table_xml_to_plaintext
 from regparser.tree.depth import heuristics, markers as mtypes, \
   optional_rules
-from regparser.tree.depth.derive import debug_idx, derive_depths,\
-  derive_depths_relaxed
+from regparser.tree.depth.markers import deemphasize
+from regparser.tree.depth.derive import debug_idx, derive_depths
 from regparser.tree.struct import Node
 from regparser.tree.xml_parser import tree_utils
 
@@ -127,15 +127,17 @@ class ParagraphProcessor(object):
             depths = derive_depths(markers, constraints)
 
             if not depths:
-                logging.warning("""Could not derive paragraph depths. Retrying
-                                   with relaxed constraints.""")
+                logging.warning("Could not derive paragraph depths."
+                                "Retrying with relaxed constraints.")
+                deemphasized_markers = [deemphasize(m) for m in markers]
                 additional_constraints = [optional_rules.star_new_level,
                                           optional_rules.limit_paragraph_types(
-                                           markers.lower, markers.upper,
-                                           markers.ints, markers.roman,
-                                           markers.em_ints, markers.em_roman,
-                                           markers.stars, markers.markerless)]
-                depths = derive_depths_relaxed(markers, additional_constraints)
+                                           mtypes.lower, mtypes.upper,
+                                           mtypes.ints, mtypes.roman,
+                                           mtypes.em_ints, mtypes.em_roman,
+                                           mtypes.stars, mtypes.markerless)]
+                depths = derive_depths(deemphasized_markers,
+                                       additional_constraints)
 
             if not depths:
                 fails_at = debug_idx(markers, constraints)

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -3,7 +3,8 @@ import logging
 
 from regparser.layer.key_terms import KeyTerms, keyterm_to_int
 from regparser.layer.formatting import table_xml_to_plaintext
-from regparser.tree.depth import heuristics, markers as mtypes
+from regparser.tree.depth import heuristics, markers as mtypes, \
+  optional_rules
 from regparser.tree.depth.derive import debug_idx, derive_depths,\
   derive_depths_relaxed
 from regparser.tree.struct import Node
@@ -126,7 +127,13 @@ class ParagraphProcessor(object):
             depths = derive_depths(markers, constraints)
 
             if not depths:
-                depths = derive_depths_relaxed(markers)
+                additional_constraints = [optional_rules.star_new_level,
+                                          optional_rules.limit_paragraph_types(
+                                           markers.lower, markers.upper,
+                                           markers.ints, markers.roman,
+                                           markers.em_ints, markers.em_roman,
+                                           markers.stars, markers.markerless)]
+                depths = derive_depths_relaxed(markers, additional_constraints)
 
             if not depths:
                 fails_at = debug_idx(markers, constraints)

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -3,12 +3,11 @@ import logging
 
 from regparser.layer.key_terms import KeyTerms, keyterm_to_int
 from regparser.layer.formatting import table_xml_to_plaintext
-from regparser.tree.depth import heuristics, markers as mtypes, optional_rules
-from regparser.tree.depth.derive import debug_idx, derive_depths, derive_depths_relaxed
+from regparser.tree.depth import heuristics, markers as mtypes
+from regparser.tree.depth.derive import debug_idx, derive_depths,\
+  derive_depths_relaxed
 from regparser.tree.struct import Node
 from regparser.tree.xml_parser import tree_utils
-
-import re
 
 
 class ParagraphProcessor(object):
@@ -128,7 +127,7 @@ class ParagraphProcessor(object):
 
             if not depths:
                 depths = derive_depths_relaxed(markers)
-            
+
             if not depths:
                 fails_at = debug_idx(markers, constraints)
                 logging.error(

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -127,6 +127,8 @@ class ParagraphProcessor(object):
             depths = derive_depths(markers, constraints)
 
             if not depths:
+                logging.warning("""Could not derive paragraph depths. Retrying
+                                   with relaxed constraints.""")
                 additional_constraints = [optional_rules.star_new_level,
                                           optional_rules.limit_paragraph_types(
                                            markers.lower, markers.upper,

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -3,8 +3,7 @@ import logging
 
 from regparser.layer.key_terms import KeyTerms
 from regparser.layer.formatting import table_xml_to_plaintext
-from regparser.tree.depth import heuristics, markers as mtypes, \
-  optional_rules
+from regparser.tree.depth import heuristics, markers as mtypes
 from regparser.tree.depth.markers import deemphasize
 from regparser.tree.depth.derive import debug_idx, derive_depths
 from regparser.tree.paragraph import hash_for_paragraph
@@ -123,16 +122,10 @@ class ParagraphProcessor(object):
 
             if not depths:
                 logging.warning("Could not derive paragraph depths."
-                                "Retrying with relaxed constraints.")
+                                " Retrying with relaxed constraints.")
                 deemphasized_markers = [deemphasize(m) for m in markers]
-                additional_constraints = [optional_rules.star_new_level,
-                                          optional_rules.limit_paragraph_types(
-                                           mtypes.lower, mtypes.upper,
-                                           mtypes.ints, mtypes.roman,
-                                           mtypes.em_ints, mtypes.em_roman,
-                                           mtypes.stars, mtypes.markerless)]
-                depths = derive_depths(deemphasized_markers,
-                                       additional_constraints)
+                constraints = self.relaxed_constraints()
+                depths = derive_depths(deemphasized_markers, constraints)
 
             if not depths:
                 fails_at = debug_idx(markers, constraints)
@@ -152,6 +145,11 @@ class ParagraphProcessor(object):
 
     def additional_constraints(self):
         """Hook for subtypes to add additional constraints"""
+        return []
+
+    def relaxed_constraints(self):
+        """Hook for subtypes to add relaxed constraints for retry
+           logic"""
         return []
 
 

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -225,7 +225,7 @@ def initial_markers(text):
 
 _collapsed_grammar = QuickSearchable(
     # A guard to reduce false positives
-    pyparsing.Suppress(pyparsing.Regex(u',|\.|-|—|>')) +
+    pyparsing.Suppress(pyparsing.Regex(u',|\.|-|—|>|means ')) +
     any_depth_p)
 
 

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -364,3 +364,11 @@ class RegtextParagraphProcessor(paragraph_processor.ParagraphProcessor):
                     mtypes.lower, mtypes.upper, mtypes.ints, mtypes.roman,
                     mtypes.em_ints, mtypes.em_roman, mtypes.stars,
                     mtypes.markerless)]
+
+    def relaxed_constraints(self):
+        return [optional_rules.star_new_level,
+                optional_rules.limit_paragraph_types(
+                    mtypes.lower, mtypes.upper,
+                    mtypes.ints, mtypes.roman,
+                    mtypes.em_ints, mtypes.em_roman,
+                    mtypes.stars, mtypes.markerless)]

--- a/tests/tree_depth_derive_tests.py
+++ b/tests/tree_depth_derive_tests.py
@@ -113,12 +113,6 @@ class DeriveTests(TestCase):
         self.assert_depth_match(['A', INLINE_STARS, STARS_TAG, '3'],
                                 [0, 1, 1, 1])
 
-    def test_markerless_outermost(self):
-        """A pattern often seen in definitions sections"""
-        self.assert_depth_match(
-            [MARKERLESS, MARKERLESS, 'a', 'b', MARKERLESS, 'a', 'b'],
-            [0, 0, 1, 1, 0, 1, 1])
-
     def test_markerless_repeated(self):
         """Repeated markerless paragraphs must be on the same level"""
         self.assert_depth_match(

--- a/tests/tree_depth_heuristics_tests.py
+++ b/tests/tree_depth_heuristics_tests.py
@@ -79,7 +79,10 @@ class HeuristicsTests(TestCase):
         self.assertEqual(solutions[0].weight, 1.0)
         self.assertTrue(solutions[1].weight < solutions[0].weight)
 
-    def test_prefer_no_markeless_sandwich(self):
+    def test_prefer_no_markerless_sandwich(self):
+        """Generate two solutions, one in which a markerless sandwich
+        is used to skip depth, and another where it is not used to 
+        skip depth."""
         self.addAssignment(markers.ints, '1', 0)
         self.addAssignment(markers.markerless, markers.MARKERLESS, 1)
         self.addAssignment(markers.roman, 'i', 1)

--- a/tests/tree_depth_heuristics_tests.py
+++ b/tests/tree_depth_heuristics_tests.py
@@ -83,6 +83,7 @@ class HeuristicsTests(TestCase):
         """Generate two solutions, one in which a markerless sandwich
         is used to skip depth, and another where it is not used to
         skip depth."""
+
         self.addAssignment(markers.ints, '1', 0)
         self.addAssignment(markers.markerless, markers.MARKERLESS, 1)
         self.addAssignment(markers.roman, 'i', 1)
@@ -92,6 +93,31 @@ class HeuristicsTests(TestCase):
         self.addAssignment(markers.ints, '1', 0)
         self.addAssignment(markers.markerless, markers.MARKERLESS, 1)
         self.addAssignment(markers.roman, 'i', 2)
+        solution2 = self.solution
+
+        solutions = [Solution(solution1), Solution(solution2)]
+        solutions = heuristics.prefer_no_markerless_sandwich(solutions, 0.5)
+        self.assertEqual(solutions[0].weight, 1.0)
+        self.assertTrue(solutions[1].weight < solutions[0].weight)
+
+        self.setUp()
+        self.addAssignment(markers.markerless, markers.MARKERLESS, 0)
+        self.addAssignment(markers.markerless, markers.MARKERLESS, 0)
+        self.addAssignment(markers.lower, 'a', 1)
+        self.addAssignment(markers.lower, 'b', 1)
+        self.addAssignment(markers.markerless, markers.MARKERLESS, 0)
+        self.addAssignment(markers.lower, 'a', 1)
+        self.addAssignment(markers.lower, 'b', 1)
+        solution1 = self.solution
+
+        self.setUp()
+        self.addAssignment(markers.markerless, markers.MARKERLESS, 0)
+        self.addAssignment(markers.markerless, markers.MARKERLESS, 0)
+        self.addAssignment(markers.lower, 'a', 1)
+        self.addAssignment(markers.lower, 'b', 1)
+        self.addAssignment(markers.markerless, markers.MARKERLESS, 2)
+        self.addAssignment(markers.lower, 'a', 3)
+        self.addAssignment(markers.lower, 'b', 3)
         solution2 = self.solution
 
         solutions = [Solution(solution1), Solution(solution2)]

--- a/tests/tree_depth_heuristics_tests.py
+++ b/tests/tree_depth_heuristics_tests.py
@@ -81,7 +81,7 @@ class HeuristicsTests(TestCase):
 
     def test_prefer_no_markerless_sandwich(self):
         """Generate two solutions, one in which a markerless sandwich
-        is used to skip depth, and another where it is not used to 
+        is used to skip depth, and another where it is not used to
         skip depth."""
         self.addAssignment(markers.ints, '1', 0)
         self.addAssignment(markers.markerless, markers.MARKERLESS, 1)

--- a/tests/tree_depth_heuristics_tests.py
+++ b/tests/tree_depth_heuristics_tests.py
@@ -94,6 +94,4 @@ class HeuristicsTests(TestCase):
         solutions = [Solution(solution1), Solution(solution2)]
         solutions = heuristics.prefer_no_markerless_sandwich(solutions, 0.5)
         self.assertEqual(solutions[0].weight, 1.0)
-        print solutions[0].weight
-        print solutions[1].weight
         self.assertTrue(solutions[1].weight < solutions[0].weight)

--- a/tests/tree_depth_heuristics_tests.py
+++ b/tests/tree_depth_heuristics_tests.py
@@ -78,3 +78,22 @@ class HeuristicsTests(TestCase):
         solutions = heuristics.prefer_shallow_depths(solutions, 0.5)
         self.assertEqual(solutions[0].weight, 1.0)
         self.assertTrue(solutions[1].weight < solutions[0].weight)
+
+    def test_prefer_no_markeless_sandwich(self):
+        self.addAssignment(markers.ints, '1', 0)
+        self.addAssignment(markers.markerless, markers.MARKERLESS, 1)
+        self.addAssignment(markers.roman, 'i', 1)
+        solution1 = self.solution
+
+        self.setUp()
+        self.addAssignment(markers.ints, '1', 0)
+        self.addAssignment(markers.markerless, markers.MARKERLESS, 1)
+        self.addAssignment(markers.roman, 'i', 2)
+        solution2 = self.solution
+
+        solutions = [Solution(solution1), Solution(solution2)]
+        solutions = heuristics.prefer_no_markerless_sandwich(solutions, 0.5)
+        self.assertEqual(solutions[0].weight, 1.0)
+        print solutions[0].weight
+        print solutions[1].weight
+        self.assertTrue(solutions[1].weight < solutions[0].weight)

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -653,8 +653,10 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
         prefixes, but not when they are part of a citation or do not have the
         appropriate prefix"""
         text = u'(a) <E T="03">Transfer </E>—(1) <E T="03">Notice.</E> follow'
-        markers = reg_text.collapsed_markers(text)
-        self.assertEqual(markers, [u'1'])
+        self.assertEqual([u'1'], reg_text.collapsed_markers(text))
+
+        text = u'(a) <E T="03">Blah </E>means (1) <E T="03">Notice.</E> follow'
+        self.assertEqual([u'1'], reg_text.collapsed_markers(text))
 
         text = '(1) See paragraph (a) for more'
         self.assertEqual([], reg_text.collapsed_markers(text))


### PR DESCRIPTION
This PR for [fec-regs#1](https://github.com/18F/fec-eregs/issues/1) is review-only at this point - not ready to be merged due to lack of tests. Currently it fixes title 11 part 104, whose problem was inconsistent use of emphasis. The solution is to retry solution-less regulations with relaxed constraints, including removal of all emphasis, removal of the depth_type_inverses optional constraint, and removal of the marker_sandwich constraint. 