### PR TITLE
Use a better date for eregs current_version

### DIFF
--- a/regparser/commands/current_version.py
+++ b/regparser/commands/current_version.py
@@ -14,7 +14,7 @@ _version_id = '{}-annual-{}'.format
 logger = logging.getLogger(__name__)
 
 
-def process_if_needed(cfr_title, cfr_part, year):
+def process_if_needed(cfr_title, cfr_part, year, publication_date):
     """Review dependencies; if they're out of date, parse the annual edition
     into a tree and store that"""
     version_id = _version_id(year, cfr_part)
@@ -32,10 +32,11 @@ def process_if_needed(cfr_title, cfr_part, year):
         tree = xml_parser.reg_text.build_tree(annual_entry.read().xml)
         tree_entry.write(tree)
         sxs_entry.write(build_fake_notice(
-            version_id, date.today().isoformat(), cfr_title, cfr_part))
+            version_id, publication_date.isoformat(), cfr_title, cfr_part))
 
 
-def create_version_entry_if_needed(cfr_title, cfr_part, year):
+def create_version_entry_if_needed(cfr_title, cfr_part, year,
+                                   publication_date):
     """Only write the version entry if it doesn't already exist. If we
     overwrote one, we'd be invalidating all related trees, etc."""
     version_id = _version_id(year, cfr_part)
@@ -43,8 +44,8 @@ def create_version_entry_if_needed(cfr_title, cfr_part, year):
 
     if version_id not in version_entries:
         (version_entries / version_id).write(
-            Version(identifier=version_id, effective=date.today(),
-                    published=date.today()))
+            Version(identifier=version_id, effective=publication_date,
+                    published=publication_date))
 
 
 @click.command()
@@ -53,8 +54,8 @@ def create_version_entry_if_needed(cfr_title, cfr_part, year):
 def current_version(cfr_title, cfr_part):
     """Build a regulation tree for the most recent annual edition. This will
     also construct a corresponding, empty notice to match. The version will be
-    marked as effective _today_"""
-
+    marked as effective on the date of the last annual edition (which is not
+    likely accurate)"""
     year = date.today().year
     vol = find_volume(year, cfr_title, cfr_part)
     if vol is None:
@@ -63,5 +64,7 @@ def current_version(cfr_title, cfr_part):
 
     logger.info("Getting current version - %s CFR %s, Year: %s",
                 cfr_title, cfr_part, year)
-    create_version_entry_if_needed(cfr_title, cfr_part, year)
-    process_if_needed(cfr_title, cfr_part, year)
+
+    create_version_entry_if_needed(
+        cfr_title, cfr_part, year, vol.publication_date)
+    process_if_needed(cfr_title, cfr_part, year, vol.publication_date)

--- a/regparser/history/annual.py
+++ b/regparser/history/annual.py
@@ -84,6 +84,10 @@ class Volume(namedtuple('Volume', ['year', 'title', 'vol_num'])):
                 self._part_span = (1, None)
         return self._part_span
 
+    @property
+    def publication_date(self):
+        return date(self.year, publication_month(self.title), 1)
+
     def should_contain(self, part):
         """Does this volume contain the part number requested?"""
         if self.part_span:
@@ -122,21 +126,23 @@ def annual_edition_for(title, notice):
     return date_of_annual_after(title, eff_date).year
 
 
-def date_of_annual_after(title, eff_date):
+def publication_month(cfr_title):
     """Annual editions are published for different titles at different points
-    throughout the year. Return the date of the _first_ annual edition which
-    should contain any changes on `eff_date`. This date may well be in the
-    future"""
-    if title <= 16:
-        month_published = 1
-    elif title <= 27:
-        month_published = 4
-    elif title <= 41:
-        month_published = 7
+    throughout the year. Return the month associated with this CFR title"""
+    if cfr_title <= 16:
+        return 1
+    elif cfr_title <= 27:
+        return 4
+    elif cfr_title <= 41:
+        return 7
     else:
-        month_published = 10
+        return 10
 
-    publication_date = date(eff_date.year, month_published, 1)
+
+def date_of_annual_after(title, eff_date):
+    """Return the date of the _first_ annual edition which should contain any
+    changes on `eff_date`. This date may well be in the future"""
+    publication_date = date(eff_date.year, publication_month(title), 1)
     if eff_date <= publication_date:
         return publication_date
     else:

