### PR TITLE
Parse Notice Preambles

### DIFF
--- a/regparser/api_writer.py
+++ b/regparser/api_writer.py
@@ -162,3 +162,6 @@ class Client:
     def diff(self, label, old_version, new_version):
         return self.writer_class(self.base, "diff", label, old_version,
                                  new_version)
+
+    def preamble(self, doc_number):
+        return self.writer_class(self.base, "preamble", doc_number)

--- a/regparser/api_writer.py
+++ b/regparser/api_writer.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import os.path
 import shutil
@@ -9,6 +10,9 @@ import requests
 from regparser.tree.struct import Node, NodeEncoder
 from regparser.notice.encoder import AmendmentEncoder
 import settings
+
+
+logger = logging.getLogger(__name__)
 
 
 class AmendmentNodeEncoder(AmendmentEncoder, NodeEncoder):
@@ -23,6 +27,7 @@ class FSWriteContent:
 
     def write(self, python_obj):
         """Write the object as json to disk"""
+        logger.debug("Writing %s", self.path)
         dir_path = os.path.split(self.path)[0]
         if not os.path.exists(dir_path):
             os.makedirs(dir_path)
@@ -41,6 +46,7 @@ class APIWriteContent:
 
     def write(self, python_obj):
         """Write the object (as json) to the API"""
