### PR TITLE
Make fake notices consistent w/ real

### DIFF
--- a/regparser/commands/write_to.py
+++ b/regparser/commands/write_to.py
@@ -40,7 +40,8 @@ def write_notices(client, only_title, only_part):
     for version_id in sxs_dir:
         tree = (sxs_dir / version_id).read()
         title_match = not only_title or tree['cfr_title'] == only_title
-        part_match = not only_part or str(only_part) in tree['cfr_parts']
+        cfr_parts = map(str, tree['cfr_parts'])
+        part_match = not only_part or str(only_part) in cfr_parts
         if title_match and part_match:
             client.notice(version_id).write(tree)
 

--- a/regparser/notice/fake.py
+++ b/regparser/notice/fake.py
@@ -8,7 +8,7 @@ def build(doc_number, effective_on, cfr_title, cfr_part):
         "initial_effective_on": effective_on,
         "publication_date": effective_on,
         "cfr_title": cfr_title,
-        "cfr_parts": [cfr_part],
+        "cfr_parts": [str(cfr_part)],   # for consistency w/ normal notices
         "fr_url": None
     }
 

--- a/tests/commands_current_version_tests.py
+++ b/tests/commands_current_version_tests.py
@@ -33,7 +33,7 @@ class CommandsCurrentVersionTests(TestCase):
             self.assertEqual(json.loads(tree), {'my': 'tree'})
             notice = entry.SxS(self.version_id).read()
             self.assertEqual(notice['document_number'], self.version_id)
-            self.assertEqual(notice['cfr_parts'], [self.part])
+            self.assertEqual(notice['cfr_parts'], [str(self.part)])
 
     def test_process_no_need_to_create(self):
         """If everything is up to date, we don't need to build new versions"""


### PR DESCRIPTION
When we parse real notices, we associate string values for CFR parts affected.
Fake notices weren't being processed this way (using real integers). While
using integers is preferred in the long term, for consistency, convert them to
strings.

Resolves #218 