### PR TITLE
Support singular search terms

### DIFF
--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -189,20 +189,23 @@ class Terms(Layer):
 
     def calculate_offsets(self, text, applicable_terms, exclusions=[],
                           inclusions=[]):
-        """Search for defined terms in this text, with a preference for all
-        larger (i.e. containing) terms."""
+        """Search for defined terms in this text, including singular and
+        plural forms of these terms, with a preference for all larger
+        (i.e. containing) terms."""
 
         # don't modify the original
         exclusions = list(exclusions)
         inclusions = list(inclusions)
 
-        # add plurals to applicable terms
-        search_terms = [(inflection.pluralize(t[0]), t[1])
-                      for t in applicable_terms]
-        search_terms += applicable_terms
+        # add singulars and plurals to search terms
+        search_terms = set((inflection.singularize(t[0]), t[1])
+                           for t in applicable_terms)
+        search_terms |= set((inflection.pluralize(t[0]), t[1])
+                            for t in applicable_terms)
 
-        #   longer terms first
-        search_terms.sort(key=lambda x: len(x[0]), reverse=True)
+        # longer terms first
+        search_terms = sorted(search_terms, key=lambda x: len(x[0]),
+                              reverse=True)
 
         matches = []
         for term, ref in search_terms:

--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -197,15 +197,15 @@ class Terms(Layer):
         inclusions = list(inclusions)
 
         # add plurals to applicable terms
-        pluralized = [(inflection.pluralize(t[0]), t[1])
+        search_terms = [(inflection.pluralize(t[0]), t[1])
                       for t in applicable_terms]
-        applicable_terms += pluralized
+        search_terms += applicable_terms
 
         #   longer terms first
-        applicable_terms.sort(key=lambda x: len(x[0]), reverse=True)
+        search_terms.sort(key=lambda x: len(x[0]), reverse=True)
 
         matches = []
-        for term, ref in applicable_terms:
+        for term, ref in search_terms:
             re_term = ur'\b' + re.escape(term) + ur'\b'
             offsets = [
                 (m.start(), m.end())

--- a/tests/layer_terms_tests.py
+++ b/tests/layer_terms_tests.py
@@ -312,16 +312,10 @@ class LayerTermTest(TestCase):
         text = "I am in a rock band. That's a band with a drum, a rock drum."
         t = Terms(None)
         matches = t.calculate_offsets(text, applicable_terms)
-        self.assertEqual(3, len(matches))
-        found = [False, False, False]
-        for _, ref, offsets in matches:
-            if ref == 'a' and offsets == [(10, 19)]:
-                found[0] = True
-            if ref == 'b' and offsets == [(30, 34)]:
-                found[1] = True
-            if ref == 'c' and offsets == [(42, 46), (55, 59)]:
-                found[2] = True
-        self.assertEqual([True, True, True], found)
+        self.assertItemsEqual(matches, [
+            ('rock band', 'a', [(10, 19)]),
+            ('band', 'b', [(30, 34)]),
+            ('drum', 'c', [(42, 46), (55, 59)])])
 
     def test_calculate_offsets_pluralized1(self):
         applicable_terms = [('rock band', 'a'), ('band', 'b'), ('drum', 'c'),
@@ -330,18 +324,11 @@ class LayerTermTest(TestCase):
         text += " Many bands. "
         t = Terms(None)
         matches = t.calculate_offsets(text, applicable_terms)
-        self.assertEqual(4, len(matches))
-        found = [False, False, False, False]
-        for _, ref, offsets in matches:
-            if ref == 'a' and offsets == [(10, 19)]:
-                found[0] = True
-            if ref == 'b' and offsets == [(66, 71)]:
-                found[1] = True
-            if ref == 'b' and offsets == [(30, 34)]:
-                found[2] = True
-            if ref == 'c' and offsets == [(42, 46), (55, 59)]:
-                found[3] = True
-        self.assertEqual([True, True, True, True], found)
+        self.assertItemsEqual(matches, [
+            ('rock band', 'a', [(10, 19)]),
+            ('band', 'b', [(30, 34)]),
+            ('bands', 'b', [(66, 71)]),
+            ('drum', 'c', [(42, 46), (55, 59)])])
 
     def test_calculate_offsets_pluralized2(self):
         applicable_terms = [('activity', 'a'), ('other thing', 'd')]

--- a/tests/layer_terms_tests.py
+++ b/tests/layer_terms_tests.py
@@ -337,6 +337,13 @@ class LayerTermTest(TestCase):
         matches = t.calculate_offsets(text, applicable_terms)
         self.assertEqual(2, len(matches))
 
+    def test_calculate_offsets_singularized(self):
+        applicable_terms = [('activities', 'a'), ('other thing', 'd')]
+        text = "activity, activities."
+        t = Terms(None)
+        matches = t.calculate_offsets(text, applicable_terms)
+        self.assertEqual(2, len(matches))
+
     def test_calculate_offsets_lexical_container(self):
         applicable_terms = [('access device', 'a'), ('device', 'd')]
         text = "This access device is fantastic!"


### PR DESCRIPTION
1. I also noticed that we patch the inflection package for person -> people. My opinion is that we don't need to do it going the other way.
2. Fixed a minor issue where if the singular and plural were the same (e.g. sheep), we would search for it twice.