### PR TITLE
Remove datatree

### DIFF
--- a/regparser/test_utils/xml_builder.py
+++ b/regparser/test_utils/xml_builder.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from functools import partial
 
 from lxml import etree
@@ -38,6 +39,11 @@ class XMLBuilder(object):
         self.cursor.append(el)
         return self
 
+    def child_from_string(self, xml_str):
+        """It can be easier to describe a child via straight XML"""
+        self.cursor.append(etree.fromstring(xml_str))
+        return self
+
     def __getattr__(self, name):
         """Handle unknown attributes by calling `self.child`"""
         return partial(self.child, name)
@@ -59,3 +65,6 @@ class XMLBuilder(object):
     @property
     def xml_str(self):
         return etree.tostring(self.xml)
+
+    def xml_copy(self):
+        return deepcopy(self.xml)

--- a/regparser/test_utils/xml_builder.py
+++ b/regparser/test_utils/xml_builder.py
@@ -1,0 +1,61 @@
+from functools import partial
+
+from lxml import etree
+
+
+class XMLBuilder(object):
+    """A small DSL for generating XML. For example,
+        with XMLBuilder("ROOT") as ctx:
+            ctx.P("Some Text")
+            with ctx.SECT(level=4):
+                ctx.P("More")
+
+        ctx.xml_str:
+        <ROOT>
+            <P>Some Text</P>
+            <SECT level="4">
+                <P>More</P>
+            </SECT>
+        </ROOT>"""
+    def __init__(self, *args, **kwargs):
+        self.cursor = etree.Element('ROOT')
+        self.child(*args, **kwargs)
+
+    def child(self, tag, _text=None, **kwargs):
+        """Add a child to our xml."""
+        # For backwards compatibility. To be removed soon
+        if '_xml' in kwargs:
+            attrs = ['{}="{}"'.format(key, value)
+                     for key, value in kwargs.items() if key != '_xml']
+            attr_str = ' '.join(attrs)
+            el = etree.fromstring(u'<{0} {1}>{2}</{0}>'.format(
+                tag, attr_str, kwargs['_xml']))
+        else:
+            el = etree.Element(tag)
+            for key, value in sorted(kwargs.items()):
+                el.set(key, str(value))
+            el.text = _text or ''
+        self.cursor.append(el)
+        return self
+
+    def __getattr__(self, name):
+        """Handle unknown attributes by calling `self.child`"""
+        return partial(self.child, name)
+
+    def __enter__(self):
+        """Focus on the most recently added child"""
+        self.cursor = self.cursor[-1]
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Remove focus"""
+        self.cursor = self.cursor.getparent()
+        return False
+
+    @property
+    def xml(self):
+        return self.cursor[-1]
+
+    @property
+    def xml_str(self):
+        return etree.tostring(self.xml)

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,5 @@
 cov-core==1.15.0
 coverage==4.0.3
-datatree==0.1.8.1
 pep8==1.7.0
 flake8==2.5.1
 httpretty==0.8.12

--- a/tests/commands_fetch_sxs_tests.py
+++ b/tests/commands_fetch_sxs_tests.py
@@ -10,17 +10,17 @@ from mock import patch
 from regparser.commands.fetch_sxs import fetch_sxs
 from regparser.index import dependency, entry
 from regparser.notice.xml import NoticeXML
-from tests.xml_builder import XMLBuilderMixin
+from regparser.test_utils.xml_builder import XMLBuilder
 
 
-class CommandsFetchSxSTests(XMLBuilderMixin, TestCase):
+class CommandsFetchSxSTests(TestCase):
     def setUp(self):
         super(CommandsFetchSxSTests, self).setUp()
         self.cli = CliRunner()
-        with self.tree.builder("ROOT") as root:
-            root.PRTPAGE(P="1234")
-            root.CFR('12 CFR 1000')
-        self.notice_xml = NoticeXML(self.tree.render_xml())
+        with XMLBuilder("ROOT") as ctx:
+            ctx.PRTPAGE(P="1234")
+            ctx.CFR('12 CFR 1000')
+        self.notice_xml = NoticeXML(ctx.xml)
 
     def test_missing_notice(self):
         """If the necessary notice XML is not present, we should expect a

--- a/tests/commands_parse_rule_changes_tests.py
+++ b/tests/commands_parse_rule_changes_tests.py
@@ -7,16 +7,16 @@ from mock import patch
 from regparser.commands.parse_rule_changes import parse_rule_changes
 from regparser.index import dependency, entry
 from regparser.notice.xml import NoticeXML
-from tests.xml_builder import XMLBuilderMixin
+from regparser.test_utils.xml_builder import XMLBuilder
 
 
-class CommandsParseRuleChangesTests(XMLBuilderMixin, TestCase):
+class CommandsParseRuleChangesTests(TestCase):
     def setUp(self):
         super(CommandsParseRuleChangesTests, self).setUp()
         self.cli = CliRunner()