--- a/tests/commands_current_version_tests.py
+++ b/tests/commands_current_version_tests.py
@@ -25,7 +25,8 @@ class CommandsCurrentVersionTests(TestCase):
                 '<ROOT />')
 
             xml_parser.reg_text.build_tree.return_value = {'my': 'tree'}
-            current_version.process_if_needed(self.title, self.part, self.year)
+            current_version.process_if_needed(
+                self.title, self.part, self.year, date.today())
             tree = entry.Entry('tree', self.title, self.part,
                                self.version_id).read()
             self.assertEqual(json.loads(tree), {'my': 'tree'})
@@ -41,7 +42,8 @@ class CommandsCurrentVersionTests(TestCase):
             annual.write('ANNUAL')
             tree.write('TREE')
 
-            current_version.process_if_needed(self.title, self.part, self.year)
+            current_version.process_if_needed(
+                self.title, self.part, self.year, date.today())
 
             # didn't change
             self.assertEqual(annual.read(), 'ANNUAL')
@@ -51,8 +53,8 @@ class CommandsCurrentVersionTests(TestCase):
         """Creates a version associated with the part and year"""
         with CliRunner().isolated_filesystem():
             current_version.create_version_entry_if_needed(
-                self.title, self.part, self.year)
+                self.title, self.part, self.year, date(self.year, 4, 8))
             version = entry.Version(
                 self.title, self.part, self.version_id).read()
-            self.assertEqual(version.effective, date.today())
-            self.assertEqual(version.published, date.today())
+            self.assertEqual(version.effective, date(self.year, 4, 8))
+            self.assertEqual(version.published, date(self.year, 4, 8))

--- a/tests/commands_current_version_tests.py
+++ b/tests/commands_current_version_tests.py
@@ -8,6 +8,7 @@ from mock import patch
 
 from regparser.commands import current_version
 from regparser.index import entry
+from regparser.history.annual import Volume
 
 
 class CommandsCurrentVersionTests(TestCase):
@@ -15,6 +16,7 @@ class CommandsCurrentVersionTests(TestCase):
         self.title = randint(1, 999)
         self.part = randint(1, 999)
         self.year = randint(2000, 2020)
+        self.volume = Volume(self.year, self.title, 1)
         self.version_id = '{}-annual-{}'.format(self.year, self.part)
 
     def test_process_creation(self):
@@ -25,8 +27,7 @@ class CommandsCurrentVersionTests(TestCase):
                 '<ROOT />')
 
             xml_parser.reg_text.build_tree.return_value = {'my': 'tree'}
-            current_version.process_if_needed(
-                self.title, self.part, self.year, date.today())
+            current_version.process_if_needed(self.volume, self.part)
             tree = entry.Entry('tree', self.title, self.part,
                                self.version_id).read()
             self.assertEqual(json.loads(tree), {'my': 'tree'})
@@ -42,8 +43,7 @@ class CommandsCurrentVersionTests(TestCase):
             annual.write('ANNUAL')
             tree.write('TREE')
 
-            current_version.process_if_needed(
-                self.title, self.part, self.year, date.today())
+            current_version.process_if_needed(self.volume, self.part)
 
             # didn't change
             self.assertEqual(annual.read(), 'ANNUAL')
@@ -53,8 +53,7 @@ class CommandsCurrentVersionTests(TestCase):
         """Creates a version associated with the part and year"""
         with CliRunner().isolated_filesystem():
             current_version.create_version_entry_if_needed(
-                self.title, self.part, self.year, date(self.year, 4, 8))
-            version = entry.Version(
-                self.title, self.part, self.version_id).read()
-            self.assertEqual(version.effective, date(self.year, 4, 8))
-            self.assertEqual(version.published, date(self.year, 4, 8))
+                Volume(2010, 20, 1), 1001)
+            version = entry.Version(20, 1001, '2010-annual-1001').read()
+            self.assertEqual(version.effective, date(2010, 4, 1))
+            self.assertEqual(version.published, date(2010, 4, 1))


### PR DESCRIPTION
`eregs current_version`, which is used by `pipeline --only-latest` had been
using the current date when creating a version associated with the annual
edition XML. This patch changes the logic to use the publication date of the
annual edition. While this isn't accurate (it's very unlikely that the last
final rule became effective on the date that the annual edition was
published), it's _consistent_ and safer than implying we've captured final
rules which have become effective after the annual edition's publication.

Resolves #212 