### PR TITLE
Integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,26 @@
 language: python
 sudo: false
 python:
-    - "2.7"
+  - "2.7"
 install:
-    - pip install -r requirements.txt
-    - pip install -r requirements_test.txt
-    - pip install coveralls
+  - pip install -r requirements.txt
+  - pip install -r requirements_test.txt
+  - pip install coveralls
+env:
+  - INTEGRATION_TARGET=
+  - INTEGRATION_TARGET=fec
+  - INTEGRATION_TARGET=atf
 script:
-    - nosetests --with-cov --cov-report term-missing --cov regparser
-    - flake8 .
+  - |
+    if [[ $INTEGRATION_TARGET = '' ]]; then
+      nosetests --with-cov --cov-report term-missing --cov regparser
+      flake8 .
+    else
+      eregs clear
+      eregs integration_test $INTEGRATION_TARGET
+    fi
 after_success:
-    coveralls
+  - |
+    if [[ $INTEGRATION_TARGET = '' ]]; then
+      coveralls
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: python
 sudo: false
 python:
   - "2.7"
+cache: pip
 install:
+  - pip install -U pip wheel
   - pip install -r requirements.txt
   - pip install -r requirements_test.txt
   - pip install coveralls
@@ -11,16 +13,6 @@ env:
   - INTEGRATION_TARGET=fec
   - INTEGRATION_TARGET=atf
 script:
-  - |
-    if [[ $INTEGRATION_TARGET = '' ]]; then
-      nosetests --with-cov --cov-report term-missing --cov regparser
-      flake8 .
-    else
-      eregs clear
-      eregs integration_test $INTEGRATION_TARGET
-    fi
+  - ./test-travis.sh
 after_success:
-  - |
-    if [[ $INTEGRATION_TARGET = '' ]]; then
-      coveralls
-    fi
+  - if [[ $INTEGRATION_TARGET = '' ]]; then coveralls; fi

--- a/eregs.py
+++ b/eregs.py
@@ -32,9 +32,9 @@ for _, command_name, _ in pkgutil.iter_modules(commands.__path__):
 
 
 def run_or_resolve(cmd, prev_dependency=None):