-        with self.tree.builder("ROOT") as root:
-            root.PRTPAGE(P="1234")
-        self.notice_xml = NoticeXML(self.tree.render_xml())
+        with XMLBuilder("ROOT") as ctx:
+            ctx.PRTPAGE(P="1234")
+        self.notice_xml = NoticeXML(ctx.xml)
 
     def test_missing_notice(self):
         """If the necessary notice XML is not present, we should expect a

--- a/tests/commands_preprocess_notice_tests.py
+++ b/tests/commands_preprocess_notice_tests.py
@@ -7,20 +7,19 @@ from mock import patch
 from regparser.commands.preprocess_notice import preprocess_notice
 from regparser.index import dependency, entry
 from regparser.notice.xml import NoticeXML
+from regparser.test_utils.xml_builder import XMLBuilder
 from tests.http_mixin import HttpMixin
-from tests.xml_builder import LXMLBuilder, XMLBuilderMixin
 
 
-class CommandsPreprocessNoticeTests(HttpMixin, XMLBuilderMixin, TestCase):
+class CommandsPreprocessNoticeTests(HttpMixin, TestCase):
     def example_xml(self, effdate_str="", source=None):
         """Returns a simple notice-like XML structure"""
-        self.tree = LXMLBuilder()
-        with self.tree.builder("ROOT") as root:
-            root.CONTENT()
-            root.P()
-            with root.EFFDATE() as effdate:
-                effdate.P(effdate_str)
-        return NoticeXML(self.tree.render_xml(), source)
+        with XMLBuilder("ROOT") as ctx:
+            ctx.CONTENT()
+            ctx.P()
+            with ctx.EFFDATE():
+                ctx.P(effdate_str)
+        return NoticeXML(ctx.xml, source)
 
     def expect_common_json(self, **kwargs):
         """Expect an HTTP call and return a common json respond"""

--- a/tests/notice_dates_tests.py
+++ b/tests/notice_dates_tests.py
@@ -2,10 +2,10 @@
 from unittest import TestCase
 
 from regparser.notice import dates
-from tests.xml_builder import XMLBuilderMixin
+from regparser.test_utils.xml_builder import XMLBuilder
 
 
-class NoticeDatesTests(XMLBuilderMixin, TestCase):
+class NoticeDatesTests(TestCase):
     def test_parse_date_sentence(self):
         self.assertEqual(('comments', '2009-01-08'),
                          dates.parse_date_sentence(
@@ -26,46 +26,46 @@ class NoticeDatesTests(XMLBuilderMixin, TestCase):
                                                    'make sense'))
 
     def test_fetch_dates_no_xml_el(self):
-        with self.tree.builder("ROOT") as root:
-            root.CHILD()
-            root.PREAMB()
-        self.assertEqual(None, dates.fetch_dates(self.tree.render_xml()))
+        with XMLBuilder("ROOT") as ctx:
+            ctx.CHILD()
+            ctx.PREAMB()
+        self.assertEqual(None, dates.fetch_dates(ctx.xml))
 
     def test_fetch_dates_no_date_text(self):
-        with self.tree.builder("ROOT") as root:
-            root.CHILD()
-            with root.PREAMB() as preamb:
-                with preamb.EFFDATE() as effdate:
-                    effdate.HD("DATES: ")
-                    effdate.P("There are no dates for this.")
-        self.assertEqual(None, dates.fetch_dates(self.tree.render_xml()))
+        with XMLBuilder("ROOT") as ctx:
+            ctx.CHILD()
+            with ctx.PREAMB():
+                with ctx.EFFDATE():
+                    ctx.HD("DATES: ")
+                    ctx.P("There are no dates for this.")
+        self.assertEqual(None, dates.fetch_dates(ctx.xml))
 
     def test_fetch_dates_emphasis(self):
-        with self.tree.builder("ROOT") as root:
-            with root.DATES() as dates_xml:
-                dates_xml.HD("DATES:", SOURCE="HED")
-                dates_xml.P(_xml=("<E T='03'>Effective date:</E>"
-                                  "The rule is effective June 1, 2077"))
-                dates_xml.P(_xml=(
-                    "<E T='03'>Applicability date:</E>"
-                    "Its requirements apply to things after that date."))
-        self.assertEqual(dates.fetch_dates(self.tree.render_xml()),
+        with XMLBuilder("ROOT") as ctx:
+            with ctx.DATES():
+                ctx.HD("DATES:", SOURCE="HED")
+                ctx.child_from_string(
+                    "<P><E T='03'>Effective date:</E>The rule is effective "
+                    "June 1, 2077</P>")
+                ctx.child_from_string(
+                    "<P><E T='03'>Applicability date:</E>Its requirements "
+                    "apply to things after that date.</P>")
+        self.assertEqual(dates.fetch_dates(ctx.xml),
                          {'effective': ['2077-06-01']})
 
     def test_fetch_dates(self):
-        with self.tree.builder("ROOT") as root:
-            root.CHILD()
-            with root.PREAMB() as preamb:
-                with preamb.EFFDATE() as effdate:
-                    effdate.HD("DATES: ")
-                    effdate.P("We said stuff that's effective on May 9, "
-                              "2005. If you'd like to add comments, please "
-                              "do so by June 3, 1987.  Wait, that doesn't "
-                              "make sense. I mean, the comment period ends "
-                              "on July 9, 2004. Whew. It would have been "
-                              "more confusing if I said August 15, 2005. "
-                              "Right?")
-        self.assertEqual(dates.fetch_dates(self.tree.render_xml()), {
+        with XMLBuilder("ROOT") as ctx:
+            ctx.CHILD()
+            with ctx.PREAMB():
+                with ctx.EFFDATE():
+                    ctx.HD("DATES: ")
+                    ctx.P("We said stuff that's effective on May 9, 2005. "
+                          "If you'd like to add comments, please do so by "
+                          "June 3, 1987. Wait, that doesn't make sense. "
+                          "I mean, the comment period ends on July 9, 2004. "
+                          "Whew. It would have been more confusing if I said "
+                          "August 15, 2005. Right?")
+        self.assertEqual(dates.fetch_dates(ctx.xml), {
             'effective': ['2005-05-09'],
             'comments': ['1987-06-03', '2004-07-09'],
             'other': ['2005-08-15']

--- a/tests/notice_preamble_tests.py
+++ b/tests/notice_preamble_tests.py
@@ -2,35 +2,35 @@ from unittest import TestCase
 
 from regparser.notice import preamble
 from regparser.notice.xml import NoticeXML
+from regparser.test_utils.xml_builder import XMLBuilder
 from tests.node_accessor import NodeAccessorMixin
-from tests.xml_builder import XMLBuilderMixin
 
 
-class NoticePreambleTests(XMLBuilderMixin, NodeAccessorMixin, TestCase):
+class NoticePreambleTests(NodeAccessorMixin, TestCase):
     def test_parse_preamble_integration(self):
         """End-to-end test for parsing a notice preamble"""
-        with self.tree.builder('ROOT') as root:
-            root.P("ignored content")
-            with root.SUPLINF() as suplinf:
-                suplinf.HED("Supp Inf")
-                suplinf.P("P1")
-                suplinf.P("P2")
-                suplinf.HD("I. H1", SOURCE="HD1")
-                suplinf.P("H1-P1")
-                suplinf.HD("A. H1-1", SOURCE="HD2")
-                suplinf.P("H1-1-P1")
-                suplinf.P("H1-1-P2")
-                suplinf.HD("B. H1-2", SOURCE="HD2")
-                suplinf.P("H1-2-P1")
-                suplinf.HD("II. H2", SOURCE="HD1")
-                suplinf.P("H2-P1")
-                suplinf.P("H2-P2")
-                with suplinf.GPH() as gph:
-                    gph.GID("111-222-333")
-                suplinf.LSTSUB()
-                suplinf.P("ignored")
-            root.P("tail also ignored")
-        xml = NoticeXML(self.tree.render_xml())
+        with XMLBuilder("ROOT") as ctx:
+            ctx.P("ignored content")
+            with ctx.SUPLINF():
+                ctx.HED("Supp Inf")
+                ctx.P("P1")
+                ctx.P("P2")
+                ctx.HD("I. H1", SOURCE="HD1")
+                ctx.P("H1-P1")
+                ctx.HD("A. H1-1", SOURCE="HD2")
+                ctx.P("H1-1-P1")
+                ctx.P("H1-1-P2")
+                ctx.HD("B. H1-2", SOURCE="HD2")
+                ctx.P("H1-2-P1")
+                ctx.HD("II. H2", SOURCE="HD1")
+                ctx.P("H2-P1")
+                ctx.P("H2-P2")
+                with ctx.GPH():
+                    ctx.GID("111-222-333")
+                ctx.LSTSUB()
+                ctx.P("ignored")
+            ctx.P("tail also ignored")
+        xml = NoticeXML(ctx.xml)
         xml.version_id = 'vvv-yyy'
         root = self.node_accessor(preamble.parse_preamble(xml), ['vvv_yyy'])
 

--- a/tests/tree_xml_parser_note_processor_tests.py
+++ b/tests/tree_xml_parser_note_processor_tests.py
@@ -2,29 +2,28 @@ from unittest import TestCase
 
 from mock import patch
 
+from regparser.test_utils.xml_builder import XMLBuilder
 from regparser.tree.depth import markers as mtypes
 from regparser.tree.xml_parser import note_processor
 from tests.node_accessor import NodeAccessorMixin
-from tests.xml_builder import XMLBuilderMixin
 
 
-class NoteProcessingTests(XMLBuilderMixin, NodeAccessorMixin, TestCase):
+class NoteProcessingTests(NodeAccessorMixin, TestCase):
     def test_integration(self):
         """Verify that a NOTE tag is converted into an appropriate tree. We
         also expect no warnings to be emitted"""
-        with self.tree.builder("NOTES") as notes:
-            notes.HD("Notes:")
-            notes.P("1. 111")
-            notes.P("a. 1a1a1a")
-            notes.P("b. 1b1b1b")
-            notes.P("2. 222")
+        with XMLBuilder("NOTES") as ctx:
+            ctx.HD("Notes:")
+            ctx.P("1. 111")
+            ctx.P("a. 1a1a1a")
+            ctx.P("b. 1b1b1b")
+            ctx.P("2. 222")
 
-        xml = self.tree.render_xml()
         matcher = note_processor.NoteMatcher()
-        self.assertTrue(matcher.matches(xml))
+        self.assertTrue(matcher.matches(ctx.xml))
         to_patch = 'regparser.tree.xml_parser.paragraph_processor.logger'
         with patch(to_patch) as logger:
-            results = matcher.derive_nodes(xml)
+            results = matcher.derive_nodes(ctx.xml)
         self.assertFalse(logger.warning.called)
 
         self.assertEqual(len(results), 1)

--- a/tests/tree_xml_parser_preprocessors_tests.py
+++ b/tests/tree_xml_parser_preprocessors_tests.py
@@ -113,7 +113,7 @@ class MoveAdjoiningCharsTests(XMLBuilderMixin, TestCase):
         xml = self.tree.render_xml()
         preprocessors.MoveAdjoiningChars().transform(xml)
         self.assertEqual(etree.tostring(
-                         xml.xpath('/SECTION/P/E')[0], encoding='UTF-8'),
+                         xml.xpath('./P/E')[0], encoding='UTF-8'),
                          expected_xml)
 
     def test_transform(self):

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -5,27 +5,27 @@ from unittest import TestCase
 from lxml import etree
 from mock import patch
 
+from regparser.test_utils.xml_builder import XMLBuilder
 from regparser.tree.depth import markers as mtypes
 from regparser.tree.struct import Node
 from regparser.tree.xml_parser import reg_text
-from tests.xml_builder import XMLBuilderMixin
 from tests.node_accessor import NodeAccessorMixin
 
 
-class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
+class RegTextTest(NodeAccessorMixin, TestCase):
     @contextmanager
     def section(self, part=8675, section=309, subject="Definitions."):
         """Many tests need a SECTION tag followed by the SECTNO and SUBJECT"""
-        with self.tree.builder("SECTION") as root:
-            root.SECTNO(u"§ {}.{}".format(part, section))
-            root.SUBJECT(subject)
-            yield root
+        with XMLBuilder("SECTION") as ctx:
+            ctx.SECTNO(u"§ {}.{}".format(part, section))
+            ctx.SUBJECT(subject)
+            yield ctx
 
     def test_build_from_section_intro_text(self):
-        with self.section() as root:
-            root.P("Some content about this section.")
-            root.P("(a) something something")
-        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+        with self.section() as ctx:
+            ctx.P("Some content about this section.")
+            ctx.P("(a) something something")
+        node = reg_text.build_from_section('8675', ctx.xml)[0]
         node = self.node_accessor(node, ['8675', '309'])
         self.assertEqual('Some content about this section.', node.text.strip())
         self.assertEqual(['a'], node.child_labels)
@@ -34,26 +34,28 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
         self.assertEqual([], node['a'].children)
 
     def test_build_from_section_collapsed_level(self):
-        with self.section() as root:
-            root.P(_xml=u"""(a) <E T="03">Transfers </E>—(1)
-                           <E T="03">Notice.</E> follow""")
-            root.P("(2) More text")
-            root.P(_xml="""(b) <E T="03">Contents</E> (1) Here""")
-            root.P("(2) More text")
-        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+        with self.section() as ctx:
+            ctx.child_from_string(
+                u'<P>(a) <E T="03">Transfers </E>—(1) <E T="03">Notice.</E> '
+                u'follow</P>')
+            ctx.P("(2) More text")
+            ctx.child_from_string(
+                '<P>(b) <E T="03">Contents</E> (1) Here</P>')
+            ctx.P("(2) More text")
+        node = reg_text.build_from_section('8675', ctx.xml)[0]
         node = self.node_accessor(node, ['8675', '309'])
         self.assertEqual(['a', 'b'], node.child_labels)
         self.assertEqual(['1', '2'], node['a'].child_labels)
         self.assertEqual(['1', '2'], node['b'].child_labels)
 
     def test_build_from_section_collapsed_level_emph(self):
-        with self.section() as root:
-            root.P("(a) aaaa")
-            root.P("(1) 1111")
-            root.P("(i) iiii")
-            root.P(_xml=u"""(A) AAA—(<E T="03">1</E>) eeee""")
-            root.STARS()
-        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+        with self.section() as ctx:
+            ctx.P("(a) aaaa")
+            ctx.P("(1) 1111")
+            ctx.P("(i) iiii")
+            ctx.child_from_string(u'<P>(A) AAA—(<E T="03">1</E>) eeee</P>')
+            ctx.STARS()
+        node = reg_text.build_from_section('8675', ctx.xml)[0]
         node = self.node_accessor(node, ['8675', '309'])
         a1iA = node['a']['1']['i']['A']
         self.assertEqual(u"(A) AAA—", a1iA.text)
@@ -61,30 +63,30 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
         self.assertEqual("(1) eeee", a1iA['1'].text.strip())
 
     def test_build_from_section_double_collapsed(self):
-        with self.section() as root:
-            root.P(_xml=u"""(a) <E T="03">Keyterm</E>—(1)(i) Content""")
-            root.P("(ii) Content2")
-        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+        with self.section() as ctx:
+            ctx.child_from_string(
+                u'<P>(a) <E T="03">Keyterm</E>—(1)(i) Content</P>')
+            ctx.P("(ii) Content2")
+        node = reg_text.build_from_section('8675', ctx.xml)[0]
         node = self.node_accessor(node, ['8675', '309'])
         self.assertEqual(['a'], node.child_labels)
         self.assertEqual(['1'], node['a'].child_labels)
         self.assertEqual(['i', 'ii'], node['a']['1'].child_labels)
 
     def test_build_from_section_reserved(self):
-        with self.tree.builder("SECTION") as root:
-            root.SECTNO(u"§ 8675.309")
-            root.RESERVED("[Reserved]")
-        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+        with XMLBuilder("SECTION") as ctx:
+            ctx.SECTNO(u"§ 8675.309")
+            ctx.RESERVED("[Reserved]")
+        node = reg_text.build_from_section('8675', ctx.xml)[0]
         self.assertEqual(node.label, ['8675', '309'])
         self.assertEqual(u'§ 8675.309 [Reserved]', node.title)
         self.assertEqual([], node.children)
 
     def test_build_from_section_reserved_range(self):
-        with self.tree.builder("SECTION") as root:
-            root.SECTNO(u"§§ 8675.309-8675.311")
-            root.RESERVED("[Reserved]")
-        n309, n310, n311 = reg_text.build_from_section(
-            '8675', self.tree.render_xml())
+        with XMLBuilder("SECTION") as ctx:
+            ctx.SECTNO(u"§§ 8675.309-8675.311")
+            ctx.RESERVED("[Reserved]")
+        n309, n310, n311 = reg_text.build_from_section('8675', ctx.xml)
         self.assertEqual(n309.label, ['8675', '309'])
         self.assertEqual(n310.label, ['8675', '310'])
         self.assertEqual(n311.label, ['8675', '311'])
@@ -93,14 +95,14 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
         self.assertEqual(u'§ 8675.311 [Reserved]', n311.title)
 
     def _setup_for_ambiguous(self, final_par):
-        with self.section() as root:
-            root.P("(g) Some Content")
-            root.P("(h) H Starts")
-            root.P("(1) H-1")
-            root.P("(2) H-2")
-            root.P("(i) Is this 8675-309-h-2-i or 8675-309-i")
-            root.P(final_par)
-        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+        with self.section() as ctx:
+            ctx.P("(g) Some Content")
+            ctx.P("(h) H Starts")
+            ctx.P("(1) H-1")
+            ctx.P("(2) H-2")
+            ctx.P("(i) Is this 8675-309-h-2-i or 8675-309-i")
+            ctx.P(final_par)
+        node = reg_text.build_from_section('8675', ctx.xml)[0]
         return self.node_accessor(node, ['8675', '309'])
 
     def test_build_from_section_ambiguous_ii(self):
@@ -127,12 +129,12 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
         self.assertEqual(['i'], n8675_309['h']['2'].child_labels)
 
     def test_build_from_section_collapsed(self):
-        with self.section() as root:
-            root.P("(a) aaa")
-            root.P("(1) 111")
-            root.P(_xml=u"""(2) 222—(i) iii. (A) AAA""")
-            root.P("(B) BBB")
-        n309 = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+        with self.section() as ctx:
+            ctx.P("(a) aaa")
+            ctx.P("(1) 111")
+            ctx.child_from_string(u'<P>(2) 222—(i) iii. (A) AAA</P>')
+            ctx.P("(B) BBB")
+        n309 = reg_text.build_from_section('8675', ctx.xml)[0]
         n309 = self.node_accessor(n309, ['8675', '309'])
         self.assertEqual(['a'], n309.child_labels)
         self.assertEqual(['1', '2'], n309['a'].child_labels)
@@ -140,14 +142,14 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
         self.assertEqual(['A', 'B'], n309['a']['2']['i'].child_labels)
 
     def test_build_from_section_italic_levels(self):
-        with self.section() as root:
-            root.P("(a) aaa")
-            root.P("(1) 111")
-            root.P("(i) iii")
-            root.P("(A) AAA")
-            root.P(_xml="""(<E T="03">1</E>) i1i1i1""")
-            root.P(_xml="""\n(<E T="03">2</E>) i2i2i2""")
-        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+        with self.section() as ctx:
+            ctx.P("(a) aaa")
+            ctx.P("(1) 111")
+            ctx.P("(i) iii")
+            ctx.P("(A) AAA")
+            ctx.child_from_string('<P>(<E T="03">1</E>) i1i1i1</P>')
+            ctx.child_from_string('<P>\n(<E T="03">2</E>) i2i2i2</P>')
+        node = reg_text.build_from_section('8675', ctx.xml)[0]
         node = self.node_accessor(node, ['8675', '309'])
         self.assertEqual(['a'], node.child_labels)
         self.assertEqual(['1'], node['a'].child_labels)
@@ -156,29 +158,30 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
         self.assertEqual(['1', '2'], node['a']['1']['i']['A'].child_labels)
 
     def test_build_from_section_bad_spaces(self):
-        with self.section(section=16) as root:
-            root.STARS()
-            root.P(_xml="""(b)<E T="03">General.</E>Content Content.""")
-        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+        with self.section(section=16) as ctx:
+            ctx.STARS()
+            ctx.child_from_string(
+                '<P>(b)<E T="03">General.</E>Content Content.</P>')
+        node = reg_text.build_from_section('8675', ctx.xml)[0]
         node = self.node_accessor(node, ['8675', '16'])
         self.assertEqual(['b'], node.child_labels)
         self.assertEqual(node['b'].text.strip(),
                          "(b) General. Content Content.")
 
     def test_build_from_section_section_with_nondigits(self):
-        with self.section(section="309a") as root:
-            root.P("Intro content here")
-        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+        with self.section(section="309a") as ctx:
+            ctx.P("Intro content here")
+        node = reg_text.build_from_section('8675', ctx.xml)[0]
         self.assertEqual(node.label, ['8675', '309a'])
         self.assertEqual(0, len(node.children))
 
     def test_build_from_section_fp(self):
-        with self.section() as root:
-            root.P("(a) aaa")
-            root.P("(b) bbb")
-            root.FP("fpfpfp")
-            root.P("(c) ccc")
-        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+        with self.section() as ctx:
+            ctx.P("(a) aaa")
+            ctx.P("(b) bbb")
+            ctx.FP("fpfpfp")
+            ctx.P("(c) ccc")
+        node = reg_text.build_from_section('8675', ctx.xml)[0]
         node = self.node_accessor(node, ['8675', '309'])
         self.assertEqual(['a', 'b', 'c'], node.child_labels)
         self.assertEqual([], node['a'].child_labels)
@@ -188,16 +191,16 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
 
     def test_build_from_section_table(self):
         """Account for regtext with a table"""
-        with self.section() as root:
-            root.P("(a) aaaa")
-            with root.GPOTABLE(CDEF="s25,10", COLS=2, OPTS="L2,i1") as table:
-                with table.BOXHD() as hd:
-                    hd.CHED(H=1)
-                    hd.CHED("Header", H=1)
-                with table.ROW() as row:
-                    row.ENT("Left content", I="01")
-                    row.ENT("Right content")
-        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+        with self.section() as ctx:
+            ctx.P("(a) aaaa")
+            with ctx.GPOTABLE(CDEF="s25,10", COLS=2, OPTS="L2,i1"):
+                with ctx.BOXHD():
+                    ctx.CHED(H=1)
+                    ctx.CHED("Header", H=1)
+                with ctx.ROW():
+                    ctx.ENT("Left content", I="01")
+                    ctx.ENT("Right content")
+        node = reg_text.build_from_section('8675', ctx.xml)[0]
         node = self.node_accessor(node, ['8675', '309'])
         self.assertEqual(['a'], node.child_labels)
         self.assertEqual(['p1'], node['a'].child_labels)
@@ -336,13 +339,13 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
 
     def test_build_from_section_extract(self):
         """Account for paragraphs within an EXTRACT tag"""
-        with self.section() as root:
-            root.P("(a) aaaa")
-            with root.EXTRACT() as extract:
-                extract.P("1. Some content")
-                extract.P("2. Other content")
-                extract.P("(3) This paragraph has parens for some reason")
-        nodes = reg_text.build_from_section('8675', self.tree.render_xml())
+        with self.section() as ctx:
+            ctx.P("(a) aaaa")
+            with ctx.EXTRACT():
+                ctx.P("1. Some content")
+                ctx.P("2. Other content")
+                ctx.P("(3) This paragraph has parens for some reason")
+        nodes = reg_text.build_from_section('8675', ctx.xml)
 
         root_node = nodes[0]
         self.assertEqual(['8675', '309'], root_node.label)
@@ -375,17 +378,17 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
 
     def test_build_from_section_example(self):
         """Account for paragraphs within an EXAMPLE tag"""
-        with self.section() as root:
-            root.P("(a) aaaa")
-            with root.EXAMPLE() as example:
-                example.P("You need a form if:")
-                example.P("1. Some content")
-                example.P("2. Other content")
-            with root.EXAMPLE() as example:
-                example.P("You do not need a form if:")
-                example.P("1. Some content")
-                example.P("2. Other content")
-        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+        with self.section() as ctx:
+            ctx.P("(a) aaaa")
+            with ctx.EXAMPLE():
+                ctx.P("You need a form if:")
+                ctx.P("1. Some content")
+                ctx.P("2. Other content")
+            with ctx.EXAMPLE():
+                ctx.P("You do not need a form if:")
+                ctx.P("1. Some content")
+                ctx.P("2. Other content")
+        node = reg_text.build_from_section('8675', ctx.xml)[0]
 
         a = node.children[0]
         self.assertEqual(u'(a) aaaa', a.text)
@@ -420,14 +423,14 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
 
     def test_build_from_section_notes(self):
         """Account for paragraphs within a NOTES tag"""
-        with self.section() as root:
-            root.P("(a) aaaa")
-            with root.NOTES() as extract:
-                extract.PRTPAGE(P="8")
-                extract.P("1. Some content")
-                extract.P("2. Other content")
+        with self.section() as ctx:
+            ctx.P("(a) aaaa")
+            with ctx.NOTES():
+                ctx.PRTPAGE(P="8")
+                ctx.P("1. Some content")
+                ctx.P("2. Other content")
         node = self.node_accessor(
-            reg_text.build_from_section('8675', self.tree.render_xml())[0],
+            reg_text.build_from_section('8675', ctx.xml)[0],
             ['8675', '309'])
 
         self.assertEqual(['a'], node.child_labels)
@@ -438,20 +441,20 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
     def test_build_from_section_whitespace(self):
         """The whitespace in the section text (and intro paragraph) should get
         removed"""
-        with self.tree.builder("SECTION", node_value="\n\n") as root:
-            root.SECTNO(u"§ 8675.309")
-            root.SUBJECT("subsubsub")
-            root.P("   Some \n content\n")
-            root.P("(a) aaa")
-            root.P("(b) bbb")
+        with XMLBuilder("SECTION", "\n\n") as ctx:
+            ctx.SECTNO(u"§ 8675.309")
+            ctx.SUBJECT("subsubsub")
+            ctx.P("   Some \n content\n")
+            ctx.P("(a) aaa")
+            ctx.P("(b) bbb")
 
-        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+        node = reg_text.build_from_section('8675', ctx.xml)[0]
         self.assertEqual(node.text, "Some \n content")
 
     def test_get_title(self):
-        with self.tree.builder("PART") as root:
-            root.HD("regulation title")
-        title = reg_text.get_title(self.tree.render_xml())
+        with XMLBuilder("PART") as ctx:
+            ctx.HD("regulation title")
+        title = reg_text.get_title(ctx.xml)
         self.assertEqual(u'regulation title', title)
 
     def test_get_reg_part(self):
@@ -466,37 +469,37 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
             self.assertEqual(part, '204')
 
     def test_get_reg_part_fr_notice_style(self):
-        with self.tree.builder("REGTEXT", PART="204") as root:
-            root.SECTION("\n")
-        part = reg_text.get_reg_part(self.tree.render_xml())
+        with XMLBuilder("REGTEXT", PART=204) as ctx:
+            ctx.SECTION("\n")
+        part = reg_text.get_reg_part(ctx.xml)
         self.assertEqual(part, '204')
 
     def test_get_subpart_title(self):
-        with self.tree.builder("SUBPART") as root:
-            root.HD(u"Subpart A—First subpart")
-        subpart_title = reg_text.get_subpart_title(self.tree.render_xml())
+        with XMLBuilder("SUBPART") as ctx:
+            ctx.HD(u"Subpart A—First subpart")
+        subpart_title = reg_text.get_subpart_title(ctx.xml)
         self.assertEqual(subpart_title, u'Subpart A—First subpart')
 
     def test_get_subpart_title_reserved(self):
-        with self.tree.builder("SUBPART") as root:
-            root.RESERVED("Subpart J [Reserved]")
-        subpart_title = reg_text.get_subpart_title(self.tree.render_xml())
+        with XMLBuilder("SUBPART") as ctx:
+            ctx.RESERVED("Subpart J [Reserved]")
+        subpart_title = reg_text.get_subpart_title(ctx.xml)
         self.assertEqual(subpart_title, u'Subpart J [Reserved]')
 
     def test_build_subpart(self):
-        with self.tree.builder("SUBPART") as root:
-            root.HD(u"Subpart A—First subpart")
-            with root.SECTION() as section:
-                section.SECTNO(u"§ 8675.309")
-                section.SUBJECT("Definitions.")
-                section.P("Some content about this section.")
-                section.P("(a) something something")
-            with root.SECTION() as section:
-                section.SECTNO(u"§ 8675.310")
-                section.SUBJECT("Definitions.")
-                section.P("Some content about this section.")
-                section.P("(a) something something")
-        subpart = reg_text.build_subpart('8675', self.tree.render_xml())
+        with XMLBuilder("SUBPART") as ctx:
+            ctx.HD(u"Subpart A—First subpart")
+            with ctx.SECTION():
+                ctx.SECTNO(u"§ 8675.309")
+                ctx.SUBJECT("Definitions.")
+                ctx.P("Some content about this section.")
+                ctx.P("(a) something something")
+            with ctx.SECTION():
+                ctx.SECTNO(u"§ 8675.310")
+                ctx.SUBJECT("Definitions.")
+                ctx.P("Some content about this section.")
+                ctx.P("(a) something something")
+        subpart = reg_text.build_subpart('8675', ctx.xml)
         self.assertEqual(subpart.node_type, 'subpart')
         self.assertEqual(len(subpart.children), 2)
         self.assertEqual(subpart.label, ['8675', 'Subpart', 'A'])
@@ -504,18 +507,18 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
         self.assertEqual([['8675', '309'], ['8675', '310']], child_labels)
 
     def test_build_subjgrp(self):
-        with self.tree.builder("SUBJGRP") as root:
-            root.HD(u"Changes of Ownership")
-            with root.SECTION() as section:
-                section.SECTNO(u"§ 479.42")
-                section.SUBJECT("Changes through death of owner.")
-                section.P(u"Whenever any person who has paid […] conditions.")
-            with root.SECTION() as section:
-                section.SECTNO(u"§ 479.43")
-                section.SUBJECT("Changes through bankruptcy of owner.")
-                section.P(u"A receiver or referee in bankruptcy may […] paid.")
-                section.P("(a) something something")
-        subpart = reg_text.build_subjgrp('479', self.tree.render_xml(), [])
+        with XMLBuilder("SUBJGRP") as ctx:
+            ctx.HD(u"Changes of Ownership")
+            with ctx.SECTION():
+                ctx.SECTNO(u"§ 479.42")
+                ctx.SUBJECT("Changes through death of owner.")
+                ctx.P(u"Whenever any person who has paid […] conditions.")
+            with ctx.SECTION():
+                ctx.SECTNO(u"§ 479.43")
+                ctx.SUBJECT("Changes through bankruptcy of owner.")
+                ctx.P(u"A receiver or referee in bankruptcy may […] paid.")
+                ctx.P("(a) something something")
+        subpart = reg_text.build_subjgrp('479', ctx.xml, [])
         self.assertEqual(subpart.node_type, 'subpart')
         self.assertEqual(len(subpart.children), 2)
         self.assertEqual(subpart.label, ['479', 'Subjgrp', 'CoO'])
@@ -579,56 +582,53 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
 
     @patch('regparser.tree.xml_parser.reg_text.content')
     def test_preprocess_xml(self, content):
-        with self.tree.builder("CFRGRANULE") as root:
-            with root.PART() as part:
-                with part.APPENDIX() as appendix:
-                    appendix.TAG("Other Text")
-                    with appendix.GPH(DEEP=453, SPAN=2) as gph:
-                        gph.GID("ABCD.0123")
+        with XMLBuilder("CFRGRANULE") as ctx:
+            with ctx.PART():
+                with ctx.APPENDIX():
+                    ctx.TAG("Other Text")
+                    with ctx.GPH(DEEP=453, SPAN=2):
+                        ctx.GID("ABCD.0123")
         content.Macros.return_value = [
             ("//GID[./text()='ABCD.0123']/..",
              """<HD SOURCE="HD1">Some Title</HD><GPH DEEP="453" SPAN="2">"""
              """<GID>EFGH.0123</GID></GPH>""")]
-        orig_xml = self.tree.render_xml()
-        reg_text.preprocess_xml(orig_xml)
+        reg_text.preprocess_xml(ctx.xml)
 
-        self.setUp()
-        with self.tree.builder("CFRGRANULE") as root:
-            with root.PART() as part:
-                with part.APPENDIX() as appendix:
-                    appendix.TAG("Other Text")
-                    appendix.HD("Some Title", SOURCE="HD1")
-                    with appendix.GPH(DEEP=453, SPAN=2) as gph:
-                        gph.GID("EFGH.0123")
-
-        self.assertEqual(etree.tostring(orig_xml), self.tree.render_string())
+        with XMLBuilder("CFRGRANULE") as ctx2:
+            with ctx2.PART():
+                with ctx2.APPENDIX():
+                    ctx2.TAG("Other Text")
+                    ctx2.HD("Some Title", SOURCE="HD1")
+                    with ctx2.GPH(DEEP=453, SPAN=2):
+                        ctx2.GID("EFGH.0123")
+        self.assertEqual(ctx.xml_str, ctx2.xml_str)
 
     def test_build_from_section_double_alpha(self):
         # Ensure we match a hierarchy like (x), (y), (z), (aa), (bb)…
-        with self.tree.builder("SECTION") as root:
-            root.SECTNO(u"§ 8675.309")
-            root.SUBJECT("Definitions.")
-            root.P("(aa) This is what things mean:")
-        node = reg_text.build_from_section('8675', self.tree.render_xml())[0]
+        with XMLBuilder("SECTION") as ctx:
+            ctx.SECTNO(u"§ 8675.309")
+            ctx.SUBJECT("Definitions.")
+            ctx.P("(aa) This is what things mean:")
+        node = reg_text.build_from_section('8675', ctx.xml)[0]
         child = node.children[0]
         self.assertEqual('(aa) This is what things mean:', child.text.strip())
         self.assertEqual(['8675', '309', 'aa'], child.label)
 
     def test_build_tree_with_subjgrp(self):
         """XML with SUBJGRPs where SUBPARTs are shouldn't cause a problem"""
