### PR TITLE
Remove dagger, replace with networkx

### DIFF
--- a/regparser/commands/fill_with_rules.py
+++ b/regparser/commands/fill_with_rules.py
@@ -35,7 +35,7 @@ def derived_from_rules(version_ids, deps, tree_path):
     for version_id in version_ids:
         path = str(tree_path / version_id)
         rule_change = str(entry.RuleChanges(version_id))
-        if path in deps.graph and rule_change in deps.graph.predecessors(path):
+        if rule_change in deps.dependencies(path):
             rule_versions.append(version_id)
     return rule_versions
 

--- a/regparser/commands/fill_with_rules.py
+++ b/regparser/commands/fill_with_rules.py
@@ -32,12 +32,10 @@ def derived_from_rules(version_ids, deps, tree_path):
     that, we'll filter by those trees which have a dependency on a parsed
     rule"""
     rule_versions = []
-    with deps.dependency_db() as db:
-        graph = dict(db)    # copy
     for version_id in version_ids:
         path = str(tree_path / version_id)
         rule_change = str(entry.RuleChanges(version_id))
-        if rule_change in graph.get(path, []):
+        if path in deps.graph and rule_change in deps.graph.predecessors(path):
             rule_versions.append(version_id)
     return rule_versions
 

--- a/regparser/index/dependency.py
+++ b/regparser/index/dependency.py
@@ -49,12 +49,14 @@ class Graph(object):
     def node(self, filename):
         """Get node attributes for a specific filename. If the node isn't
         present, create it"""
+        filename = str(filename)
         if filename not in self._graph:
             self._graph.add_node(filename)
         return self._graph.node[filename]
 
     def dependencies(self, filename):
         """What does other nodes does this filename *directly* depend on?"""
+        filename = str(filename)
         if filename in self._graph:
             return self._graph.predecessors(filename)
         else:
@@ -73,6 +75,8 @@ class Graph(object):
                 modtime = time()
                 stale = node
 
+            # Check immediate dependencies (which were updated in a previous
+            # step)
             for dependency in self.dependencies(node):
                 if self.node(dependency)['modtime'] > modtime:
                     stale = dependency

--- a/regparser/index/dependency.py
+++ b/regparser/index/dependency.py
@@ -30,9 +30,9 @@ class Graph(object):
             os.makedirs(ROOT)
 
         if os.path.exists(self.GML_FILE):
-            self.graph = networkx.read_gml(self.GML_FILE)
+            self._graph = networkx.read_gml(self.GML_FILE)
         else:
-            self.graph = networkx.DiGraph()
+            self._graph = networkx.DiGraph()
         self._ran = False
 
     def add(self, output_entry, input_entry):
@@ -40,34 +40,50 @@ class Graph(object):
         self._ran = False
         from_str, to_str = str(output_entry), str(input_entry)
 
-        self.graph.add_edge(to_str, from_str)
-        networkx.write_gml(self.graph, self.GML_FILE)
+        self._graph.add_edge(to_str, from_str)
+        networkx.write_gml(self._graph, self.GML_FILE)
+
+    def __contains__(self, key):
+        return key in self._graph
+
+    def node(self, filename):
+        if filename not in self._graph:
+            self._graph.add_node(filename)
+        return self._graph.node[filename]
+
+    def dependencies(self, filename):
+        if filename in self._graph:
+            return self._graph.predecessors(filename)
+        else:
+            return []
+
+    def roots(self):
+        for node in self._graph:
+            if not self.dependencies(node):
+                yield(node)
 
     def derive_stale(self, filename, parent=None):
-        modtime = self.graph.node[filename].get('modtime')
-        stale = self.graph.node[filename].get('stale')
+        modtime = self.node(filename).get('modtime')
+        stale = self.node(filename).get('stale')
         if os.path.exists(filename):
             modtime = os.path.getmtime(filename)
         else:
             stale = filename
 
-        if (parent and modtime and
-                self.graph.node[parent]['modtime'] > modtime):
+        if parent and modtime and self.node(parent)['modtime'] > modtime:
             stale = parent
         elif parent:
-            stale = stale or self.graph.node[parent]['stale']
+            stale = stale or self.node(parent)['stale']
 
-        self.graph.node[filename]['modtime'] = modtime
-        self.graph.node[filename]['stale'] = stale
+        self.node(filename).update(modtime=modtime, stale=stale)
 
-        for adj in self.graph[filename]:
+        for adj in self._graph[filename]:
             self.derive_stale(adj, filename)
 
     def _run_if_needed(self):
         if not self._ran:
-            for node in self.graph:
-                if not self.graph.predecessors(node):
-                    self.derive_stale(node)
+            for root in self.roots():
+                self.derive_stale(root)
             self._ran = True
 
     def validate_for(self, entry):
@@ -75,11 +91,11 @@ class Graph(object):
         self._run_if_needed()
         key = str(entry)
         logger.debug("Validating dependencies for %r", key)
-        for dependency in self.graph.predecessors(key):
-            if self.graph.node[dependency].get('stale'):
-                raise Missing(key, self.graph.node[dependency]['stale'])
+        for dependency in self.dependencies(key):
+            if self.node(dependency).get('stale'):
+                raise Missing(key, self.node(dependency)['stale'])
 
     def is_stale(self, entry):
         """Determine if a file needs to be rebuilt"""
         self._run_if_needed()
-        return bool(self.graph.node[str(entry)].get('stale'))
+        return bool(self.node(str(entry)).get('stale'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 boto3==1.2.4
 click==6.2
 coloredlogs==5.0
-dagger==1.3.0
 GitPython==1.0.1
 inflection==0.3.1
 ipdb==0.8.1
 json-delta==2.0
 lxml==3.5.0
+networkx==1.11
 pyparsing==2.0.5  # 2.0.6 has a unicode bug, fixed in current trunk: http://sourceforge.net/p/pyparsing/code/HEAD/tree/tags/pyparsing_2.0.6/src/pyparsing.py#l2354
 python-constraint==1.2
 requests==2.9.1

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,12 @@ setup(
     install_requires=[
         "click",
         "coloredLogs",
-        "dagger",
         "GitPython",
         "inflection",
         "ipdb",
         "json-delta",
         "lxml",
+        "networkx",
         "pyparsing",
         "python-constraint",
         "requests",

--- a/tests/commands_fill_with_rules_tests.py
+++ b/tests/commands_fill_with_rules_tests.py
@@ -28,26 +28,24 @@ class CommandsFillWithRulesTests(TestCase):
                 tree_dir, version_ids, '12', '1000')
 
             # First is skipped, as we can't build it from a rule
-            self.assertNotIn(str(tree_dir / '111'), deps.graph)
+            self.assertNotIn(str(tree_dir / '111'), deps)
             # Second can also be skipped as a tree already exists
-            self.assertItemsEqual(deps.graph.node.get(str(tree_dir / '222')),
-                                  [])
+            self.assertEqual(deps.dependencies(str(tree_dir / '222')), [])
             # Third relies on the associated versions and the second tree
             self.assertItemsEqual(
-                deps.graph.predecessors(str(tree_dir / '333')),
+                deps.dependencies(str(tree_dir / '333')),
                 [str(tree_dir / '222'), str(rule_dir / '333'),
                  str(vers_dir / '333')])
             # Fourth relies on the third, even though it's not been built
             self.assertItemsEqual(
-                deps.graph.predecessors(str(tree_dir / '444')),
+                deps.dependencies(str(tree_dir / '444')),
                 [str(tree_dir / '333'), str(rule_dir / '444'),
                  str(vers_dir / '444')])
             # Fifth can be skipped as the tree already exists
-            self.assertItemsEqual(deps.graph.node.get(str(tree_dir / '555')),
-                                  [])
+            self.assertEqual(deps.dependencies(str(tree_dir / '555')), [])
             # Six relies on the fifth
             self.assertItemsEqual(
-                deps.graph.predecessors(str(tree_dir / '666')),
+                deps.dependencies(str(tree_dir / '666')),
                 [str(tree_dir / '555'), str(rule_dir / '666'),
                  str(vers_dir / '666')])
 

--- a/tests/commands_fill_with_rules_tests.py
+++ b/tests/commands_fill_with_rules_tests.py
@@ -26,33 +26,30 @@ class CommandsFillWithRulesTests(TestCase):
 
             deps = fill_with_rules.dependencies(
                 tree_dir, version_ids, '12', '1000')
-            with deps.dependency_db() as db:
-                graph = dict(db)    # copy
 
             # First is skipped, as we can't build it from a rule
-            self.assertNotIn(str(tree_dir / '111'), graph)
+            self.assertNotIn(str(tree_dir / '111'), deps.graph)
             # Second can also be skipped as a tree already exists
-            self.assertNotIn(str(tree_dir / '222'), graph)
+            self.assertItemsEqual(deps.graph.node.get(str(tree_dir / '222')),
+                                  [])
             # Third relies on the associated versions and the second tree
-            self.assertEqual(
-                graph[str(tree_dir / '333')],
-                set([str(tree_dir / '222'),
-                     str(rule_dir / '333'),
-                     str(vers_dir / '333')]))
+            self.assertItemsEqual(
+                deps.graph.predecessors(str(tree_dir / '333')),
+                [str(tree_dir / '222'), str(rule_dir / '333'),
+                 str(vers_dir / '333')])
             # Fourth relies on the third, even though it's not been built
-            self.assertEqual(
-                graph[str(tree_dir / '444')],
-                set([str(tree_dir / '333'),
-                     str(rule_dir / '444'),
-                     str(vers_dir / '444')]))
+            self.assertItemsEqual(
+                deps.graph.predecessors(str(tree_dir / '444')),
+                [str(tree_dir / '333'), str(rule_dir / '444'),
+                 str(vers_dir / '444')])
             # Fifth can be skipped as the tree already exists
-            self.assertNotIn(str(tree_dir / '555'), graph)
+            self.assertItemsEqual(deps.graph.node.get(str(tree_dir / '555')),
+                                  [])
             # Six relies on the fifth
-            self.assertEqual(
-                graph[str(tree_dir / '666')],
-                set([str(tree_dir / '555'),
-                     str(rule_dir / '666'),
-                     str(vers_dir / '666')]))
+            self.assertItemsEqual(
+                deps.graph.predecessors(str(tree_dir / '666')),
+                [str(tree_dir / '555'), str(rule_dir / '666'),
+                 str(vers_dir / '666')])
 
     def test_derived_from_rules(self):
         """Should filter a set of version ids to only those with a dependency