+        logger.debug("Writing %s", self.path)
         requests.post(
             self.path,
             data=AmendmentNodeEncoder().encode(python_obj),
@@ -88,6 +94,7 @@ class GitWriteContent:
             self.write_tree(child_path, child)
 
     def write(self, python_object):
+        logger.debug("Writing %s", self.path)
         if "regulation" in self.path:
             dir_path, version_id = os.path.split(self.path)
             cfr_part = os.path.split(dir_path)[1]

--- a/regparser/commands/notice_preamble.py
+++ b/regparser/commands/notice_preamble.py
@@ -1,0 +1,26 @@
+import logging
+
+import click
+
+from regparser.index import dependency, entry
+from regparser.notice.preamble import convert_id, parse_preamble
+
+
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.argument('doc_number')
+def notice_preamble(doc_number):
+    """Pull down and parse the preamble from this notice."""
+    logger.info("Parsing Preamble for %s", doc_number)
+    preamble_path = entry.Preamble(convert_id(doc_number))
+    notice_path = entry.Notice(doc_number)
+
+    deps = dependency.Graph()
+    deps.add(preamble_path, notice_path)
+    deps.validate_for(preamble_path)
+
+    if deps.is_stale(preamble_path):
+        preamble = parse_preamble(notice_path.read())
+        preamble_path.write(preamble)

--- a/regparser/commands/versions.py
+++ b/regparser/commands/versions.py
@@ -57,9 +57,18 @@ def generate_dependencies(version_dir, version_ids, delays):
     return deps
 
 
+class InvalidEffectiveDate(Exception):
+    def __init__(self, version_id):
+        self.version_id = version_id
+        super(InvalidEffectiveDate, self).__init__(
+            "No effective date for this rule: {}".format(version_id))
+
+
 def write_to_disk(xml, version_entry, delay=None):
     """Serialize a Version instance to disk"""
     effective = xml.effective if delay is None else delay.until
+    if not effective:
+        raise InvalidEffectiveDate(xml.version_id)
     version = Version(identifier=xml.version_id, effective=effective,
                       published=xml.published)
     version_entry.write(version)

--- a/regparser/commands/write_to.py
+++ b/regparser/commands/write_to.py
@@ -8,53 +8,56 @@ from regparser.index import entry
 logger = logging.getLogger(__name__)
 
 
-# The write process is split into a set of functions, each responsible for
-# writing a particular type of entity
+def relevant_paths(root_dir, only_title, only_part):
+    """We may want to filter the paths we search in to those relevant to a
+    particular cfr title/part. Most index entries encode this as their first
+    two path components"""
+    title_dirs = [(root_dir / title) for title in root_dir
+                  if not only_title or str(only_title) == title]
+    part_dirs = [(title_dir / part)
+                 for title_dir in title_dirs for part in title_dir
+                 if not only_part or str(only_part) == part]
+    return [(part_dir / child)
+            for part_dir in part_dirs for child in part_dir]
 
-def write_trees(client, cfr_title, cfr_part):
-    tree_dir = entry.Tree(cfr_title, cfr_part)
-    for version_id in entry.Version(cfr_title, cfr_part):
-        if version_id in tree_dir:
-            logger.debug("Writing tree %s", version_id)
-            tree = (tree_dir / version_id).read()
-            client.regulation(cfr_part, version_id).write(tree)
+
+def write_trees(client, only_title, only_part):
+    for tree_entry in relevant_paths(entry.Tree(), only_title, only_part):
+        cfr_title, cfr_part, version_id = tree_entry.path
+        client.regulation(cfr_part, version_id).write(tree_entry.read())
 
 
-def write_layers(client, cfr_title, cfr_part):
-    for version_id in entry.Version(cfr_title, cfr_part):
-        layer_dir = entry.Layer(cfr_title, cfr_part, version_id)
+def write_layers(client, only_title, only_part):
+    for layer_dir in relevant_paths(entry.Layer(), only_title, only_part):
+        cfr_title, cfr_part, version_id = layer_dir.path
         for layer_name in layer_dir:
-            logger.debug("Writing layer %s@%s", layer_name, version_id)
             layer = (layer_dir / layer_name).read()
             client.layer(layer_name, cfr_part, version_id).write(layer)
 
 
-def write_notices(client, cfr_title, cfr_part):
+def write_notices(client, only_title, only_part):
     sxs_dir = entry.SxS()
-    for version_id in entry.Version(cfr_title, cfr_part):
-        if version_id in sxs_dir:
-            logger.debug("Writing notice %s", version_id)
-            tree = (sxs_dir / version_id).read()
+    for version_id in sxs_dir:
+        tree = (sxs_dir / version_id).read()
+        title_match = not only_title or tree['cfr_title'] == only_title
+        part_match = not only_part or str(only_part) in tree['cfr_parts']
+        if title_match and part_match:
             client.notice(version_id).write(tree)
 
 
-def write_diffs(client, cfr_title, cfr_part):
-    diff_dir = entry.Diff(cfr_title, cfr_part)
-    version_ids = list(entry.Version(cfr_title, cfr_part))
-    for lhs_id in version_ids:
-        container = diff_dir / lhs_id
-        for rhs_id in version_ids:
-            if rhs_id in container:
-                logger.debug("Writing diff %s to %s", lhs_id, rhs_id)
-                diff = (container / rhs_id).read()
-                client.diff(cfr_part, lhs_id, rhs_id).write(diff)
+def write_diffs(client, only_title, only_part):
+    for diff_dir in relevant_paths(entry.Diff(), only_title, only_part):
+        cfr_title, cfr_part, lhs_id = diff_dir.path
+        for rhs_id in diff_dir:
+            diff = (diff_dir / rhs_id).read()
+            client.diff(cfr_part, lhs_id, rhs_id).write(diff)
 
 
 @click.command()
-@click.argument('cfr_title', type=int)
-@click.argument('cfr_part', type=int)
 @click.argument('output')
-def write_to(cfr_title, cfr_part, output):
+@click.option('--cfr_title', type=int, help="Limit to one CFR title")
+@click.option('--cfr_part', type=int, help="Limit to one CFR part")
+def write_to(output, cfr_title, cfr_part):
     """Export data. Sends all data in the index to an external source.
 
     \b
@@ -66,7 +69,6 @@ def write_to(cfr_title, cfr_part, output):
     logger.info("Export output - %s CFR %s, Destination: %s",
                 cfr_title, cfr_part, output)
     client = Client(output)
-    cfr_part = str(cfr_part)
     write_trees(client, cfr_title, cfr_part)
     write_layers(client, cfr_title, cfr_part)
     write_notices(client, cfr_title, cfr_part)

--- a/regparser/commands/write_to.py
+++ b/regparser/commands/write_to.py
@@ -53,6 +53,12 @@ def write_diffs(client, only_title, only_part):
             client.diff(cfr_part, lhs_id, rhs_id).write(diff)
 
 
+def write_preambles(client):
+    for doc_id in entry.Preamble():
+        preamble = entry.Preamble(doc_id).read()
+        client.preamble(doc_id).write(preamble)
+
+
 @click.command()
 @click.argument('output')
 @click.option('--cfr_title', type=int, help="Limit to one CFR title")
@@ -73,3 +79,5 @@ def write_to(output, cfr_title, cfr_part):
     write_layers(client, cfr_title, cfr_part)
     write_notices(client, cfr_title, cfr_part)
     write_diffs(client, cfr_title, cfr_part)
+    if cfr_title is None and cfr_part is None:
+        write_preambles(client)

--- a/regparser/index/entry.py
+++ b/regparser/index/entry.py
@@ -151,3 +151,10 @@ class Layer(_JSONEntry):
 class Diff(_JSONEntry):
     """Processes diffs, keyed by diff"""
     PREFIX = (ROOT, 'diff')
+
+
+class Preamble(_JSONEntry):
+    """Processes notice preambles, keyed by document id"""
+    PREFIX = (ROOT, 'preamble')
+    JSON_ENCODER = FullNodeEncoder
+    JSON_DECODER = staticmethod(full_node_decode_hook)

--- a/regparser/index/entry.py
+++ b/regparser/index/entry.py
@@ -19,20 +19,20 @@ class Entry(object):
     PREFIX = (ROOT,)
 
     def __init__(self, *args):
-        self._path = tuple(str(arg) for arg in args)
+        self.path = tuple(str(arg) for arg in args)
 
     def __div__(self, other):
         """Embellishment in the form of a DSL.
         Entry(1, 2, 3) / 4 / 5 == Entry(1, 2, 3, 4, 5)"""
-        args = self._path + (other,)
+        args = self.path + (other,)
         return self.__class__(*args)
 
     def __str__(self):
-        return os.path.join(*(self.PREFIX + self._path))
+        return os.path.join(*(self.PREFIX + self.path))
 
     def _create_parent_dir(self):
         """Create the requisite directories if needed"""
-        path = os.path.join(*(self.PREFIX + self._path[:-1]))
+        path = os.path.join(*(self.PREFIX + self.path[:-1]))
         if not os.path.exists(path):
             os.makedirs(path)
 

--- a/regparser/notice/preamble.py
+++ b/regparser/notice/preamble.py
@@ -26,20 +26,25 @@ def simple_children(elements, deeper_source, label):
 
 
 def nested_children(elements, deeper_source, label):
-    """Make recursively calls `make_node` to generate the
+    """Make recursive calls to `make_node` to generate
     children-with-subchildren
         :param list[etree.Element] elements:
         :param str deeper_source: SOURCE attribute which indicates a deeper
         header
         :param list[str] label: label of the parent Node"""
-    hd_idxs = [idx for idx, elt in enumerate(elements)
-               if elt.tag == 'HD' and elt.get('SOURCE') == deeper_source]
-    spans = zip(hd_idxs, hd_idxs[1:] + [len(elements)])
+    indexes_of_next_level_headers = [
+        idx for idx, elt in enumerate(elements)
+        if elt.tag == 'HD' and elt.get('SOURCE') == deeper_source]
+    # Pairs of [start, end) indexes, defining runs of XML elements which
+    # should be grouped together. The final pair will include len(elements),
+    # the end of the list
+    start_end_pairs = zip(indexes_of_next_level_headers,
+                          indexes_of_next_level_headers[1:] + [len(elements)])
     children = []
-    for idx, (begin, end) in enumerate(spans):
-        header = elements[begin]
-        sub_elements = elements[begin + 1:end]
-        ident = 'p{}'.format(hd_idxs[0] + idx)
+    for idx, (start, end) in enumerate(start_end_pairs):
+        header = elements[start]
+        sub_elements = elements[start + 1:end]
+        ident = 'p{}'.format(indexes_of_next_level_headers[0] + idx)
         child = make_node(sub_elements, header.text, label + [ident])
         children.append(child)
     return children

--- a/regparser/notice/preamble.py
+++ b/regparser/notice/preamble.py
@@ -1,0 +1,74 @@
+from copy import deepcopy
+from itertools import takewhile
+
+from regparser.tree.struct import Node
+from regparser.tree.xml_parser.tree_utils import get_node_text
+
+
+def convert_id(doc_number):
+    """Dashes have special significance in other parts of eRegs"""
+    return doc_number.replace('-', '_')
+
+
+def simple_children(elements, deeper_source, label):
+    """All paragraphs before the appropriate header can be converted into
+    Nodes without further depth analysis or recursion
+        :param list[etree.Element] elements:
+        :param str deeper_source: SOURCE attribute which indicates a deeper
+        header
+        :param list[str] label: label of the parent Node"""
+    initial_nodes = takewhile(
+        lambda e: e.tag != 'HD' or e.get('SOURCE') != deeper_source,
+        elements)
+    return [Node(text=get_node_text(el), label=label + ['p{}'.format(idx)],
+                 node_type='PREAMBLE')
+            for idx, el in enumerate(initial_nodes)]
+
+
+def nested_children(elements, deeper_source, label):
+    """Make recursively calls `make_node` to generate the
+    children-with-subchildren
+        :param list[etree.Element] elements:
+        :param str deeper_source: SOURCE attribute which indicates a deeper
+        header
+        :param list[str] label: label of the parent Node"""
+    hd_idxs = [idx for idx, elt in enumerate(elements)
+               if elt.tag == 'HD' and elt.get('SOURCE') == deeper_source]
+    spans = zip(hd_idxs, hd_idxs[1:] + [len(elements)])
+    children = []
+    for idx, (begin, end) in enumerate(spans):
+        header = elements[begin]
+        sub_elements = elements[begin + 1:end]
+        ident = 'p{}'.format(hd_idxs[0] + idx)
+        child = make_node(sub_elements, header.text, label + [ident])
+        children.append(child)
+    return children
+
+
+def make_node(elements, title, label):
+    """Construct a Node by deriving relationships based on the depth
+    associated with HD[@SOURCE] elements
+        :param list[etree.Element] elements:
+        :param str title: title of the parent Node
+        :param list[str] label: label of the parent Node"""
+    deeper_source = 'HD{}'.format(len(label))
+    children = simple_children(elements, deeper_source, label)
+    children += nested_children(elements, deeper_source, label)
+
+    return Node(title=title, label=label, children=children,
+                node_type='PREAMBLE')
+
+
+def parse_preamble(notice_xml):
+    """Convert preamble into a Node tree. The preamble is contained within the
+    SUPLINF tag, but before a list of altered subjects.
+       :param NoticeXML xml: wrapped XML element"""
+    suplinf = deepcopy(notice_xml.xpath('.//SUPLINF')[0])
+    subject_list = suplinf.xpath('./LSTSUB')
+    if subject_list:
+        subject_list_idx = suplinf.index(subject_list[0])
+        del suplinf[subject_list_idx:]
+
+    title = suplinf[0].text
+    label = [convert_id(notice_xml.version_id)]
+    return make_node(suplinf[1:], title, label)

--- a/regparser/notice/xml.py
+++ b/regparser/notice/xml.py
@@ -42,16 +42,14 @@ class NoticeXML(XMLWrapper):
         dates_tag.attrib["eregs-{}-date".format(date_type)] = value
 
     def derive_effective_date(self):
-        """Attempt to parse effective date from DATES tags. Raises exception
-        if it cannot. Also sets the field. Returns a datetime.date"""
+        """Attempt to parse effective date from DATES tags. Returns a
+        datetime.date and sets the corresponding field"""
         dates = fetch_dates(self.xml) or {}
-        if 'effective' not in dates:
-            raise Exception(
-                "Could not derive effective date for notice {}".format(
-                    self.version_id))
-        effective = datetime.strptime(dates['effective'][0], "%Y-%m-%d").date()
-        self.effective = effective
-        return effective
+        if 'effective' in dates:
+            effective = datetime.strptime(
+                dates['effective'][0], "%Y-%m-%d").date()
+            self.effective = effective
+            return effective
 
     def _get_date_attr(self, date_type):
         """Pulls out the date set in `set_date_attr`, as a datetime.date. If

--- a/tests/api_writer_tests.py
+++ b/tests/api_writer_tests.py
@@ -197,31 +197,32 @@ class ClientTest(TestCase):
         settings.OUTPUT_DIR = self.old_output
 
     def test_regulation(self):
-        client = Client()
-        reg_writer = client.regulation("lablab", "docdoc")
+        reg_writer = Client().regulation("lablab", "docdoc")
         self.assertEqual(
             os.path.join(self.tmpdir, "regulation", "lablab", "docdoc"),
             reg_writer.path)
 
     def test_layer(self):
-        client = Client()
-        reg_writer = client.layer("boblayer", "lablab", "docdoc")
+        reg_writer = Client().layer("boblayer", "lablab", "docdoc")
         self.assertEqual(
             os.path.join(self.tmpdir, "layer", "boblayer", "lablab", "docdoc"),
             reg_writer.path)
 
     def test_notice(self):
-        client = Client()
-        reg_writer = client.notice("docdoc")
+        reg_writer = Client().notice("docdoc")
         self.assertEqual(
             os.path.join(self.tmpdir, "notice", "docdoc"), reg_writer.path)
 
     def test_diff(self):
-        client = Client()
-        reg_writer = client.diff("lablab", "oldold", "newnew")
+        reg_writer = Client.diff("lablab", "oldold", "newnew")
         self.assertEqual(
             os.path.join(self.tmpdir, "diff", "lablab", "oldold", "newnew"),
             reg_writer.path)
+
+    def test_preamble(self):
+        reg_writer = Client().preamble("docdoc")
+        self.assertEqual(
+            os.path.join(self.tmpdir, "preamble", "docdoc"), reg_writer.path)
 
     def test_writer_class_fs(self):
         """File System writer is the appropriate class when a protocol isn't

--- a/tests/api_writer_tests.py
+++ b/tests/api_writer_tests.py
@@ -214,7 +214,7 @@ class ClientTest(TestCase):
             os.path.join(self.tmpdir, "notice", "docdoc"), reg_writer.path)
 
     def test_diff(self):
