### PR TITLE
Parse and write preamble layer data

### DIFF
--- a/regparser/api_writer.py
+++ b/regparser/api_writer.py
@@ -152,9 +152,8 @@ class Client:
     def regulation(self, label, doc_number):
         return self.writer_class(self.base, "regulation", label, doc_number)
 
-    def layer(self, layer_name, label, doc_number):
-        return self.writer_class(self.base, "layer", layer_name, label,
-                                 doc_number)
+    def layer(self, layer_name, reference):
+        return self.writer_class(self.base, "layer", layer_name, reference)
 
     def notice(self, doc_number):
         return self.writer_class(self.base, "notice", doc_number)

--- a/regparser/api_writer.py
+++ b/regparser/api_writer.py
@@ -152,8 +152,11 @@ class Client:
     def regulation(self, label, doc_number):
         return self.writer_class(self.base, "regulation", label, doc_number)
 
-    def layer(self, layer_name, reference):
-        return self.writer_class(self.base, "layer", layer_name, reference)
+    def layer(self, layer_name, label, version=None):
+        args = [self.base, "layer", layer_name, label]
+        if version:
+            args.append(version)
+        return self.writer_class(*args)
 
     def notice(self, doc_number):
         return self.writer_class(self.base, "notice", doc_number)

--- a/regparser/commands/layers.py
+++ b/regparser/commands/layers.py
@@ -16,18 +16,19 @@ for doc_type in LAYER_CLASSES:
 logger = logging.getLogger(__name__)
 
 
-def stale_cfr_layers(version_entry):
-    """Return the name of CFR layer dependencies which are now stale"""
+def stale_layers(doc_entry, doc_type):
+    """Return the name of layer dependencies which are now stale. Limit to a
+    particular doc_type"""
     deps = dependency.Graph()
-    tree_entry = entry.Tree(*version_entry.path)
-    layer_dir = entry.Layer.cfr(*version_entry.path)
-    for layer_name in LAYER_CLASSES['cfr']:
+    layer_dir = entry.Layer(doc_type, *doc_entry.path)
+    for layer_name in LAYER_CLASSES[doc_type]:
         # Layers depend on their associated tree
-        deps.add(layer_dir / layer_name, tree_entry)
-    # Meta layer also depends on the version info
-    deps.add(layer_dir / 'meta', version_entry)
+        deps.add(layer_dir / layer_name, doc_entry)
+    if doc_type == 'cfr':
+        # Meta layer also depends on the version info
+        deps.add(layer_dir / 'meta', entry.Version(*doc_entry.path))
 
-    for layer_name in LAYER_CLASSES['cfr']:
+    for layer_name in LAYER_CLASSES[doc_type]:
         layer_entry = layer_dir / layer_name
         deps.validate_for(layer_entry)
         if deps.is_stale(layer_entry):
@@ -53,10 +54,11 @@ def process_cfr_layers(stale_names, cfr_title, version_entry):
 def layers(cfr_title, cfr_part):
     """Build all layers for all known versions."""
     logger.info("Build layers - %s CFR %s", cfr_title, cfr_part)
-    tree_dir = entry.Tree(cfr_title, cfr_part)
 
+    tree_dir = entry.Tree(cfr_title, cfr_part)
     for version_id in tree_dir:
+        tree_entry = tree_dir / version_id
         version_entry = entry.Version(cfr_title, cfr_part, version_id)
-        stale = stale_cfr_layers(version_entry)
+        stale = stale_layers(tree_entry, 'cfr')
         if stale:
             process_cfr_layers(stale, cfr_title, version_entry)

--- a/regparser/commands/layers.py
+++ b/regparser/commands/layers.py
@@ -16,38 +16,34 @@ for doc_type in LAYER_CLASSES:
 logger = logging.getLogger(__name__)
 
 
