### PR TITLE
Add fallback for graphics layer

### DIFF
--- a/regparser/layer/graphics.py
+++ b/regparser/layer/graphics.py
@@ -8,19 +8,25 @@ from regparser.layer.layer import Layer
 import settings
 
 
+def check_url(url):
+    """Verify that content exists at a given URL"""
+    response = requests.head(url)
+
+    if response.status_code == requests.codes.not_implemented:
+        response = requests.get(url)
+
+    if response.status_code == requests.codes.ok:
+        return url
+
+
 class Graphics(Layer):
     gid = re.compile(ur'!\[([\w\s]*)\]\(([a-zA-Z0-9.\-]+?)\)')
+    ext = re.compile(r'\.(png|gif|jpg)$')
     shorthand = 'graphics'
 
     def check_for_thumb(self, url):
-        thumb_url = re.sub(r'(.(png|gif|jpg))$', '.thumb' + '\\1', url)
-        response = requests.head(thumb_url)
-
-        if response.status_code == requests.codes.not_implemented:
-            response = requests.get(thumb_url)
-
-        if response.status_code == requests.codes.ok:
-            return thumb_url
+        thumb_url = self.ext.sub(r'.thumb\g<0>', url)
+        return check_url(thumb_url)
 
     def process(self, node):
         """If this node has a marker for an image in it, note where to get

--- a/regparser/layer/graphics.py
+++ b/regparser/layer/graphics.py
@@ -24,22 +24,24 @@ def check_url(url):
 
 
 def gid_to_url(gid):
-    """Take a few guesses as to where this image may be"""
+    """Take a few guesses as to where this image may be. This will be
+    simplified once FR.gov adds image data to their API"""
     override = content.ImageOverrides().get(gid)
     if override and check_url(override):
         return override
     elif override:
         logger.warning("Overridden image 404s: %s->%s", gid, override)
 
-    upper_url = settings.DEFAULT_IMAGE_URL % gid
-    if check_url(upper_url):
-        return upper_url
+    default = settings.DEFAULT_IMAGE_URL
+    png = settings.DEFAULT_IMAGE_URL.replace('.gif', '.png')
+    urls = [default % gid, default % gid.lower(), png % gid.lower()]
+    for url in urls:
+        if check_url(url):
+            return url
 
-    lower_url = settings.DEFAULT_IMAGE_URL % gid.lower()
-    if not check_url(lower_url):
-        logger.warning("No image could be found for %s. Tried:\n%s\n%s",
-                       gid, upper_url, lower_url)
-    return lower_url
+    logger.warning("No image could be found for %s. Tried:\n%s",
+                   gid, "\n".join(urls))
+    return url  # last option
 
 
 class Graphics(Layer):

--- a/regparser/layer/graphics.py
+++ b/regparser/layer/graphics.py
@@ -20,7 +20,7 @@ def check_url(url):
 
 
 class Graphics(Layer):
-    gid = re.compile(ur'!\[([\w\s]*)\]\(([a-zA-Z0-9.\-]+?)\)')
+    gid = re.compile(ur'!\[(?P<alt>[\w\s]*)\]\((?P<gid>[a-zA-Z0-9.\-]+?)\)')
     ext = re.compile(r'\.(png|gif|jpg)$')
     shorthand = 'graphics'
 
@@ -43,7 +43,7 @@ class Graphics(Layer):
             layer_el_vals = {
                 'text': match.group(0),
                 'url': url,
-                'alt': match.group(1),
+                'alt': match.group('alt'),
                 'locations': list(range(len(matches_by_text[text])))
             }
             thumb_url = self.check_for_thumb(url)

--- a/tests/http_mixin.py
+++ b/tests/http_mixin.py
@@ -21,7 +21,7 @@ class HttpMixin(object):
             json_dict = {"key": "value"}
         kwargs['body'] = json.dumps(json_dict)
         kwargs['content_type'] = 'text/json'
-        self._expect_http(**kwargs)
+        self.expect_http(**kwargs)
 
     def expect_xml_http(self, xml_str=None, **kwargs):
         """Wraps httpretty.register_uri with some defaults for XML"""
@@ -29,10 +29,13 @@ class HttpMixin(object):
             xml_str = '<ROOT></ROOT>'
         kwargs['body'] = xml_str
         kwargs['content_type'] = 'text/xml'
-        self._expect_http(**kwargs)
+        self.expect_http(**kwargs)
 
-    def _expect_http(self, **kwargs):
+    def expect_http(self, **kwargs):
         """Wraps httpretty.register_uri with some defaults"""
+        kwargs['body'] = kwargs.get('body', b'')
+        kwargs['content_type'] = kwargs.get('content_type',
+                                            'application/octet-stream')
         kwargs['method'] = kwargs.get('method', httpretty.GET)
         # Default to catching all requests
         kwargs['uri'] = kwargs.get('uri', re.compile(".*"))

--- a/tests/layer_graphics_tests.py
+++ b/tests/layer_graphics_tests.py
@@ -12,7 +12,7 @@ class LayerGraphicsTest(HttpMixin, TestCase):
     def setUp(self):
         super(LayerGraphicsTest, self).setUp()
         self.default_url = settings.DEFAULT_IMAGE_URL
-        settings.DEFAULT_IMAGE_URL = 'http://example.com/%s.jpg'
+        settings.DEFAULT_IMAGE_URL = 'http://example.com/%s.gif'
 
     def tearDown(self):
         super(LayerGraphicsTest, self).tearDown()
@@ -24,10 +24,10 @@ class LayerGraphicsTest(HttpMixin, TestCase):
                     "and ![](NOTEXT)")
         g = Graphics(None)
         for gid in ('ABCD', 'XXX', 'NOTEXT'):
-            self.expect_http(uri='http://example.com/{}.jpg'.format(gid),
+            self.expect_http(uri='http://example.com/{}.gif'.format(gid),
                              method='HEAD')
             self.expect_http(
-                uri='http://example.com/{}.thumb.jpg'.format(gid),
+                uri='http://example.com/{}.thumb.gif'.format(gid),
                 method='HEAD')
 
         result = g.process(node)
@@ -55,25 +55,25 @@ class LayerGraphicsTest(HttpMixin, TestCase):
     def test_process_format(self):
         node = Node("![A88 Something](ER22MY13.257-1)")
         g = Graphics(None)
-        self.expect_http(uri='http://example.com/ER22MY13.257-1.jpg',
+        self.expect_http(uri='http://example.com/ER22MY13.257-1.gif',
                          method='HEAD')
-        self.expect_http(uri='http://example.com/ER22MY13.257-1.thumb.jpg',
+        self.expect_http(uri='http://example.com/ER22MY13.257-1.thumb.gif',
                          method='HEAD')
 
         self.assertEqual(1, len(g.process(node)))
 
     @patch('regparser.layer.graphics.content')
     def test_process_custom_url(self, content):
-        img_url = 'http://example.com/img1.jpg'
-        imga_url = 'http://example2.com/AAA.jpg'
-        imgf_url = 'http://example2.com/F8.jpg'
+        img_url = 'http://example.com/img1.gif'
+        imga_url = 'http://example2.com/AAA.gif'
+        imgf_url = 'http://example2.com/F8.gif'
         content.ImageOverrides.return_value = {'a': imga_url, 'f': imgf_url}
 
         node = Node("![Alt1](img1)   ![Alt2](f)  ![Alt3](a)")
         g = Graphics(None)
         for url in (img_url, imga_url, imgf_url):
             self.expect_http(uri=url, method='HEAD')
-            self.expect_http(uri=url[:-3] + 'thumb.jpg', method='HEAD')
+            self.expect_http(uri=url[:-3] + 'thumb.gif', method='HEAD')
 
         results = g.process(node)
         self.assertEqual(3, len(results))
@@ -87,7 +87,7 @@ class LayerGraphicsTest(HttpMixin, TestCase):
         node = Node("![alt1](img1)")
         g = Graphics(None)
         thumb_url = settings.DEFAULT_IMAGE_URL % 'img1.thumb'
-        self.expect_http(uri='http://example.com/img1.jpg', method='HEAD')
+        self.expect_http(uri='http://example.com/img1.gif', method='HEAD')
 
         self.expect_http(uri=thumb_url, method='HEAD')
         self.expect_http(uri=thumb_url, status=404)
@@ -104,9 +104,11 @@ class LayerGraphicsTest(HttpMixin, TestCase):
 
     def test_gid_to_url(self):
         """Verify that we fall back to lowercase"""
-        self.expect_http(uri='http://example.com/ABCD123.jpg', method='HEAD',
+        self.expect_http(uri='http://example.com/ABCD123.gif', method='HEAD',
                          status=403)
-        self.expect_http(uri='http://example.com/abcd123.jpg', method='HEAD')
+        self.expect_http(uri='http://example.com/abcd123.gif', method='HEAD',
+                         status=403)
+        self.expect_http(uri='http://example.com/abcd123.png', method='HEAD')
 
         self.assertEqual(gid_to_url('ABCD123'),
-                         'http://example.com/abcd123.jpg')
+                         'http://example.com/abcd123.png')

--- a/tests/layer_graphics_tests.py
+++ b/tests/layer_graphics_tests.py
@@ -1,18 +1,21 @@
 from unittest import TestCase
 
-from mock import patch, Mock
+from mock import patch
 
-from regparser.layer.graphics import Graphics
+from regparser.layer.graphics import gid_to_url, Graphics
 from regparser.tree.struct import Node
 import settings
+from tests.http_mixin import HttpMixin
 
 
-class LayerGraphicsTest(TestCase):
-
+class LayerGraphicsTest(HttpMixin, TestCase):
     def setUp(self):
+        super(LayerGraphicsTest, self).setUp()
         self.default_url = settings.DEFAULT_IMAGE_URL
+        settings.DEFAULT_IMAGE_URL = 'http://example.com/%s.jpg'
 
     def tearDown(self):
+        super(LayerGraphicsTest, self).tearDown()
         settings.DEFAULT_IMAGE_URL = self.default_url
 
     def test_process(self):
@@ -20,8 +23,14 @@ class LayerGraphicsTest(TestCase):
                     "some more ![222](XXX) followed by ![ex](ABCD) and XXX " +
                     "and ![](NOTEXT)")
         g = Graphics(None)
-        with patch('regparser.layer.graphics.requests'):
-            result = g.process(node)
+        for gid in ('ABCD', 'XXX', 'NOTEXT'):
+            self.expect_http(uri='http://example.com/{}.jpg'.format(gid),
+                             method='HEAD')
+            self.expect_http(
+                uri='http://example.com/{}.thumb.jpg'.format(gid),
+                method='HEAD')
+
+        result = g.process(node)
         self.assertEqual(3, len(result))
         found = [False, False, False]
         for res in result:
@@ -46,53 +55,49 @@ class LayerGraphicsTest(TestCase):
     def test_process_format(self):
         node = Node("![A88 Something](ER22MY13.257-1)")
         g = Graphics(None)
-        with patch('regparser.layer.graphics.requests'):
-            self.assertEqual(1, len(g.process(node)))
+        self.expect_http(uri='http://example.com/ER22MY13.257-1.jpg',
+                         method='HEAD')
+        self.expect_http(uri='http://example.com/ER22MY13.257-1.thumb.jpg',
+                         method='HEAD')
+
+        self.assertEqual(1, len(g.process(node)))
 
     @patch('regparser.layer.graphics.content')
     def test_process_custom_url(self, content):
-        settings.DEFAULT_IMAGE_URL = ":::::%s:::::"
-        content.ImageOverrides.return_value = {"a": "AAA", "f": "F8"}
+        img_url = 'http://example.com/img1.jpg'
+        imga_url = 'http://example2.com/AAA.jpg'
+        imgf_url = 'http://example2.com/F8.jpg'
+        content.ImageOverrides.return_value = {'a': imga_url, 'f': imgf_url}
 
         node = Node("![Alt1](img1)   ![Alt2](f)  ![Alt3](a)")
         g = Graphics(None)
-        with patch('regparser.layer.graphics.requests'):
-            results = g.process(node)
+        for url in (img_url, imga_url, imgf_url):
+            self.expect_http(uri=url, method='HEAD')
+            self.expect_http(uri=url[:-3] + 'thumb.jpg', method='HEAD')
+
+        results = g.process(node)
         self.assertEqual(3, len(results))
-        found = [False, False, False]
-        for result in results:
-            if result['alt'] == 'Alt1' and result['url'] == ':::::img1:::::':
-                found[0] = True
-            elif result['alt'] == 'Alt2' and result['url'] == 'F8':
-                found[1] = True
-            elif result['alt'] == 'Alt3' and result['url'] == 'AAA':
-                found[2] = True
-        self.assertEqual([True, True, True], found)
+        results = set((r['alt'], r['url']) for r in results)
+        self.assertIn(('Alt1', img_url), results)
+        self.assertIn(('Alt2', imgf_url), results)
+        self.assertIn(('Alt3', imga_url), results)
 
-    def test_find_thumb1(self):
+    def test_find_thumb(self):
+        """When trying to find a thumbnail, first try HEAD, then GET"""
         node = Node("![alt1](img1)")
-        settings.DEFAULT_IMAGE_URL = "%s.png"
         g = Graphics(None)
-        with patch('regparser.layer.graphics.requests') as requests:
-            response = Mock()
-            requests.head.return_value = response
-            requests.codes.not_implemented = 501
-            requests.codes.ok = 200
-            response.status_code = 200
-            results = g.process(node)
+        thumb_url = settings.DEFAULT_IMAGE_URL % 'img1.thumb'
+        self.expect_http(uri='http://example.com/img1.jpg', method='HEAD')
 
-        for result in results:
-            self.assertEqual(result['thumb_url'], 'img1.thumb.png')
+        self.expect_http(uri=thumb_url, method='HEAD')
+        self.expect_http(uri=thumb_url, status=404)
+        # doesn't hit GET
+        self.assertEqual(g.process(node)[0].get('thumb_url'), thumb_url)
 
-    def test_find_thumb2(self):
-        node = Node("![alt2](img2)")
-        settings.DEFAULT_IMAGE_URL = "%s.png"
-        g = Graphics(None)
-        with patch('regparser.layer.graphics.requests') as requests:
-            response = Mock()
-            requests.head.return_value = response
-            response.status_code = 404
-            results = g.process(node)
+        self.expect_http(uri=thumb_url, method='HEAD', status=501)
+        self.expect_http(uri=thumb_url)
+        self.assertEqual(g.process(node)[0].get('thumb_url'), thumb_url)
 
-        for result in results:
-            self.assertTrue('thumb_url' not in result)
+        self.expect_http(uri=thumb_url, method='HEAD', status=501)
+        self.expect_http(uri=thumb_url, status=404)
+        self.assertNotIn('thumb_url', g.process(node)[0])

--- a/tests/layer_graphics_tests.py
+++ b/tests/layer_graphics_tests.py
@@ -101,3 +101,12 @@ class LayerGraphicsTest(HttpMixin, TestCase):
         self.expect_http(uri=thumb_url, method='HEAD', status=501)
         self.expect_http(uri=thumb_url, status=404)
         self.assertNotIn('thumb_url', g.process(node)[0])
+
+    def test_gid_to_url(self):
+        """Verify that we fall back to lowercase"""
+        self.expect_http(uri='http://example.com/ABCD123.jpg', method='HEAD',
+                         status=403)
+        self.expect_http(uri='http://example.com/abcd123.jpg', method='HEAD')
+
+        self.assertEqual(gid_to_url('ABCD123'),
+                         'http://example.com/abcd123.jpg')


### PR DESCRIPTION
The FR accidentally changed their format for images a few months ago. While they go back and clean this up, we should accommodate their new system. They promised to add the mappings to their JSON output at some point in the future (so we won't need to guess at URLs).

Also performs some cleanup.

Resolves eregs/notice-and-comment#50