-        reg_writer = Client.diff("lablab", "oldold", "newnew")
+        reg_writer = Client().diff("lablab", "oldold", "newnew")
         self.assertEqual(
             os.path.join(self.tmpdir, "diff", "lablab", "oldold", "newnew"),
             reg_writer.path)

--- a/tests/commands_notice_preamble_tests.py
+++ b/tests/commands_notice_preamble_tests.py
@@ -1,0 +1,31 @@
+from unittest import TestCase
+
+from click.testing import CliRunner
+from mock import patch
+
+from regparser.commands.notice_preamble import notice_preamble
+from regparser.index import dependency, entry
+
+
+class CommandsNoticePreambleTests(TestCase):
+    @patch('regparser.commands.notice_preamble.parse_preamble')
+    def test_notice_preamble(self, parse_preamble):
+        """A preprocessed notice must be present before we can parse the
+        preamble. If we've already written a preamble, we don't need to
+        process it again"""
+        parse_preamble.return_value = {'example': 'preamble'}
+        cli = CliRunner()
+        with cli.isolated_filesystem():
+            result = cli.invoke(notice_preamble, ['111-222'])
+            self.assertIsInstance(result.exception, dependency.Missing)
+            self.assertFalse(parse_preamble.called)
+
+            entry.Entry('notice_xml', '111-222').write('<ROOT />')
+            result = cli.invoke(notice_preamble, ['111-222'])
+            self.assertIsNone(result.exception)
+            self.assertTrue(parse_preamble.called)
+
+            parse_preamble.reset_mock()
+            result = cli.invoke(notice_preamble, ['111-222'])
+            self.assertIsNone(result.exception)
+            self.assertFalse(parse_preamble.called)