-        with self.tree.builder("ROOT") as root:
-            with root.PART() as part:
-                part.EAR("Pt. 123")
-                part.HD(u"PART 123—SOME STUFF", SOURCE="HED")
-                with part.SUBPART() as subpart:
-                    subpart.HD(u"Subpart A—First subpart")
-                with part.SUBJGRP() as subjgrp:
-                    subjgrp.HD(u"Changes of Ownership")
-                with part.SUBPART() as subpart:
-                    subpart.HD(u"Subpart B—First subpart")
-                with part.SUBJGRP() as subjgrp:
-                    subjgrp.HD(u"Another Top Level")
-        node = reg_text.build_tree(self.tree.render_xml())
+        with XMLBuilder("ROOT") as ctx:
+            with ctx.PART():
+                ctx.EAR("Pt. 123")
+                ctx.HD(u"PART 123—SOME STUFF", SOURCE="HED")
+                with ctx.SUBPART():
+                    ctx.HD(u"Subpart A—First subpart")
+                with ctx.SUBJGRP():
+                    ctx.HD(u"Changes of Ownership")
+                with ctx.SUBPART():
+                    ctx.HD(u"Subpart B—First subpart")
+                with ctx.SUBJGRP():
+                    ctx.HD(u"Another Top Level")
+        node = reg_text.build_tree(ctx.xml)
         self.assertEqual(node.label, ['123'])
         self.assertEqual(4, len(node.children))
         subpart_a, subjgrp_1, subpart_b, subjgrp_2 = node.children
