### PR TITLE
Add simple internal citations layer for preambles

### DIFF
--- a/regparser/layer/preamble/internal_citations.py
+++ b/regparser/layer/preamble/internal_citations.py
@@ -1,0 +1,51 @@
+import logging
+import string
+
+from pyparsing import Optional, Suppress, Word
+
+from regparser.grammar.utils import QuickSearchable
+from regparser.layer.layer import Layer
+
+logger = logging.getLogger(__name__)
+
+
+level1 = Word("IVXLCDM").leaveWhitespace().setResultsName("l1")
+level2 = Word(string.uppercase).leaveWhitespace().setResultsName("l2")
+level3 = Word(string.digits).leaveWhitespace().setResultsName("l3")
+level4 = Word(string.lowercase).leaveWhitespace().setResultsName("l4")
+level5 = Word("ivxlcdm").leaveWhitespace().setResultsName("l5")
+level6 = Word(string.lowercase).leaveWhitespace().setResultsName("l6")
+period = Suppress(".").leaveWhitespace()
+
+# e.g. I.B, I.B.3, I.B.3.d, I.B.3.d.v, I.B.3.d.v.f
+citation = level1 + period + level2 + Optional(period + level3 + Optional(
+    period + level4 + Optional(period + level5 + Optional(period + level6))))
+citation = QuickSearchable(citation)
+
+
+class InternalCitations(Layer):
+    shorthand = 'internal-citations'
+
+    def __init__(self, tree, **context):
+        super(InternalCitations, self).__init__(tree, **context)
+        self.known_citations = set()
+
+    def pre_process(self):
+        """As a preprocessing step, run through the entire tree, collecting
+        all labels"""
+        labels = self.tree.walk(lambda node: tuple(node.label))
+        self.known_citations = set(labels)
+
+    def process(self, node):
+        """Find citations to elements within this preamble"""
+        results = []
+        for match, start, end in citation.scanString(node.text):
+            label = tuple(self.tree.label[:1] + list(match))
+            if label in self.known_citations:
+                results.append({'offsets': [(start, end)],
+                                'citation': label})
+            else:
+                logger.warning("Missing citation? %s %r",
+                               node.text[start:end], label)
+                logger.debug("Context: %s", node.text)
+        return results or None      # "None" for consistency with other layers

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -75,6 +75,10 @@ class Node(object):
         part of the appendix"""
         return len(self.label) == 2 and self.label[1][:1].isdigit()
 
+    def walk(self, fn):
+        """See walk(node, fn)"""
+        return walk(self, fn)
+
 
 class NodeEncoder(JSONEncoder):
     """Custom JSON encoder to handle Node objects"""

--- a/settings.py
+++ b/settings.py
@@ -144,7 +144,9 @@ LAYERS = {
         'regparser.layer.interpretations.Interpretations',
         # SectionBySection layer is a created via a separate command
     ],
-    'preamble': [],
+    'preamble': [
+        'regparser.layer.preamble.internal_citations.InternalCitations'
+    ],
     # It probably makes more sense to use plugins.update_dictionary, but we're
     # keeping this for backwards compatibility
     'ALL': plugins.extend_list('eregs_ns.parser.layers', [

--- a/tests/layer_preamble_internal_citations_tests.py
+++ b/tests/layer_preamble_internal_citations_tests.py
@@ -1,0 +1,30 @@
+from unittest import TestCase
+
+from regparser.layer.preamble.internal_citations import InternalCitations
+from regparser.tree.struct import Node
+
+
+class InternalCitationsTests(TestCase):
+    def setUp(self):
+        self.ic = InternalCitations(Node(label=['111_22']))
+        cits = ['111_22', '111_22-I', '111_22-I-A', '111_22-I-A-1',
+                '111_22-I-A-1-a', '111_22-I-A-1-a-i', '111_22-I-A-1-a-i-a']
+        self.ic.known_citations = {tuple(cit.split('-')) for cit in cits}
+
+    def test_process_success(self):
+        """We should find text with citations"""
+        text = ("XXX section I.A, XXX I.A.1 XXX I.A.1.a XXX I.A.1.a.i XXX "
+                "I.A.1.a.i.a")
+        results = self.ic.process(Node(text))
+        results = [(r['citation'], text[r['offsets'][0][0]:r['offsets'][0][1]])
+                   for r in results]
+        for cit, text in results:
+            self.assertEqual(cit[0], '111_22')
+            self.assertEqual(cit[1:], tuple(text.split('.')))
+        results = [t for _, t in results]
+        self.assertItemsEqual(results, [
+            'I.A', 'I.A.1', 'I.A.1.a', 'I.A.1.a.i', 'I.A.1.a.i.a'])
+
+    def test_process_unknown(self):
+        """We should not find a citation if it doesn't exist in the tree"""
+        self.assertIsNone(self.ic.process(Node("XXX section I.B")))


### PR DESCRIPTION
Super simple implementation which matches text like "III.F.4" if that node is
present in the preamble.

Resolves eregs/notice-and-comment#45

Looks like
<img width="539" alt="screen shot 2016-03-23 at 11 50 05 am" src="https://cloud.githubusercontent.com/assets/326918/13991199/96b1381e-f0ed-11e5-864a-1b4bcd27e32f.png">