--- a/tests/commands_versions_tests.py
+++ b/tests/commands_versions_tests.py
@@ -100,6 +100,14 @@ class CommandsVersionsTests(TestCase):
             self.assertEqual((path / '111').read().effective, date(2002, 2, 2))
             self.assertEqual((path / '222').read().effective, date(2004, 4, 4))
 
+    def test_write_to_disk_no_effective(self):
+        """If a version is somehow associated with a proposed rule (or a final
+        rule has been misparsed), we should get an exception"""
+        xml = Mock()
+        xml.effective = None
+        with self.assertRaises(versions.InvalidEffectiveDate):
+            versions.write_to_disk(xml, entry.Version('12', '1000', '11'))
+
     @patch('regparser.commands.versions.write_to_disk')
     def test_write_if_needed_raises_exception(self, write_to_disk):
         """If an input file is missing, this raises an exception"""

--- a/tests/commands_write_to_tests.py
+++ b/tests/commands_write_to_tests.py
@@ -1,4 +1,4 @@
-from datetime import date
+from contextlib import contextmanager
 import os
 import tempfile
 import shutil
@@ -7,35 +7,18 @@ from unittest import TestCase
 from click.testing import CliRunner
 
 from regparser.commands.write_to import write_to
-from regparser.history.versions import Version
 from regparser.index import entry
 from regparser.tree.struct import Node
 
 
 class CommandsWriteToTests(TestCase):