-def dependencies(tree_dir, layer_dir, version_dir):
-    """Modify and return the dependency graph pertaining to layers"""
+def stale_cfr_layers(version_entry):
+    """Return the name of CFR layer dependencies which are now stale"""
     deps = dependency.Graph()
-    for version_id in tree_dir:
-        for layer_name in LAYER_CLASSES['cfr']:
-            # Layers depend on their associated tree
-            deps.add(layer_dir / version_id / layer_name,
-                     tree_dir / version_id)
-        # Meta layer also depends on the version info
-        deps.add(layer_dir / version_id / 'meta', version_dir / version_id)
-    return deps
-
-
-def stale_layers(deps, layer_dir):
-    """Return all of the layer dependencies which are now stale within
-    layer_dir"""
+    tree_entry = entry.Tree(*version_entry.path)
+    layer_dir = entry.Layer.cfr(*version_entry.path)
     for layer_name in LAYER_CLASSES['cfr']:
-        entry = layer_dir / layer_name
-        deps.validate_for(entry)
-        if deps.is_stale(entry):
+        # Layers depend on their associated tree
+        deps.add(layer_dir / layer_name, tree_entry)
+    # Meta layer also depends on the version info
+    deps.add(layer_dir / 'meta', version_entry)
+
+    for layer_name in LAYER_CLASSES['cfr']:
+        layer_entry = layer_dir / layer_name
+        deps.validate_for(layer_entry)
+        if deps.is_stale(layer_entry):
             yield layer_name
 
 
-def process_layers(stale, cfr_title, cfr_part, version):
+def process_cfr_layers(stale_names, cfr_title, version_entry):
     """Build all of the stale layers for this version, writing them into the
     index. Assumes all dependencies have already been checked"""
-    tree = entry.Tree(cfr_title, cfr_part, version.identifier).read()
-    layer_dir = entry.Layer(cfr_title, cfr_part)
-    for layer_name in stale:
+    tree = entry.Tree(*version_entry.path).read()
+    version = version_entry.read()
+    layer_dir = entry.Layer.cfr(*version_entry.path)
+    for layer_name in stale_names:
         layer_json = LAYER_CLASSES['cfr'][layer_name](
             tree, cfr_title=cfr_title, version=version).build()
-        (layer_dir / version.identifier / layer_name).write(layer_json)
+        (layer_dir / layer_name).write(layer_json)
 
 
 @click.command()
@@ -58,14 +54,9 @@ def layers(cfr_title, cfr_part):
     """Build all layers for all known versions."""
     logger.info("Build layers - %s CFR %s", cfr_title, cfr_part)
     tree_dir = entry.Tree(cfr_title, cfr_part)
-    layer_dir = entry.Layer(cfr_title, cfr_part)
-    version_dir = entry.Version(cfr_title, cfr_part)
-    deps = dependencies(tree_dir, layer_dir, version_dir)
 
     for version_id in tree_dir:
-        stale = list(stale_layers(deps, layer_dir / version_id))
+        version_entry = entry.Version(cfr_title, cfr_part, version_id)
+        stale = stale_cfr_layers(version_entry)
         if stale:
-            process_layers(
-                stale, cfr_title, cfr_part,
-                version=(version_dir / version_id).read()
-            )
+            process_cfr_layers(stale, cfr_title, version_entry)

--- a/regparser/commands/layers.py
+++ b/regparser/commands/layers.py
@@ -44,7 +44,7 @@ def process_cfr_layers(stale_names, cfr_title, version_entry):
     layer_dir = entry.Layer.cfr(*version_entry.path)
     for layer_name in stale_names:
         layer_json = LAYER_CLASSES['cfr'][layer_name](
-            tree, cfr_title=cfr_title, version=version).build()
+            tree, cfr_title=int(cfr_title), version=version).build()
         (layer_dir / layer_name).write(layer_json)
 
 