@@ -676,48 +676,43 @@ class RegTextTest(XMLBuilderMixin, NodeAccessorMixin, TestCase):
 
     def test_next_marker_found(self):
         """Find the first paragraph marker following a paragraph"""
-        with self.tree.builder("ROOT") as root:
-            root.P("(A) AAA")
-            root.PRTPART()
-            root.P("(d) ddd")
-            root.P("(1) 111")
-        xml = self.tree.render_xml()[0]
-        self.assertEqual(reg_text.next_marker(xml), 'd')
+        with XMLBuilder("ROOT") as ctx:
+            ctx.P("(A) AAA")
+            ctx.PRTPART()
+            ctx.P("(d) ddd")
+            ctx.P("(1) 111")
+        self.assertEqual(reg_text.next_marker(ctx.xml[0]), 'd')
 
     def test_next_marker_stars(self):
         """STARS tag has special significance."""
-        with self.tree.builder("ROOT") as root:
-            root.P("(A) AAA")
-            root.PRTPART()
-            root.STARS()
-            root.P("(d) ddd")
-            root.P("(1) 111")
-        xml = self.tree.render_xml()[0]
-        self.assertEqual(reg_text.next_marker(xml),
-                         mtypes.STARS_TAG)
+        with XMLBuilder("ROOT") as ctx:
+            ctx.P("(A) AAA")
+            ctx.PRTPART()
+            ctx.STARS()
+            ctx.P("(d) ddd")
+            ctx.P("(1) 111")
+        self.assertEqual(reg_text.next_marker(ctx.xml[0]), mtypes.STARS_TAG)
 
     def test_next_marker_none(self):
         """If no marker is present, return None"""