-    """Wrapper around cli(), providing exception handling for dependency
-    errors. When a dependency is missing, this will try to resolve that
-    dependency and then retry running cli(). When retrying, the
+    """Wrapper around a click command or group, providing exception handling for
+    dependency errors. When a dependency is missing, this will try to resolve
+    that dependency and then retry running cli(). When retrying, the
     `prev_dependency` parameter indirectly tells us if we've progressed, due
     to the dependency changing"""
     try:

--- a/eregs.py
+++ b/eregs.py
@@ -31,14 +31,14 @@ for _, command_name, _ in pkgutil.iter_modules(commands.__path__):
         cli.add_command(subcommand)
 
 
-def main(prev_dependency=None):
+def run_or_resolve(cmd, prev_dependency=None):
     """Wrapper around cli(), providing exception handling for dependency
     errors. When a dependency is missing, this will try to resolve that
     dependency and then retry running cli(). When retrying, the
     `prev_dependency` parameter indirectly tells us if we've progressed, due
     to the dependency changing"""
     try:
-        cli()
+        cmd()
     except dependency.Missing, e:
         resolvers = [resolver(e.dependency)
                      for resolver in DependencyResolver.__subclasses__()]
@@ -48,7 +48,11 @@ def main(prev_dependency=None):
         else:
             click.echo("Attempting to resolve dependency: " + e.dependency)
             resolvers[0].resolution()
-            main(e.dependency)
+            run_or_resolve(cmd, e.dependency)
+
+
+def main(prev_dependency=None):
+    run_or_resolve(cli, prev_dependency=prev_dependency)
 
 
 if __name__ == '__main__':

--- a/integration_test.py
+++ b/integration_test.py
@@ -14,7 +14,7 @@ from regparser.commands.compare_to import compare_to
 
 targets = {
     'fec': {
-        'title': 12,
+        'title': 11,
         'parts': (
             [1, 2, 4, 5, 6, 7, 8] +
             range(100, 117) + [200, 201, 300] +

--- a/integration_test.py
+++ b/integration_test.py
@@ -7,6 +7,7 @@ import sys
 import pip
 import click
 
+from eregs import run_or_resolve
 from regparser.commands.pipeline import pipeline
 from regparser.commands.compare_to import compare_to
 
@@ -73,4 +74,4 @@ def build_and_compare(ctx, config, part):
 
 
 if __name__ == '__main__':
-    cli()
+    run_or_resolve(cli)

--- a/regparser/commands/compare_to.py
+++ b/regparser/commands/compare_to.py
@@ -46,7 +46,8 @@ def compare(local_path, remote_url, prompt=True):
             click.echo("Content differs: {} {}".format(local_path, remote_url))
             if not prompt or click.confirm("Show diff?"):
                 diffs_str = '\n'.join(udiff(remote, local))
-                (click.echo_via_pager if prompt else click.echo)(diffs_str)
+                echo = click.echo_via_pager if prompt else click.echo
+                echo(diffs_str)
                 return diffs_str
 
 

--- a/regparser/commands/compare_to.py
+++ b/regparser/commands/compare_to.py
@@ -30,7 +30,7 @@ def local_and_remote_generator(api_base, paths):
         yield (local_name, remote_name)
 
 
-def compare(local_path, remote_url, prompt):
+def compare(local_path, remote_url, prompt=True):
     """Downloads and compares a local JSON file with a remote one. If there is
     a difference, notifies the user and prompts them if they want to see the
     diff"""
@@ -45,10 +45,9 @@ def compare(local_path, remote_url, prompt):
         if remote != local:
             click.echo("Content differs: {} {}".format(local_path, remote_url))
             if not prompt or click.confirm("Show diff?"):
-                diff = udiff(remote, local)
-                diffs_str = '\n'.join(diff)
+                diffs_str = '\n'.join(udiff(remote, local))
                 (click.echo_via_pager if prompt else click.echo)(diffs_str)
-                return diff
+                return diffs_str
 
 
 @click.command()
@@ -75,4 +74,4 @@ def compare_to(ctx, api_base, paths, prompt):
     requests_cache.uninstall_cache()
 
     pairs = local_and_remote_generator(api_base, paths)
-    return any(compare(local, remote, prompt) for local, remote in pairs)
+    return any([compare(local, remote, prompt) for local, remote in pairs])

--- a/regparser/commands/integration_test.py
+++ b/regparser/commands/integration_test.py
@@ -15,7 +15,7 @@ targets = {
     # },
     'atf': {
         'title': 27,
-        'parts': [447],
+        'parts': [447, 478, 479, 555, 646],
         'source': 'https://atf-eregs.apps.cloud.gov/api',
     },
 }

--- a/regparser/commands/integration_test.py
+++ b/regparser/commands/integration_test.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+import click
+
+from regparser.commands.pipeline import pipeline
+from regparser.commands.compare_to import compare_to
+
+
+targets = {
+    # 'fec': {
+    #     'title': 12,
+    #     'parts': [1, 2, 4, 5, 6, 7, 8],
+    #     'source': '',
+    # },
+    'atf': {
+        'title': 27,
+        'parts': [447],
+        'source': 'https://atf-eregs.apps.cloud.gov/api',
+    },
+}
+
+
+@click.command()
+@click.argument('target')
+@click.pass_context
+def integration_test(ctx, target):
+    config = targets[target]
+    if any(build_and_compare(ctx, config, part) for part in config['parts']):
+        sys.exit(1)
+
+
+def build_and_compare(ctx, config, part):
+    ctx.invoke(
+        pipeline,
+        cfr_title=config['title'],
+        cfr_part=part,
+        output='output',
+        only_latest=True,
+    )
+    return ctx.invoke(
+        compare_to,
+        api_base=config['source'],
+        paths=[os.path.join('output', 'regulation', str(part))],
+        prompt=False,
+    )

--- a/regparser/commands/integration_test.py
+++ b/regparser/commands/integration_test.py
@@ -6,13 +6,17 @@ import click
 from regparser.commands.pipeline import pipeline
 from regparser.commands.compare_to import compare_to
 
-
 targets = {
-    # 'fec': {
-    #     'title': 12,
-    #     'parts': [1, 2, 4, 5, 6, 7, 8],
-    #     'source': '',
-    # },
+    'fec': {
+        'title': 12,
+        'parts': (
+            [1, 2, 4, 5, 6, 7, 8] +
+            range(100, 117) + [200, 201, 300] +
+            range(9001, 9009) + [9012] + range(9031, 9040) +
+            [9405, 9407, 9409, 9410, 9411, 9420, 9428, 9430]
+        ),
+        'source': 'https://fec-eregs.apps.cloud.gov/api',
+    },
     'atf': {
         'title': 27,
         'parts': [447, 478, 479, 555, 646],
@@ -26,7 +30,7 @@ targets = {
 @click.pass_context
 def integration_test(ctx, target):
     config = targets[target]
-    if any(build_and_compare(ctx, config, part) for part in config['parts']):
+    if any([build_and_compare(ctx, config, part) for part in config['parts']]):
         sys.exit(1)
 
 

--- a/test-travis.sh
+++ b/test-travis.sh
@@ -1,0 +1,10 @@
+set -e
+set -x
+
+if [[ $INTEGRATION_TARGET = '' ]]; then
+  nosetests --with-cov --cov-report term-missing --cov regparser
+  flake8 .
+else
+  eregs clear
+  eregs integration_test $INTEGRATION_TARGET
+fi

--- a/test-travis.sh
+++ b/test-travis.sh
@@ -6,5 +6,6 @@ if [[ $INTEGRATION_TARGET = '' ]]; then
   flake8 .
 else
   eregs clear
-  eregs integration_test $INTEGRATION_TARGET
+  ./integration_test.py install $INTEGRATION_TARGET
+  ./integration_test.py test $INTEGRATION_TARGET
 fi


### PR DESCRIPTION
This patch revises the travis configuration to run unit tests in one environment, and to run integration tests on each downstream client in a separate environment. In the spirit of writing the simplest implementation possible, this proof of concept uses `compare_to` to diff the current parse against the latest parse on each agency's remote, and fails the build on any differences. I think it would be useful to pause for discussion at this point and see what others who are more familiar with the needs of the project have to say.

cc @cmc333333 @tadhg-ohiggins @vrajmohan @anthonygarvan 

* [x] Add integration test CLI task
* [x] Add downstream agencies to build matrix and `targets`
* [ ] Handle files that are missing on the remote (currently ignored)
* [ ] Provide clearer output on diffs--right now, they're just echoed inline
* [ ] Decide what the "ground truth" parse of a reg is
* [x] Handle installing agency-specific plugins