### PR TITLE
Add GraphicsMatcher for embedded images

### DIFF
--- a/regparser/notice/preamble.py
+++ b/regparser/notice/preamble.py
@@ -7,8 +7,10 @@ from lxml import etree
 from regparser.tree.depth import heuristics
 from regparser.tree.depth.derive import markers as mtypes
 from regparser.tree.struct import Node
+from regparser.tree.xml_parser.flatsubtree_processor import FlatsubtreeMatcher
 from regparser.tree.xml_parser.paragraph_processor import (
-    BaseMatcher, ParagraphProcessor, SimpleTagMatcher)
+    BaseMatcher, GraphicsMatcher, IgnoreTagMatcher, ParagraphProcessor,
+    SimpleTagMatcher, TableMatcher)
 
 
 _MARKER_REGEX = re.compile(r'(?P<marker>([0-9]+)|([a-z]+)|([A-Z]+))\.')
@@ -39,7 +41,12 @@ class PreambleLevelMatcher(BaseMatcher):
 
 
 class PreambleProcessor(ParagraphProcessor):
-    MATCHERS = [PreambleLevelMatcher(), SimpleTagMatcher('P', 'FP')]
+    MATCHERS = [PreambleLevelMatcher(), SimpleTagMatcher('P', 'FP'),
+                # FTNT's are already converted; we can ignore the original
+                IgnoreTagMatcher('FTNT', 'PRTPAGE'), GraphicsMatcher(),
+                FlatsubtreeMatcher(tags=['EXTRACT'], node_type=Node.EXTRACT),
+                TableMatcher()
+                ]
 
     def select_depth(self, depths):
         """Override ParagraphProcessor to add different weights"""

--- a/regparser/tree/xml_parser/paragraph_processor.py
+++ b/regparser/tree/xml_parser/paragraph_processor.py
@@ -244,3 +244,15 @@ class FencedMatcher(BaseMatcher):
         texts.append("```")
 
         return [Node("\n".join(texts), label=[mtypes.MARKERLESS])]
+
+
+class GraphicsMatcher(BaseMatcher):
+    """Convert Graphics tags into a markdown-esque format"""
+    def matches(self, xml):
+        return xml.tag == 'GPH'
+
+    def derive_nodes(self, xml, processor=None):
+        text = ''
+        for gid_xml in xml.xpath('./GID'):
+            text += '![]({})'.format(gid_xml.text)
+        return [Node(text, label=[mtypes.MARKERLESS])]

--- a/tests/notice_preamble_tests.py
+++ b/tests/notice_preamble_tests.py
@@ -25,6 +25,8 @@ class NoticePreambleTests(XMLBuilderMixin, NodeAccessorMixin, TestCase):
                 suplinf.HD("II. H2", SOURCE="HD1")
                 suplinf.P("H2-P1")
                 suplinf.P("H2-P2")
+                with suplinf.GPH() as gph:
+                    gph.GID("111-222-333")
                 suplinf.LSTSUB()
                 suplinf.P("ignored")
             root.P("tail also ignored")
@@ -45,3 +47,4 @@ class NoticePreambleTests(XMLBuilderMixin, NodeAccessorMixin, TestCase):
         self.assertEqual(root['II'].title, 'II. H2')
         self.assertEqual(root['II']['p1'].text, 'H2-P1')
         self.assertEqual(root['II']['p2'].text, 'H2-P2')
+        self.assertEqual(root['II']['p3'].text, '![](111-222-333)')


### PR DESCRIPTION
We already use something similar in the appendix-specific code. Also adds
EXTRACT and GPOTABLE matchers for preambles, and explicitly ignores FTNT and
PRTPAGE tags

Should resolve eregs/notice-and-comment#16