@@ -66,13 +66,12 @@ def layers(cfr_title, cfr_part):
     """Build all layers for all known versions."""
     logger.info("Build layers - %s CFR %s", cfr_title, cfr_part)
 
-    for tree_dir in utils.relevant_paths(entry.Tree(), cfr_title, cfr_part):
-        for version_id in tree_dir:
-            tree_entry = tree_dir / version_id
-            version_entry = entry.Version(cfr_title, cfr_part, version_id)
-            stale = stale_layers(tree_entry, 'cfr')
-            if stale:
-                process_cfr_layers(stale, cfr_title, version_entry)
+    for tree_entry in utils.relevant_paths(entry.Tree(), cfr_title, cfr_part):
+        tree_title, tree_part, version_id = tree_entry.path
+        version_entry = entry.Version(tree_title, tree_part, version_id)
+        stale = stale_layers(tree_entry, 'cfr')
+        if stale:
+            process_cfr_layers(stale, tree_title, version_entry)
 
     if cfr_title is None and cfr_part is None:
         preamble_dir = entry.Preamble()

--- a/regparser/commands/utils.py
+++ b/regparser/commands/utils.py
@@ -1,0 +1,11 @@
+def relevant_paths(root_dir, only_title, only_part):
+    """We may want to filter the paths we search in to those relevant to a
+    particular cfr title/part. Most index entries encode this as their first
+    two path components"""
+    title_dirs = [(root_dir / title) for title in root_dir
+                  if not only_title or str(only_title) == title]
+    part_dirs = [(title_dir / part)
+                 for title_dir in title_dirs for part in title_dir
+                 if not only_part or str(only_part) == part]
+    return [(part_dir / child)
+            for part_dir in part_dirs for child in part_dir]

--- a/regparser/commands/write_to.py
+++ b/regparser/commands/write_to.py
@@ -28,8 +28,8 @@ def write_trees(client, only_title, only_part):
 
 
 def write_layers(client, only_title, only_part):
-    for layer_dir in relevant_paths(entry.Layer(), only_title, only_part):
-        cfr_title, cfr_part, version_id = layer_dir.path
+    for layer_dir in relevant_paths(entry.Layer.cfr(), only_title, only_part):
+        doc_type, cfr_title, cfr_part, version_id = layer_dir.path
         for layer_name in layer_dir:
             layer = (layer_dir / layer_name).read()
             client.layer(layer_name, cfr_part, version_id).write(layer)

--- a/regparser/commands/write_to.py
+++ b/regparser/commands/write_to.py
@@ -2,33 +2,23 @@ import click
 import logging
 
 from regparser.api_writer import Client
+from regparser.commands import utils
 from regparser.index import entry
 
 
 logger = logging.getLogger(__name__)
 
 
-def relevant_paths(root_dir, only_title, only_part):
-    """We may want to filter the paths we search in to those relevant to a
-    particular cfr title/part. Most index entries encode this as their first
-    two path components"""
-    title_dirs = [(root_dir / title) for title in root_dir
-                  if not only_title or str(only_title) == title]
-    part_dirs = [(title_dir / part)
-                 for title_dir in title_dirs for part in title_dir
-                 if not only_part or str(only_part) == part]
-    return [(part_dir / child)
-            for part_dir in part_dirs for child in part_dir]
-
-
 def write_trees(client, only_title, only_part):
-    for tree_entry in relevant_paths(entry.Tree(), only_title, only_part):
+    for tree_entry in utils.relevant_paths(entry.Tree(), only_title,
+                                           only_part):
         cfr_title, cfr_part, version_id = tree_entry.path
         client.regulation(cfr_part, version_id).write(tree_entry.read())
 
 
 def write_layers(client, only_title, only_part):
-    for layer_dir in relevant_paths(entry.Layer.cfr(), only_title, only_part):
+    for layer_dir in utils.relevant_paths(entry.Layer.cfr(), only_title,
+                                          only_part):
         doc_type, cfr_title, cfr_part, version_id = layer_dir.path
         for layer_name in layer_dir:
             layer = (layer_dir / layer_name).read()