--- a/tests/commands_layers_tests.py
+++ b/tests/commands_layers_tests.py
@@ -37,7 +37,7 @@ class CommandsLayersTests(TestCase):
 
             self.assertIn(
                 str(version_entry),
-                dependency.Graph().graph.predecessors(
+                dependency.Graph().dependencies(
                     str(entry.Layer.cfr(111, 22, 'aaa', 'meta'))))
 
     def test_process_cfr_layers(self):

--- a/tests/commands_layers_tests.py
+++ b/tests/commands_layers_tests.py
@@ -35,10 +35,10 @@ class CommandsLayersTests(TestCase):
             self.assertItemsEqual(
                 layers.stale_layers(tree_entry, 'cfr'), ['keyterms', 'other'])
 
-            with dependency.Graph().dependency_db() as db:
-                self.assertIn(
-                    str(version_entry),
-                    db[str(entry.Layer.cfr(111, 22, 'aaa', 'meta'))])
+            self.assertIn(
+                str(version_entry),
+                dependency.Graph().graph.predecessors(
+                    str(entry.Layer.cfr(111, 22, 'aaa', 'meta'))))
 
     def test_process_cfr_layers(self):
         """All layers for a single version should get written."""

--- a/tests/commands_preprocess_notice_tests.py
+++ b/tests/commands_preprocess_notice_tests.py
@@ -91,10 +91,10 @@ class CommandsPreprocessNoticeTests(HttpMixin, TestCase):
         with cli.isolated_filesystem():
             cli.invoke(preprocess_notice, ['1234-5678'])
             entry_str = str(entry.Notice() / '1234-5678')
-            self.assertIn(entry_str, dependency.Graph().graph)
+            self.assertIn(entry_str, dependency.Graph())
 
         notice_xmls_for_url.return_value[0].source = 'http://example.com'
         with cli.isolated_filesystem():
             cli.invoke(preprocess_notice, ['1234-5678'])
             entry_str = str(entry.Notice() / '1234-5678')
-            self.assertNotIn(entry_str, dependency.Graph().graph)
+            self.assertNotIn(entry_str, dependency.Graph())

--- a/tests/commands_preprocess_notice_tests.py
+++ b/tests/commands_preprocess_notice_tests.py
@@ -91,12 +91,10 @@ class CommandsPreprocessNoticeTests(HttpMixin, TestCase):
         with cli.isolated_filesystem():
             cli.invoke(preprocess_notice, ['1234-5678'])
             entry_str = str(entry.Notice() / '1234-5678')
-            with dependency.Graph().dependency_db() as db:
-                self.assertTrue(entry_str in db)
+            self.assertIn(entry_str, dependency.Graph().graph)
 
         notice_xmls_for_url.return_value[0].source = 'http://example.com'
         with cli.isolated_filesystem():
             cli.invoke(preprocess_notice, ['1234-5678'])
             entry_str = str(entry.Notice() / '1234-5678')
-            with dependency.Graph().dependency_db() as db:
-                self.assertFalse(entry_str in db)
+            self.assertNotIn(entry_str, dependency.Graph().graph)

--- a/tests/index_dependency_tests.py
+++ b/tests/index_dependency_tests.py
@@ -49,8 +49,7 @@ class DependencyGraphTests(TestCase):
             # Set the update time of the dependency to the future
             os.utime(str(self.dependency),
                      (time()*1000 + 1000, time()*1000 + 1000))
-            dgraph._ran = False
-            dgraph._run_if_needed()
+            dgraph.rebuild()
             self.assertFalse(dgraph.is_stale(self.dependency))
             self.assertTrue(dgraph.is_stale(self.depender))
 

--- a/tests/index_dependency_tests.py
+++ b/tests/index_dependency_tests.py
@@ -61,9 +61,9 @@ class DependencyGraphTests(TestCase):
             dgraph.add(self.depender, self.dependency / '1')
             dgraph.add(self.depender, self.dependency / '2')
             self.assertItemsEqual(
-                dgraph.graph.predecessors(str(self.depender)),
+                dgraph.dependencies(str(self.depender)),
                 [str(self.dependency / 1), str(self.dependency / 2)])
 
             self.assertItemsEqual(
-                dependency.Graph().graph.predecessors(str(self.depender)),
+                dependency.Graph().dependencies(str(self.depender)),
                 [str(self.dependency / 1), str(self.dependency / 2)])

--- a/tests/index_dependency_tests.py
+++ b/tests/index_dependency_tests.py
@@ -60,14 +60,10 @@ class DependencyGraphTests(TestCase):
         with self.dependency_graph() as dgraph:
             dgraph.add(self.depender, self.dependency / '1')
             dgraph.add(self.depender, self.dependency / '2')
-            with dgraph.dependency_db() as db:
-                dependencies = db[str(self.depender)]
-            self.assertEqual(
-                dependencies,
-                set([str(self.dependency / 1), str(self.dependency / 2)]))
+            self.assertItemsEqual(
+                dgraph.graph.predecessors(str(self.depender)),
+                [str(self.dependency / 1), str(self.dependency / 2)])
 
-            with dependency.Graph().dependency_db() as db:
-                dependencies = db[str(self.depender)]
-            self.assertEqual(
-                dependencies,
-                set([str(self.dependency / 1), str(self.dependency / 2)]))
+            self.assertItemsEqual(
+                dependency.Graph().graph.predecessors(str(self.depender)),
+                [str(self.dependency / 1), str(self.dependency / 2)])

--- a/tests/index_dependency_tests.py
+++ b/tests/index_dependency_tests.py
@@ -17,6 +17,10 @@ class DependencyGraphTests(TestCase):
             self.dependency = path / 'dependency'
             yield dependency.Graph()
 
+    def _touch(self, filename, offset):
+        """Update the modification time for a dependency"""
+        os.utime(str(filename), (time()*1000 + offset, time()*1000 + offset))
+
     def test_nonexistent_files_are_stale(self):
         """By definition, if a file is not present, it needs to be rebuilt"""
         with self.dependency_graph() as dgraph:
@@ -46,9 +50,7 @@ class DependencyGraphTests(TestCase):
             self.assertFalse(dgraph.is_stale(self.dependency))
             self.assertFalse(dgraph.is_stale(self.depender))
 
-            # Set the update time of the dependency to the future
-            os.utime(str(self.dependency),
-                     (time()*1000 + 1000, time()*1000 + 1000))
+            self._touch(self.dependency, 1000)
             dgraph.rebuild()
             self.assertFalse(dgraph.is_stale(self.dependency))
             self.assertTrue(dgraph.is_stale(self.depender))
@@ -66,3 +68,59 @@ class DependencyGraphTests(TestCase):
             self.assertItemsEqual(
                 dependency.Graph().dependencies(str(self.depender)),
                 [str(self.dependency / 1), str(self.dependency / 2)])
+
+    def assert_rebuilt_state(self, graph, path, **kwargs):
+        """Shorthand to verify that stale values are set appropriately.
+        For example, self.assert_rebuilt_state(graph, path, a='a', b='ab')
+        verifies that path/a is stale due to path/a and path/b is stale due to
+        either path/a or path/b"""
+        graph.rebuild()
+        for key, values in kwargs.items():
+            if not values:
+                self.assertEqual(graph.node(path / key)['stale'], '')
+            else:
+                self.assertIn(graph.node(path / key)['stale'],
+                              [str(path / char) for char in values])
+
+    def test_rebuild(self):
+        """Validate that the `rebuild()` method calculates the correct
+        "stale" references"""
+        with CliRunner().isolated_filesystem():
+            graph = dependency.Graph()
+
+            path = entry.Entry('path')
+            a, b, c, d = [path / char for char in 'abcd']
+            # (A, B) -> C -> D
+            graph.add(c, a)
+            graph.add(c, b)
+            graph.add(d, c)
+
+            # None of the files exist yet; A & B have no dependencies, so they
+            # are stale due to themselves. C & D are stale due either A or B
+            self.assert_rebuilt_state(graph, path,
+                                      a='a', b='b', c='ab', d='ab')
+
+            b.write('bbb')
+            # B exists now, so dependency errors are only due to A now
+            self.assert_rebuilt_state(graph, path, a='a', b='', c='a', d='a')
+
+            a.write('aaa')
+            # A exists now, too, so C is the bottleneck
+            self.assert_rebuilt_state(graph, path, a='', b='', c='c', d='c')
+
+            c.write('ccc')
+            # Now there's only the final, self-reference
+            self.assert_rebuilt_state(graph, path, a='', b='', c='', d='d')
+
+            d.write('ddd')
+            # Now no one is stale
+            self.assert_rebuilt_state(graph, path, a='', b='', c='', d='')
+
+            self._touch(a, 1000)
+            # A's been updated. Need to run everything after it
+            self.assert_rebuilt_state(graph, path, a='', b='', c='a', d='a')
+
+            self._touch(d, 2000)
+            self._touch(c, 3000)
+            # C and D have been updated, but C's been updated after D
+            self.assert_rebuilt_state(graph, path, a='', b='', c='', d='c')

--- a/tests/index_dependency_tests.py
+++ b/tests/index_dependency_tests.py
@@ -49,7 +49,8 @@ class DependencyGraphTests(TestCase):
             # Set the update time of the dependency to the future
             os.utime(str(self.dependency),
                      (time()*1000 + 1000, time()*1000 + 1000))
-            dgraph.dag.run()
+            dgraph._ran = False
+            dgraph._run_if_needed()
             self.assertFalse(dgraph.is_stale(self.dependency))
             self.assertTrue(dgraph.is_stale(self.depender))
 


### PR DESCRIPTION
[Networkx](https://networkx.github.io/) is a general purpose library for working with graphs; [dagger](http://pythonhosted.org/dagger/) is a more specific tool that focuses on file-modification timing. The latter is basically _exactly_ what we want to determine dependencies, but doesn't have Python3 support, and we'll likely get some use from networkx in other contexts.

This PR removes dagger in favor of networkx, which simplifies some of the accounting, but requires a custom "staleness" function based on a topological sort.

Resolves #184 