-    def setUp(self):
-        self.cli = CliRunner()
-        self.tmpdir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        shutil.rmtree(self.tmpdir)
-
-    def add_versions(self):
-        """Add some versions to the index"""
-        entry.Version('12', '1000', 'v1').write(
-            Version('v1', date(2001, 1, 1), date(2001, 1, 1)))
-        entry.Version('12', '1000', 'v2').write(
-            Version('v2', date(2002, 2, 2), date(2002, 2, 2)))
-        entry.Version('12', '1000', 'v3').write(
-            Version('v3', date(2003, 3, 3), date(2003, 3, 3)))
-        entry.Version('12', '1001', 'other').write(
-            Version('other', date(2003, 3, 3), date(2003, 3, 3)))
-
     def add_trees(self):
         """Add some versions to the index"""
         entry.Tree('12', '1000', 'v2').write(Node('v2'))
         entry.Tree('12', '1000', 'v3').write(Node('v3'))
         entry.Tree('12', '1000', 'v4').write(Node('v4'))
+        entry.Tree('11', '1000', 'v5').write(Node('v5'))
+        entry.Tree('12', '1001', 'v6').write(Node('v6'))
 
     def add_layers(self):
         """Add an assortment of layers to the index"""
@@ -43,7 +26,8 @@ class CommandsWriteToTests(TestCase):
         entry.Layer('12', '1000', 'v2', 'layer2').write({'2': 2})
         entry.Layer('12', '1000', 'v3', 'layer2').write({'2': 2})
         entry.Layer('12', '1000', 'v3', 'layer3').write({'3': 3})