@@ -47,7 +37,7 @@ def write_notices(client, only_title, only_part):
 
 
 def write_diffs(client, only_title, only_part):
-    for diff_dir in relevant_paths(entry.Diff(), only_title, only_part):
+    for diff_dir in utils.relevant_paths(entry.Diff(), only_title, only_part):
         cfr_title, cfr_part, lhs_id = diff_dir.path
         for rhs_id in diff_dir:
             diff = (diff_dir / rhs_id).read()

--- a/regparser/commands/write_to.py
+++ b/regparser/commands/write_to.py
@@ -23,10 +23,9 @@ def write_layers(client, only_title, only_part):
     for layer_dir in utils.relevant_paths(entry.Layer.cfr(), only_title,
                                           only_part):
         _, cfr_title, cfr_part, version_id = layer_dir.path
-        reference = '{}:{}'.format(version_id, cfr_part)
         for layer_name in layer_dir:
             layer = (layer_dir / layer_name).read()
-            client.layer(layer_name, reference).write(layer)
+            client.layer(layer_name, cfr_part, version_id).write(layer)
 
     if only_title is None and only_part is None:
         non_cfr_doc_types = [doc_type for doc_type in entry.Layer()

--- a/regparser/commands/write_to.py
+++ b/regparser/commands/write_to.py
@@ -17,12 +17,26 @@ def write_trees(client, only_title, only_part):
 
 
 def write_layers(client, only_title, only_part):
+    """Write all layers that match the filtering criteria. If CFR title/part
+    are used to filter, only process CFR layers. Otherwise, process all
+    layers."""
     for layer_dir in utils.relevant_paths(entry.Layer.cfr(), only_title,
                                           only_part):
-        doc_type, cfr_title, cfr_part, version_id = layer_dir.path
+        _, cfr_title, cfr_part, version_id = layer_dir.path
+        reference = '{}:{}'.format(version_id, cfr_part)
         for layer_name in layer_dir:
             layer = (layer_dir / layer_name).read()
-            client.layer(layer_name, cfr_part, version_id).write(layer)
+            client.layer(layer_name, reference).write(layer)
+
+    if only_title is None and only_part is None:
+        non_cfr_doc_types = [doc_type for doc_type in entry.Layer()
+                             if doc_type != 'cfr']
+        for doc_type in non_cfr_doc_types:
+            for doc_id in entry.Layer(doc_type):
+                reference = "{}:{}".format(doc_type, doc_id)
+                for layer_name in entry.Layer(doc_type, doc_id):
+                    layer = entry.Layer(doc_type, doc_id, layer_name).read()
+                    client.layer(layer_name, reference).write(layer)
 
 
 def write_notices(client, only_title, only_part):

--- a/regparser/index/entry.py
+++ b/regparser/index/entry.py
@@ -65,6 +65,9 @@ class Entry(object):
     def __len__(self):
         return len(list(self.__iter__()))
 
+    def exists(self):
+        return os.path.exists(str(self))
+
 
 class Notice(Entry):
     """Processes NoticeXMLs, keyed by notice_xml"""

--- a/regparser/index/entry.py
+++ b/regparser/index/entry.py
@@ -152,6 +152,11 @@ class Layer(_JSONEntry):
         """Return a Layer entry in the appropriate namespace"""
         return cls("cfr", *args)
 
+    @classmethod
+    def preamble(cls, *args):
+        """Return a Layer entry in the appropriate namespace"""
+        return cls("preamble", *args)
+
 
 class Diff(_JSONEntry):
     """Processes diffs, keyed by diff"""

--- a/regparser/index/entry.py
+++ b/regparser/index/entry.py
@@ -147,6 +147,11 @@ class Layer(_JSONEntry):
     """Processes layers, keyed by layer"""
     PREFIX = (ROOT, 'layer')
 
+    @classmethod
+    def cfr(cls, *args):
+        """Return a Layer entry in the appropriate namespace"""
+        return cls("cfr", *args)
+
 
 class Diff(_JSONEntry):
     """Processes diffs, keyed by diff"""

--- a/tests/commands_layers_tests.py
+++ b/tests/commands_layers_tests.py
@@ -14,26 +14,26 @@ class CommandsLayersTests(TestCase):
     def setUp(self):
         self.cli = CliRunner()
 
-    def test_stale_cfr_layers(self):
-        """We should have dependencies between all of the CFR layers and their
+    def test_stale_layers(self):
+        """We should have dependencies between all of the layers and their
         associated trees. We should also tie the meta layer to the version"""
         configured_layers = {'cfr': {'keyterms': None, 'other': None}}
         with self.cli.isolated_filesystem(), patch.dict(
                 layers.LAYER_CLASSES, configured_layers):
             version_entry = entry.Version(111, 22, 'aaa')
             version_entry.write(Version('aaa', date.today(), date.today()))
+            tree_entry = entry.Tree(111, 22, 'aaa')
             # Use list() to instantiate
             self.assertRaises(dependency.Missing,
-                              list, layers.stale_cfr_layers(version_entry))
+                              list, layers.stale_layers(tree_entry, 'cfr'))
 
             entry.Entry('tree', 111, 22, 'bbb').write('')    # wrong version
             self.assertRaises(dependency.Missing,
-                              list, layers.stale_cfr_layers(version_entry))
+                              list, layers.stale_layers(tree_entry, 'cfr'))
 
             entry.Entry('tree', 111, 22, 'aaa').write('')
             self.assertItemsEqual(
-                layers.stale_cfr_layers(version_entry),
-                ['keyterms', 'other'])
+                layers.stale_layers(tree_entry, 'cfr'), ['keyterms', 'other'])
 
             with dependency.Graph().dependency_db() as db:
                 self.assertIn(

--- a/tests/commands_layers_tests.py
+++ b/tests/commands_layers_tests.py
@@ -2,11 +2,11 @@ from datetime import date
 from unittest import TestCase
 
 from click.testing import CliRunner
-from mock import Mock, patch
+from mock import patch
 
 from regparser.commands import layers
 from regparser.history.versions import Version
-from regparser.index import entry
+from regparser.index import dependency, entry
 from regparser.tree.struct import Node
 
 
@@ -14,51 +14,43 @@ class CommandsLayersTests(TestCase):
     def setUp(self):
         self.cli = CliRunner()
 
-    def test_dependencies(self):
-        """We should have dependencies between all of the layers and their
-        associated trees. We should also have a tie from the meta layer to the
-        version info"""
-        with self.cli.isolated_filesystem():
-            tree_dir = entry.Entry('tree')
-            layer_dir = entry.Entry('layer')
-            version_dir = entry.Entry('version')
+    def test_stale_cfr_layers(self):
+        """We should have dependencies between all of the CFR layers and their
+        associated trees. We should also tie the meta layer to the version"""
+        configured_layers = {'cfr': {'keyterms': None, 'other': None}}
+        with self.cli.isolated_filesystem(), patch.dict(
+                layers.LAYER_CLASSES, configured_layers):
+            version_entry = entry.Version(111, 22, 'aaa')
+            version_entry.write(Version('aaa', date.today(), date.today()))
+            # Use list() to instantiate
+            self.assertRaises(dependency.Missing,
+                              list, layers.stale_cfr_layers(version_entry))
 
-            # Trees
-            (tree_dir / '1111').write('tree1')
-            (tree_dir / '2222').write('tree2')
-            (tree_dir / '3333').write('tree3')
+            entry.Entry('tree', 111, 22, 'bbb').write('')    # wrong version
+            self.assertRaises(dependency.Missing,
+                              list, layers.stale_cfr_layers(version_entry))
 
-            deps = layers.dependencies(tree_dir, layer_dir, version_dir)
-            layer_names = [
-                'external-citations', 'internal-citations', 'toc',
-                'interpretations', 'terms', 'paragraph-markers', 'keyterms',
-                'formatting', 'graphics']
+            entry.Entry('tree', 111, 22, 'aaa').write('')
+            self.assertItemsEqual(
+                layers.stale_cfr_layers(version_entry),
+                ['keyterms', 'other'])
 
-            with deps.dependency_db() as db:
-                graph = dict(db)    # copy
-            for version_id in ('1111', '2222', '3333'):
-                for layer_name in layer_names:
-                    self.assertEqual(
-                        graph[str(layer_dir / version_id / layer_name)],
-                        set([str(tree_dir / version_id)]))
-                self.assertEqual(
-                    graph[str(layer_dir / version_id / 'meta')],
-                    set([str(tree_dir / version_id),
-                         str(version_dir / version_id)]))
+            with dependency.Graph().dependency_db() as db:
+                self.assertIn(
+                    str(version_entry),
+                    db[str(entry.Layer.cfr(111, 22, 'aaa', 'meta'))])
 
-    def test_process_layers(self):
+    def test_process_cfr_layers(self):
         """All layers for a single version should get written."""
         with self.cli.isolated_filesystem():
-            meta, keyterms = Mock(), Mock()
-            meta.return_value.build.return_value = {'1': 1}
-            keyterms.return_value.build.return_value = {'2': 2}
-
-            version = Version('1234', date(2000, 1, 1), date(2000, 1, 1))
+            version_entry = entry.Version(12, 1000, '1234')
+            version_entry.write(Version('1234', date.today(), date.today()))
             entry.Tree('12', '1000', '1234').write(Node())
 
-            with patch.dict(layers.LAYER_CLASSES,
-                            {'cfr': {'meta': meta, 'keyterms': keyterms}}):
-                layers.process_layers(
-                    ['meta', 'keyterms'], '12', '1000', version)
-            self.assertTrue(meta.called)
-            self.assertTrue(keyterms.called)
+            layers.process_cfr_layers(
+                ['keyterms', 'meta'], 12, version_entry)
+
+            self.assertEqual(
+                entry.Layer.cfr(12, 1000, '1234', 'keyterms').read(), {})
+            self.assertEqual(
+                entry.Layer.cfr(12, 1000, '1234', 'meta').read(), {})

--- a/tests/commands_layers_tests.py
+++ b/tests/commands_layers_tests.py
@@ -50,7 +50,18 @@ class CommandsLayersTests(TestCase):
             layers.process_cfr_layers(
                 ['keyterms', 'meta'], 12, version_entry)
 
-            self.assertEqual(
-                entry.Layer.cfr(12, 1000, '1234', 'keyterms').read(), {})
-            self.assertEqual(
-                entry.Layer.cfr(12, 1000, '1234', 'meta').read(), {})
+            self.assertTrue(
+                entry.Layer.cfr(12, 1000, '1234', 'keyterms').exists())
+            self.assertTrue(
+                entry.Layer.cfr(12, 1000, '1234', 'meta').exists())
+
+    def test_process_preamble_layers(self):
+        """All layers for a single preamble should get written."""
+        with self.cli.isolated_filesystem():
+            preamble_entry = entry.Preamble('111_222')
+            preamble_entry.write(Node())
+
+            layers.process_preamble_layers(['graphics'], preamble_entry)
+
+            self.assertTrue(
+                entry.Layer.preamble('111_222', 'graphics').exists())

--- a/tests/commands_write_to_tests.py
+++ b/tests/commands_write_to_tests.py
@@ -28,6 +28,7 @@ class CommandsWriteToTests(TestCase):
         entry.Layer.cfr('12', '1000', 'v3', 'layer3').write({'3': 3})
         entry.Layer.cfr('11', '1000', 'v4', 'layer4').write({'4': 4})
         entry.Layer.cfr('12', '1001', 'v3', 'layer3').write({'3': 3})
+        entry.Layer.preamble('555_55', 'layer5').write({'5': 5})
 
     def add_diffs(self):
         """Adds an uneven assortment of diffs between trees"""
@@ -89,6 +90,8 @@ class CommandsWriteToTests(TestCase):
             # these don't match the requested cfr title/part
             self.assertFalse(self.file_exists('layer', 'layer4', '1000', 'v4'))
             self.assertFalse(self.file_exists('layer', 'layer3', '1001', 'v3'))
+            self.assertFalse(self.file_exists('layer', 'layer5',
+                                              'preamble:555_55'))
 
             self.assertTrue(self.file_exists('diff', '1000', 'v1', 'v2'))
             self.assertTrue(self.file_exists('diff', '1000', 'v2', 'v2'))
@@ -117,6 +120,8 @@ class CommandsWriteToTests(TestCase):
             self.assertTrue(self.file_exists('diff', '1001', 'v3', 'v1'))
             self.assertFalse(self.file_exists('notice', 'v0'))
             self.assertFalse(self.file_exists('notice', 'v1'))
+            self.assertFalse(self.file_exists('layer', 'layer5',
+                                              'preamble:555_55'))
 
     def test_no_params(self):
         """Integration test that all local files are written"""
@@ -128,3 +133,5 @@ class CommandsWriteToTests(TestCase):
             self.assertTrue(self.file_exists('diff', '1000', 'v3', 'v1'))
             self.assertTrue(self.file_exists('notice', 'v0'))
             self.assertTrue(self.file_exists('notice', 'v1'))
+            self.assertTrue(self.file_exists('layer', 'layer5',
+                                             'preamble:555_55'))

--- a/tests/commands_write_to_tests.py
+++ b/tests/commands_write_to_tests.py
@@ -22,12 +22,12 @@ class CommandsWriteToTests(TestCase):
 
     def add_layers(self):
         """Add an assortment of layers to the index"""
-        entry.Layer('12', '1000', 'v2', 'layer1').write({'1': 1})
-        entry.Layer('12', '1000', 'v2', 'layer2').write({'2': 2})
-        entry.Layer('12', '1000', 'v3', 'layer2').write({'2': 2})
-        entry.Layer('12', '1000', 'v3', 'layer3').write({'3': 3})
-        entry.Layer('11', '1000', 'v4', 'layer4').write({'4': 4})
-        entry.Layer('12', '1001', 'v3', 'layer3').write({'3': 3})
+        entry.Layer.cfr('12', '1000', 'v2', 'layer1').write({'1': 1})
+        entry.Layer.cfr('12', '1000', 'v2', 'layer2').write({'2': 2})
+        entry.Layer.cfr('12', '1000', 'v3', 'layer2').write({'2': 2})
+        entry.Layer.cfr('12', '1000', 'v3', 'layer3').write({'3': 3})
+        entry.Layer.cfr('11', '1000', 'v4', 'layer4').write({'4': 4})
+        entry.Layer.cfr('12', '1001', 'v3', 'layer3').write({'3': 3})
 
     def add_diffs(self):
         """Adds an uneven assortment of diffs between trees"""


### PR DESCRIPTION
Builds on #221 [diff](https://github.com/cmc333333/regulations-parser/compare/17-rework-layers...18-preamble-layers)

The high level ideas here:
* have a separate configuration namespace for preamble layers
* process preamble layers when running `layers` (by making the CFR title/part optional)
* look for those layers when writing (`write_to`). Preamble layers are written with the id "preamble:doc_num"

The individual changesets here are probably too confusing to review -- I went back and forth a few times. It may be easiest just to review the final diff.

Resolves eregs/notice-and-comment#18