### PR TITLE
Updates to IGNORE_DEFINITIONS_IN

### DIFF
--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -94,11 +94,16 @@ class Terms(Layer):
     def is_exclusion(self, term, node):
         """Some definitions are exceptions/exclusions of a previously
         defined term. At the moment, we do not want to include these as they
-        would replace previous (correct) definitions."""
+        would replace previous (correct) definitions. We also remove terms
+        which are inside an instance of the IGNORE_DEFINITIONS_IN setting"""
         applicable_terms = self.applicable_terms(node.label)
         if term in applicable_terms:
             regex = 'the term .?' + re.escape(term) + '.? does not include'
-            return bool(re.search(regex, node.text.lower()))
+            if re.search(regex, node.text.lower()):
+                return True
+            for start, end in self.ignored_offsets(node.label[0], node.text):
+                if term in node.text[start:end]:
+                    return True
         return False
 
     def node_definitions(self, node, stack=None):

--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -151,6 +151,7 @@ class Terms(Layer):
     def _word_matches(self, term, text):
         """Return the start and end indexes of the term within the text,
         accounting for word boundaries"""
+        # @todo - this is rather slow -- probably want to memoize the results
         regex = re.escape(term)
         if self.STARTS_WITH_WORDCHAR.match(term):
             regex = r'\b' + regex

--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -36,6 +36,8 @@ class ParentStack(PriorityStack):
 
 class Terms(Layer):
     shorthand = 'terms'
+    STARTS_WITH_WORDCHAR = re.compile('^\w.*$')
+    ENDS_WITH_WORDCHAR = re.compile('^.*\w$')
 
     def __init__(self, *args, **kwargs):
         Layer.__init__(self, *args, **kwargs)
@@ -149,8 +151,14 @@ class Terms(Layer):
     def _word_matches(self, term, text):
         """Return the start and end indexes of the term within the text,
         accounting for word boundaries"""
-        return [(match.start(), match.end()) for match in
-                re.finditer(r'\b' + re.escape(term) + r'\b', text)]
+        regex = re.escape(term)
+        if self.STARTS_WITH_WORDCHAR.match(term):
+            regex = r'\b' + regex
+        if self.ENDS_WITH_WORDCHAR.match(term):
+            regex += r'\b'
+        regex = re.compile(regex)
+        return [(match.start(), match.end())
+                for match in regex.finditer(text)]
 
     def ignored_offsets(self, cfr_part, text):
         """Return a list of offsets corresponding to the presence of an

--- a/settings.py
+++ b/settings.py
@@ -63,17 +63,17 @@ DEFAULT_IMAGE_URL = (
     'https://s3.amazonaws.com/images.federalregister.gov/' +
     '%s/original.gif')
 
-# list of strings: phrases which shouldn't be broken by definition links
-IGNORE_DEFINITIONS_IN = {'ALL': []}
-# Look in extensions for definition phrases to be excluded:
+# dict: string->[string]: List of phrases which shouldn't contain defined
+# terms. Keyed by CFR part of 'ALL'.
 IGNORE_DEFINITIONS_IN = plugins.update_dictionary(
-    "eregs_ns.parser.term_definition_exclusions", IGNORE_DEFINITIONS_IN)
+    "eregs_ns.parser.term_ignores", {'ALL': []})
 
-# List of strings: phrases which should be included as definition links
-INCLUDE_DEFINITIONS_IN = {'ALL': []}
-# Add include definitions from extensions:
+# dict: string->[(string,string)]: List of phrases which *should* trigger a
+# definition. Pair is of the form (term, context), where "context" refers to a
+# substring match for a specific paragraph. e.g.
+# ("bob", "text noting that it defines bob")
 INCLUDE_DEFINITIONS_IN = plugins.update_dictionary(
-    "eregs_ns.parser.term_definitions", INCLUDE_DEFINITIONS_IN)
+    "eregs_ns.parser.term_definitions", {'ALL': []})
 
 # list of modules implementing the __contains__ and __getitem__ methods
 OVERRIDES_SOURCES = [

--- a/settings.py
+++ b/settings.py
@@ -64,7 +64,7 @@ DEFAULT_IMAGE_URL = (
     '%s/original.gif')
 
 # dict: string->[string]: List of phrases which shouldn't contain defined
-# terms. Keyed by CFR part of 'ALL'.
+# terms. Keyed by CFR part or 'ALL'.
 IGNORE_DEFINITIONS_IN = plugins.update_dictionary(
     "eregs_ns.parser.term_ignores", {'ALL': []})
 


### PR DESCRIPTION
See changesets for specifics, but at the high level, this 
1) Reduces logic around this config
2) Uses them when looking for terms _being defined_
3) Allows ignores to begin/end with non-word chars

In service of 18f/atf-eregs#313