-        entry.Layer('12', '1000', 'v0', 'layer1').write({'1': 1})
+        entry.Layer('11', '1000', 'v4', 'layer4').write({'4': 4})
+        entry.Layer('12', '1001', 'v3', 'layer3').write({'3': 3})
 
     def add_diffs(self):
         """Adds an uneven assortment of diffs between trees"""
@@ -51,45 +35,96 @@ class CommandsWriteToTests(TestCase):
         entry.Diff('12', '1000', 'v2', 'v2').write({'2': 2})
         entry.Diff('12', '1000', 'v2', 'v1').write({'2': 1})
         entry.Diff('12', '1000', 'v0', 'v1').write({'0': 1})
+        entry.Diff('11', '1000', 'v3', 'v1').write({'3': 1})
+        entry.Diff('12', '1001', 'v3', 'v1').write({'3': 1})
 
     def add_notices(self):
         """Adds an uneven assortment of notices"""
-        entry.SxS('v0').write({'0': 0})
-        entry.SxS('v1').write({'1': 1})
-        entry.SxS('v2').write({'2': 2})
+        data = {'doc_number': 'v0', 'cfr_title': '11', 'cfr_parts': []}
+        entry.SxS('v0').write(data)
+        data.update(cfr_parts=['1000'], doc_number='v1')
+        entry.SxS('v1').write(data)
+        data.update(cfr_title='12', doc_number='v2')
+        entry.SxS('v2').write(data)
+        data['doc_number'] = 'v3'
+        entry.SxS('v3').write(data)
 
-    def assert_file_exists(self, *parts):
+    def file_exists(self, *parts):
         """Helper method to verify that a file was created"""
         path = os.path.join(self.tmpdir, *parts)
-        self.assertTrue(os.path.exists(path))
+        return os.path.exists(path)
 
-    def test_integration(self):
-        """Create a (small) set of files in the index. These files have
-        various mismatches between version information -- we should only write
-        the files which have an associated version"""
-        with self.cli.isolated_filesystem():
-            self.add_versions()
+    @contextmanager
+    def integration(self):
+        """Create a (small) set of files in the index. Handles setup and
+        teardown of temporary directories"""
+        cli = CliRunner()
+        self.tmpdir = tempfile.mkdtemp()
+        with cli.isolated_filesystem():
             self.add_trees()
             self.add_layers()
             self.add_diffs()
             self.add_notices()
