### PR TITLE
Move NodeAccessor testing logic

### DIFF
--- a/regparser/test_utils/node_accessor.py
+++ b/regparser/test_utils/node_accessor.py
@@ -20,4 +20,3 @@ class NodeAccessor(object):
                 if child.label[-1] == label:
                     return NodeAccessor(child)
         raise KeyError()
-

--- a/regparser/test_utils/node_accessor.py
+++ b/regparser/test_utils/node_accessor.py
@@ -1,0 +1,23 @@
+class NodeAccessor(object):
+    """Wrapper class around a node that allows us to navigate the tree via
+    dictionary access"""
+    def __init__(self, node):
+        self.node = node
+        self.child_labels = [c.label[-1] for c in node.children]
+        self._memoized = {}
+
+    def __getattr__(self, name):
+        """Pass through to self.node"""
+        return getattr(self.node, name)
+
+    def __getitem__(self, label):
+        """Access child labels as a dictionary. node['111']['a']['2'] would
+        access the node with label '111-a-2'"""
+        if label in self._memoized:
+            return self._memoized[label]
+        else:
+            for child in self.node.children:
+                if child.label[-1] == label:
+                    return NodeAccessor(child)
+        raise KeyError()
+

--- a/tests/node_accessor.py
+++ b/tests/node_accessor.py
@@ -1,25 +1,6 @@
-class NodeAccessor(object):
-    """Wrapper class around a node that allows us to navigate the tree via
-    dictionary access"""
-    def __init__(self, node):
-        self.node = node
-        self.child_labels = [c.label[-1] for c in node.children]
-        self._memoized = {}
-
-    def __getattr__(self, name):
-        """Pass through to self.node"""
-        return getattr(self.node, name)
-
-    def __getitem__(self, label):
-        """Access child labels as a dictionary. node['111']['a']['2'] would
-        access the node with label '111-a-2'"""
-        if label in self._memoized:
-            return self._memoized[label]
-        else:
-            for child in self.node.children:
-                if child.label[-1] == label:
-                    return NodeAccessor(child)
-        raise KeyError()
+"""This will be deleted soon -- we just need to migrate atf-eregs and
+fec-eregs to use NodeAccessor directly"""
+from regparser.test_utils.node_accessor import NodeAccessor
 
 
 class NodeAccessorMixin(object):

--- a/tests/notice_preamble_tests.py
+++ b/tests/notice_preamble_tests.py
@@ -2,11 +2,11 @@ from unittest import TestCase
 
 from regparser.notice import preamble
 from regparser.notice.xml import NoticeXML
+from regparser.test_utils.node_accessor import NodeAccessor
 from regparser.test_utils.xml_builder import XMLBuilder
-from tests.node_accessor import NodeAccessorMixin
 
 
-class NoticePreambleTests(NodeAccessorMixin, TestCase):
+class NoticePreambleTests(TestCase):
     def test_parse_preamble_integration(self):
         """End-to-end test for parsing a notice preamble"""
         with XMLBuilder("ROOT") as ctx:
@@ -32,8 +32,9 @@ class NoticePreambleTests(NodeAccessorMixin, TestCase):
             ctx.P("tail also ignored")
         xml = NoticeXML(ctx.xml)
         xml.version_id = 'vvv-yyy'
-        root = self.node_accessor(preamble.parse_preamble(xml), ['vvv_yyy'])
+        root = NodeAccessor(preamble.parse_preamble(xml))
 
+        self.assertEqual(root.label, ['vvv_yyy'])
         self.assertEqual(root.title, 'Supp Inf')
         self.assertEqual(root['p1'].text, 'P1')
         self.assertEqual(root['p2'].text, 'P2')

--- a/tests/tree_xml_parser_note_processor_tests.py
+++ b/tests/tree_xml_parser_note_processor_tests.py
@@ -4,7 +4,6 @@ from mock import patch
 
 from regparser.test_utils.node_accessor import NodeAccessor
 from regparser.test_utils.xml_builder import XMLBuilder
-from regparser.tree.depth import markers as mtypes
 from regparser.tree.xml_parser import note_processor
 
 

--- a/tests/tree_xml_parser_note_processor_tests.py
+++ b/tests/tree_xml_parser_note_processor_tests.py
@@ -2,13 +2,13 @@ from unittest import TestCase
 
 from mock import patch
 
+from regparser.test_utils.node_accessor import NodeAccessor
 from regparser.test_utils.xml_builder import XMLBuilder
 from regparser.tree.depth import markers as mtypes
 from regparser.tree.xml_parser import note_processor
-from tests.node_accessor import NodeAccessorMixin
 
 
-class NoteProcessingTests(NodeAccessorMixin, TestCase):
+class NoteProcessingTests(TestCase):
     def test_integration(self):
         """Verify that a NOTE tag is converted into an appropriate tree. We
         also expect no warnings to be emitted"""
@@ -27,7 +27,7 @@ class NoteProcessingTests(NodeAccessorMixin, TestCase):
         self.assertFalse(logger.warning.called)
 
         self.assertEqual(len(results), 1)
-        tree = self.node_accessor(results[0], [mtypes.MARKERLESS])
+        tree = NodeAccessor(results[0])
         self.assertEqual(tree['1'].text, '1. 111')
         self.assertEqual(tree['1']['a'].text, 'a. 1a1a1a')
         self.assertEqual(tree['1']['b'].text, 'b. 1b1b1b')

--- a/tests/tree_xml_parser_simple_hierarchy_processor_tests.py
+++ b/tests/tree_xml_parser_simple_hierarchy_processor_tests.py
@@ -1,12 +1,12 @@
 from unittest import TestCase
 
+from regparser.test_utils.node_accessor import NodeAccessor
 from regparser.test_utils.xml_builder import XMLBuilder
 from regparser.tree.xml_parser.simple_hierarchy_processor import (
         SimpleHierarchyMatcher)
-from tests.node_accessor import NodeAccessorMixin
 
 
-class SimpleHierarchyTests(NodeAccessorMixin, TestCase):
+class SimpleHierarchyTests(TestCase):
     def test_deep_hierarchy(self):
         """Run through a full example, converting an XML node into an
         appropriate tree of nodes"""
@@ -24,7 +24,7 @@ class SimpleHierarchyTests(NodeAccessorMixin, TestCase):
         nodes = matcher.derive_nodes(ctx.xml)
         self.assertEqual(1, len(nodes))
 
-        node = self.node_accessor(nodes[0], nodes[0].label)
+        node = NodeAccessor(nodes[0])
         self.assertEqual('some_type', node.node_type)
         self.assertEqual(['a', 'b', 'c'], node.child_labels)
         self.assertNotEqual('some_type', node['a'].node_type)


### PR DESCRIPTION
This moves the second test utility, `NodeAccessor` into a shared space per #214