-        with self.tree.builder("ROOT") as root:
-            root.P("(1) 111")
-            root.P("Content")
-            root.P("(i) iii")
-        xml = self.tree.render_xml()[0]
-        self.assertIsNone(reg_text.next_marker(xml))
+        with XMLBuilder("ROOT") as ctx:
+            ctx.P("(1) 111")
+            ctx.P("Content")
+            ctx.P("(i) iii")
+        self.assertIsNone(reg_text.next_marker(ctx.xml[0]))
 
 
-class RegtextParagraphProcessorTests(XMLBuilderMixin, NodeAccessorMixin,
-                                     TestCase):
+class RegtextParagraphProcessorTests(NodeAccessorMixin, TestCase):
     def test_process_markerless_collapsed(self):
         """Should be able to find collapsed markers in a markerless
         paragraph"""
-        with self.tree.builder("ROOT") as root:
-            root.P("Intro text")
-            root.P(_xml='<E T="03">Some term.</E> (a) First definition')
-            root.P("(b) Second definition")
-        xml = self.tree.render_xml()
+        with XMLBuilder("ROOT") as ctx:
+            ctx.P("Intro text")
+            ctx.child_from_string(
+                '<P><E T="03">Some term.</E> (a) First definition</P>')
+            ctx.P("(b) Second definition")
         root = Node(label=['111', '22'])