-            self.cli.invoke(write_to, ['12', '1000', self.tmpdir])
+            yield cli
+        shutil.rmtree(self.tmpdir)
 
-            self.assert_file_exists('regulation', '1000', 'v2')
-            self.assert_file_exists('regulation', '1000', 'v3')
-            # v4 is skipped as there is no corresponding version
+    def test_cfr_title_part(self):
+        """Integration test that verifies only files associated with the
+        requested CFR title/part are created"""
+        with self.integration() as cli:
+            cli.invoke(write_to, [self.tmpdir, '--cfr_title', '12',
+                                  '--cfr_part', '1000'])
 
-            self.assert_file_exists('layer', 'layer1', '1000', 'v2')
-            self.assert_file_exists('layer', 'layer2', '1000', 'v2')
-            self.assert_file_exists('layer', 'layer2', '1000', 'v3')
-            self.assert_file_exists('layer', 'layer3', '1000', 'v3')
-            # v0, layer1 is skipped as there is no corresponding version
+            self.assertTrue(self.file_exists('regulation', '1000', 'v2'))
+            self.assertTrue(self.file_exists('regulation', '1000', 'v3'))
+            self.assertTrue(self.file_exists('regulation', '1000', 'v4'))
+            # these don't match the requested cfr title/part
+            self.assertFalse(self.file_exists('regulation', '1000', 'v5'))
+            self.assertFalse(self.file_exists('regulation', '1001', 'v6'))
 
-            self.assert_file_exists('diff', '1000', 'v1', 'v2')
-            self.assert_file_exists('diff', '1000', 'v2', 'v2')
-            self.assert_file_exists('diff', '1000', 'v2', 'v1')
-            # v0, v1 is skipped as there is no corresponding version
+            self.assertTrue(self.file_exists('layer', 'layer1', '1000', 'v2'))
+            self.assertTrue(self.file_exists('layer', 'layer2', '1000', 'v2'))
+            self.assertTrue(self.file_exists('layer', 'layer2', '1000', 'v3'))
+            self.assertTrue(self.file_exists('layer', 'layer3', '1000', 'v3'))
+            # these don't match the requested cfr title/part
+            self.assertFalse(self.file_exists('layer', 'layer4', '1000', 'v4'))
+            self.assertFalse(self.file_exists('layer', 'layer3', '1001', 'v3'))
 
-            # v0 is skipped as there is no corresponding version
-            self.assert_file_exists('notice', 'v1')
-            self.assert_file_exists('notice', 'v2')
+            self.assertTrue(self.file_exists('diff', '1000', 'v1', 'v2'))
+            self.assertTrue(self.file_exists('diff', '1000', 'v2', 'v2'))
+            self.assertTrue(self.file_exists('diff', '1000', 'v2', 'v1'))
+            # these don't match the requested cfr title/part
+            self.assertFalse(self.file_exists('diff', '1000', 'v3', 'v1'))
+            self.assertFalse(self.file_exists('diff', '1001', 'v3', 'v1'))
+
+            self.assertTrue(self.file_exists('notice', 'v2'))
+            self.assertTrue(self.file_exists('notice', 'v3'))
+            # these don't match the requested cfr title/part
+            self.assertFalse(self.file_exists('notice', 'v0'))
+            self.assertFalse(self.file_exists('notice', 'v1'))
+
+    def test_cfr_title(self):
+        """Integration test that verifies only files associated with the
+        requested CFR title are created"""
+        with self.integration() as cli:
+            cli.invoke(write_to, [self.tmpdir, '--cfr_title', '12'])
+
+            self.assertFalse(self.file_exists('regulation', '1000', 'v5'))
+            self.assertTrue(self.file_exists('regulation', '1001', 'v6'))
+            self.assertFalse(self.file_exists('layer', 'layer4', '1000', 'v4'))
+            self.assertTrue(self.file_exists('layer', 'layer3', '1001', 'v3'))
+            self.assertFalse(self.file_exists('diff', '1000', 'v3', 'v1'))
+            self.assertTrue(self.file_exists('diff', '1001', 'v3', 'v1'))
+            self.assertFalse(self.file_exists('notice', 'v0'))
+            self.assertFalse(self.file_exists('notice', 'v1'))
+
+    def test_no_params(self):
+        """Integration test that all local files are written"""
+        with self.integration() as cli:
+            cli.invoke(write_to, [self.tmpdir])
+
+            self.assertTrue(self.file_exists('regulation', '1000', 'v5'))
+            self.assertTrue(self.file_exists('layer', 'layer4', '1000', 'v4'))
+            self.assertTrue(self.file_exists('diff', '1000', 'v3', 'v1'))
+            self.assertTrue(self.file_exists('notice', 'v0'))
+            self.assertTrue(self.file_exists('notice', 'v1'))