-        root = reg_text.RegtextParagraphProcessor().process(xml, root)
+        root = reg_text.RegtextParagraphProcessor().process(ctx.xml, root)
         root = self.node_accessor(root, ['111', '22'])
 
         self.assertEqual(2, len(root.child_labels))
@@ -727,16 +722,15 @@ class RegtextParagraphProcessorTests(XMLBuilderMixin, NodeAccessorMixin,
         self.assertEqual(['a', 'b'], root[keyterm_label].child_labels)
 
     def test_process_nested_uscode(self):
-        with self.tree.builder("ROOT") as root:
-            root.P("Some intro")
-            with root.EXTRACT() as extract:
-                extract.HD("The U.S. Code!")
-                with extract.USCODE() as uscode:
-                    uscode.P("(x)(1) Some content")
-                    uscode.P("(A) Sub-sub-paragraph")
-                    uscode.P("(i)(I) Even more nested")
-        xml = self.tree.render_xml()
-        root = reg_text.RegtextParagraphProcessor().process(xml, Node())
+        with XMLBuilder("ROOT") as ctx:
+            ctx.P("Some intro")
+            with ctx.EXTRACT():
+                ctx.HD("The U.S. Code!")
+                with ctx.USCODE():
+                    ctx.P("(x)(1) Some content")
+                    ctx.P("(A) Sub-sub-paragraph")
+                    ctx.P("(i)(I) Even more nested")
+        root = reg_text.RegtextParagraphProcessor().process(ctx.xml, Node())
         root = self.node_accessor(root, [])
 
         self.assertEqual(root['p1'].text, "Some intro")

--- a/tests/tree_xml_parser_simple_hierarchy_processor_tests.py
+++ b/tests/tree_xml_parser_simple_hierarchy_processor_tests.py
@@ -1,27 +1,27 @@
 from unittest import TestCase
 
+from regparser.test_utils.xml_builder import XMLBuilder
 from regparser.tree.xml_parser.simple_hierarchy_processor import (
         SimpleHierarchyMatcher)
-from tests.xml_builder import XMLBuilderMixin
 from tests.node_accessor import NodeAccessorMixin
 
 
-class SimpleHierarchyTests(XMLBuilderMixin, NodeAccessorMixin, TestCase):
+class SimpleHierarchyTests(NodeAccessorMixin, TestCase):
     def test_deep_hierarchy(self):
         """Run through a full example, converting an XML node into an
         appropriate tree of nodes"""
-        with self.tree.builder("ROOT") as root:
-            root.P("(a) AAA")
-            root.P("(b) BBB")
-            root.P("i. BIBIBI")
-            root.P("ii. BIIBIIBII")
-            root.P("(1) BII1BII1BII1")
-            root.P("(2) BII2BII2BII2")
-            root.P("iii. BIIIBIIIBIII")
-            root.P("(c) CCC")
+        with XMLBuilder("ROOT") as ctx:
+            ctx.P("(a) AAA")
+            ctx.P("(b) BBB")
+            ctx.P("i. BIBIBI")
+            ctx.P("ii. BIIBIIBII")
+            ctx.P("(1) BII1BII1BII1")
+            ctx.P("(2) BII2BII2BII2")
+            ctx.P("iii. BIIIBIIIBIII")
+            ctx.P("(c) CCC")
 
         matcher = SimpleHierarchyMatcher(['ROOT'], 'some_type')
-        nodes = matcher.derive_nodes(self.tree.render_xml())
+        nodes = matcher.derive_nodes(ctx.xml)
         self.assertEqual(1, len(nodes))
 
         node = self.node_accessor(nodes[0], nodes[0].label)
@@ -50,11 +50,11 @@ class SimpleHierarchyTests(XMLBuilderMixin, NodeAccessorMixin, TestCase):
     def test_no_children(self):
         """Elements with only one, markerless paragraph should not have
         children"""
-        with self.tree.builder("NOTE") as root:
-            root.P("Some text here")
+        with XMLBuilder("NOTE") as ctx:
+            ctx.P("Some text here")
 
         matcher = SimpleHierarchyMatcher(['NOTE'], 'note')
-        nodes = matcher.derive_nodes(self.tree.render_xml())
+        nodes = matcher.derive_nodes(ctx.xml)
         self.assertEqual(1, len(nodes))
         node = nodes[0]
 

--- a/tests/xml_builder.py
+++ b/tests/xml_builder.py
@@ -1,3 +1,5 @@
+"""This will be deleted soon -- we just need to migrate atf-eregs and
+fec-eregs to use XMLBuilder directly"""
 from contextlib import contextmanager
 
 from lxml import etree


### PR DESCRIPTION
Looks like a lot of changes, but >90% are syntactic.

We used `datatree` for building XML easily for tests. This removes that dependency by adding a drop-in replacement. That replacement is a bit cleaner and more concise for our needs. When used indirectly (through `XMLBuilderMixin`), the replacement is backwards compatible (verified by running existing tests). This PR goes one step further and removes all references to `tests.xml_builder` from the core code base. We'll be able to completely remove that file once we're sure that atf-eregs and fec-eregs don't need it.

Resolves #187 