--- a/tests/commands_write_to_tests.py
+++ b/tests/commands_write_to_tests.py
@@ -40,11 +40,11 @@ class CommandsWriteToTests(TestCase):
 
     def add_notices(self):
         """Adds an uneven assortment of notices"""
-        data = {'doc_number': 'v0', 'cfr_title': '11', 'cfr_parts': []}
+        data = {'doc_number': 'v0', 'cfr_title': 11, 'cfr_parts': []}
         entry.SxS('v0').write(data)
         data.update(cfr_parts=['1000'], doc_number='v1')
         entry.SxS('v1').write(data)
-        data.update(cfr_title='12', doc_number='v2')
+        data.update(cfr_title=12, doc_number='v2')
         entry.SxS('v2').write(data)
         data['doc_number'] = 'v3'
         entry.SxS('v3').write(data)

--- a/tests/notice_preamble_tests.py
+++ b/tests/notice_preamble_tests.py
@@ -1,0 +1,47 @@
+from unittest import TestCase
+
+from regparser.notice import preamble
+from regparser.notice.xml import NoticeXML
+from tests.node_accessor import NodeAccessorMixin
+from tests.xml_builder import XMLBuilderMixin
+
+
+class NoticePreambleTests(XMLBuilderMixin, NodeAccessorMixin, TestCase):
+    def test_parse_preamble_integration(self):
+        """End-to-end test for parsing a notice preamble"""
+        with self.tree.builder('ROOT') as root:
+            root.P("ignored content")
+            with root.SUPLINF() as suplinf:
+                suplinf.HED("Supp Inf")
+                suplinf.P("P1")
+                suplinf.P("P2")
+                suplinf.HD("H1", SOURCE="HD1")
+                suplinf.P("H1-P1")
+                suplinf.HD("H1-1", SOURCE="HD2")
+                suplinf.P("H1-1-P1")
+                suplinf.P("H1-1-P2")
+                suplinf.HD("H1-2", SOURCE="HD2")
+                suplinf.P("H1-2-P1")
+                suplinf.HD("H2", SOURCE="HD1")
+                suplinf.P("H2-P1")
+                suplinf.P("H2-P2")
+                suplinf.LSTSUB()
+                suplinf.P("ignored")
+            root.P("tail also ignored")
+        xml = NoticeXML(self.tree.render_xml())
+        xml.version_id = 'vvv-yyy'
+        root = self.node_accessor(preamble.parse_preamble(xml), ['vvv_yyy'])
+
+        self.assertEqual(root.title, 'Supp Inf')
+        self.assertEqual(root['p0'].text, 'P1')
+        self.assertEqual(root['p1'].text, 'P2')
+        self.assertEqual(root['p2'].title, 'H1')
+        self.assertEqual(root['p2']['p0'].text, 'H1-P1')
+        self.assertEqual(root['p2']['p1'].title, 'H1-1')
+        self.assertEqual(root['p2']['p1']['p0'].text, 'H1-1-P1')
+        self.assertEqual(root['p2']['p1']['p1'].text, 'H1-1-P2')
+        self.assertEqual(root['p2']['p2'].title, 'H1-2')
+        self.assertEqual(root['p2']['p2']['p0'].text, 'H1-2-P1')
+        self.assertEqual(root['p3'].title, 'H2')
+        self.assertEqual(root['p3']['p0'].text, 'H2-P1')
+        self.assertEqual(root['p3']['p1'].text, 'H2-P2')


### PR DESCRIPTION
Adds logic to convert notice preambles into `Node` structures and to write that content to an API/disk. This is a naive first draft which doesn't take into account the header labels (e.g. "IX" in "IX. Some Section")

Extends #211; see [diff](https://github.com/cmc333333/regulations-parser/compare/12-prep...13-parse-notice-preambles)

Should resolve eregs/notice-and-comment#13